### PR TITLE
Add small README to get started

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Developer Tooling
+
+This repository contains the source code for various JS/TS developer tools and CLI(s) released by cLabs 
+for the Celo community. 
+
+This includes: 
+
+- [`@celo/celocli`](https://www.npmjs.com/package/@celo/celocli)
+- [`@celo/base`](https://www.npmjs.com/package/@celo/base)
+- [`@celo/connect`](https://www.npmjs.com/package/@celo/connect)
+- [`@celo/contractkit`](https://www.npmjs.com/package/@celo/contractkit)
+- [`@celo/cryptographic-utils`](https://www.npmjs.com/package/@celo/cryptographic-utils)
+- [`@celo/explorer`](https://www.npmjs.com/package/@celo/explorer)
+- [`@celo/governance`](https://www.npmjs.com/package/@celo/governance)
+- [`@celo/keystore`](https://www.npmjs.com/package/@celo/keystores)
+- [`@celo/network-utils`](https://www.npmjs.com/package/@celo/network-utils)
+- [`@celo/phone-utils`](https://www.npmjs.com/package/@celo/phone-utils) (may be deprecated soon ⚠️)
+- [`@celo/transaction-uri`](https://www.npmjs.com/package/@celo/transactions-uri)
+- Wallet related packages including:
+  - [`@celo/wallet-base`](https://www.npmjs.com/package/@celo/wallet-base)
+  - [`@celo/wallet-hsm`](https://www.npmjs.com/package/@celo/wallet-hsm)
+  - [`@celo/wallet-hsm-aws`](https://www.npmjs.com/package/@celo/wallet-hsm-aws)
+  - [`@celo/wallet-hsm-azure`](https://www.npmjs.com/package/@celo/wallet-hsm-azure)
+  - [`@celo/wallet-hsm-gcp`](https://www.npmjs.com/package/@celo/wallet-hsm-azure)
+  - [`@celo/wallet-ledger`](https://www.npmjs.com/package/@celo/wallet-ledger)
+  - [`@celo/wallet-local`](https://www.npmjs.com/package/@celo/wallet-local)
+  - [`@celo/wallet-remote`](https://www.npmjs.com/package/@celo/wallet-remote)
+  - [`@celo/wallet-rpc`](https://www.npmjs.com/package/@celo/wallet-rpc)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Developer Tooling
 
 > **NOTE** This is a relatively new repository and is still under active development.
-> Some of the packages and release process may not be fully documented yet.
+> Some of the packages and release processes may not be fully documented yet.
 
 This repository contains the source code for various JS/TS developer tools and CLI(s) released by cLabs 
 for the Celo community. 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Developer Tooling
 
+> **NOTE** This is a relatively new repository and is still under active development.
+> Some of the packages and release process may not be fully documented yet.
+
 This repository contains the source code for various JS/TS developer tools and CLI(s) released by cLabs 
 for the Celo community. 
 


### PR DESCRIPTION
### Description

Adds a simple README that lists all NPM packages published from the repository,

### Other changes

None.

### Tested

Not applicable, markdown only.

### Related issues

- Fixes #24 

### Backwards compatibility

N/A

### Documentation

N/A