### PR TITLE
Celocli standalone container image

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,7 +10,7 @@ jobs:
   split-version:
     runs-on: ['ubuntu-latest']
     if: |
-      contains(github.event.release.name, '@celo/celicli')
+      contains(github.event.release.name, '@celo/celocli')
     outputs:
       CELOCLI_VERSION: ${{ steps.split.outputs.CELOCLI_VERSION }}
     steps:
@@ -24,11 +24,11 @@ jobs:
           echo "CELOCLI_VERSION=$CELOCLI_VERSION" >> $GITHUB_OUTPUT
   # CeloCli standalone image
   celocli-standalone:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.0
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.1
     name: Build us-west1-docker.pkg.dev/devopsre/dev-images/celocli:${{ needs.split-version.outputs.CELOCLI_VERSION }}
     needs: ['split-version']
     if: |
-      contains(github.event.release.name, '@celo/celicli')
+      contains(github.event.release.name, '@celo/celocli')
     with:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-developer-tooling/providers/github-by-repos
       service-account: 'developer-tooling-dev@devopsre.iam.gserviceaccount.com'

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         run: |
           # CELOCLI_VERSION="$(${{ github.event.release.name }}##*@)"
-          CELOCLI_VERSION="0.0.0-test"
+          CELOCLI_VERSION="3.1.3"
           echo "CELOCLI_VERSION=$CELOCLI_VERSION" >> $GITHUB_OUTPUT
   # CeloCli standalone image
   celocli-standalone:
@@ -35,7 +35,7 @@ jobs:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-developer-tooling/providers/github-by-repos
       service-account: 'developer-tooling-dev@devopsre.iam.gserviceaccount.com'
       artifact-registry: us-west1-docker.pkg.dev/devopsre/developer-tooling/celocli
-      tags: ${{ needs.split-version.outputs.CELOCLI_VERSION }}
+      tags: ci-test-${{ needs.split-version.outputs.CELOCLI_VERSION }}
       context: .
       file: packages/cli/standalone.Dockerfile
       build-args: VERSION=${{ needs.split-version.outputs.CELOCLI_VERSION }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -12,8 +12,8 @@ on:
 jobs:
   split-version:
     runs-on: ['ubuntu-latest']
-    if: |
-      contains(github.event.release.name, '@celo/celocli')
+    # if: |
+    #   contains(github.event.release.name, '@celo/celocli')
     outputs:
       CELOCLI_VERSION: ${{ steps.split.outputs.CELOCLI_VERSION }}
     steps:
@@ -29,8 +29,8 @@ jobs:
     uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.1
     name: Build us-west1-docker.pkg.dev/devopsre/dev-images/celocli:${{ needs.split-version.outputs.CELOCLI_VERSION }}
     needs: ['split-version']
-    if: |
-      contains(github.event.release.name, '@celo/celocli')
+    # if: |
+    #   contains(github.event.release.name, '@celo/celocli')
     with:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-developer-tooling/providers/github-by-repos
       service-account: 'developer-tooling-dev@devopsre.iam.gserviceaccount.com'

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -5,9 +5,6 @@ on:
   release:
     types:
       - "published"
-  push:
-    branches:
-      - jcortejoso/celocli-container
 
 jobs:
   split-version:
@@ -21,9 +18,9 @@ jobs:
         id: split
         shell: bash
         run: |
-          # CELOCLI_VERSION="$(${{ github.event.release.name }}##*@)"
-          CELOCLI_VERSION="3.1.3"
+          CELOCLI_VERSION="$(${{ github.event.release.name }}##*@)"
           echo "CELOCLI_VERSION=$CELOCLI_VERSION" >> $GITHUB_OUTPUT
+
   # CeloCli standalone image
   celocli-standalone:
     uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.1
@@ -35,7 +32,7 @@ jobs:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-developer-tooling/providers/github-by-repos
       service-account: 'developer-tooling-dev@devopsre.iam.gserviceaccount.com'
       artifact-registry: us-west1-docker.pkg.dev/devopsre/developer-tooling/celocli
-      tags: ci-test-${{ needs.split-version.outputs.CELOCLI_VERSION }}
+      tags: ${{ needs.split-version.outputs.CELOCLI_VERSION }}
       context: .
       file: packages/cli/standalone.Dockerfile
       build-args: VERSION=${{ needs.split-version.outputs.CELOCLI_VERSION }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -5,6 +5,9 @@ on:
   release:
     types:
       - "published"
+  push:
+    branches:
+      - jcortejoso/celocli-container
 
 jobs:
   split-version:
@@ -15,12 +18,11 @@ jobs:
       CELOCLI_VERSION: ${{ steps.split.outputs.CELOCLI_VERSION }}
     steps:
       - name: Split celocli-version
-        env:
-          CELOCLI_VERSION: ${{ github.ref_name }}
         id: split
         shell: bash
         run: |
-          CELOCLI_VERSION="$(${{ github.event.release.name }}##*@)"
+          # CELOCLI_VERSION="$(${{ github.event.release.name }}##*@)"
+          CELOCLI_VERSION="0.0.0-test"
           echo "CELOCLI_VERSION=$CELOCLI_VERSION" >> $GITHUB_OUTPUT
   # CeloCli standalone image
   celocli-standalone:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,40 @@
+---
+name: Build containers
+
+on:
+  release:
+    types:
+      - "published"
+
+jobs:
+  split-version:
+    runs-on: ['ubuntu-latest']
+    if: |
+      contains(github.event.release.name, '@celo/celicli')
+    outputs:
+      CELOCLI_VERSION: ${{ steps.split.outputs.CELOCLI_VERSION }}
+    steps:
+      - name: Split celocli-version
+        env:
+          CELOCLI_VERSION: ${{ github.ref_name }}
+        id: split
+        shell: bash
+        run: |
+          CELOCLI_VERSION="$(${{ github.event.release.name }}##*@)"
+          echo "CELOCLI_VERSION=$CELOCLI_VERSION" >> $GITHUB_OUTPUT
+  # CeloCli standalone image
+  celocli-standalone:
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.0
+    name: Build us-west1-docker.pkg.dev/devopsre/dev-images/celocli:${{ needs.split-version.outputs.CELOCLI_VERSION }}
+    needs: ['split-version']
+    if: |
+      contains(github.event.release.name, '@celo/celicli')
+    with:
+      workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-developer-tooling/providers/github-by-repos
+      service-account: 'developer-tooling-dev@devopsre.iam.gserviceaccount.com'
+      artifact-registry: us-west1-docker.pkg.dev/devopsre/developer-tooling/celocli
+      tags: ${{ needs.split-version.outputs.CELOCLI_VERSION }}
+      context: .
+      file: packages/cli/standalone.Dockerfile
+      build-args: VERSION=${{ needs.split-version.outputs.CELOCLI_VERSION }}
+      trivy: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,12 +14,12 @@
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "typescript.updateImportsOnFileMove.enabled": "always",
   "editor.codeActionsOnSave": {
-    "source.organizeImports": false
+    "source.organizeImports": "never"
   },
   "[javascript]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": false
+      "source.organizeImports": "never"
     }
   },
   "[javascriptreact]": {
@@ -44,5 +44,10 @@
   "editor.tabSize": 2,
   "editor.detectIndentation": false,
   "tslint.jsEnable": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[javascriptreact][typescript][typescriptreact]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
+  }
 }

--- a/packages/cli/standalone.Dockerfile
+++ b/packages/cli/standalone.Dockerfile
@@ -1,0 +1,29 @@
+# Docker image containing the celocli, built from NPM.
+#
+# Example build command (manual):
+#
+#   VERSION=x.y.z; docker build . --build-arg VERSION=$VERSION -t celocli-standalone:$VERSION
+FROM node:20-alpine
+LABEL org.opencontainers.image.authors="devops@clabs.co"
+
+# Install cli install dependencies.
+RUN apk add --no-cache python3 git make gcc g++ bash libusb-dev linux-headers eudev-dev
+
+# Add an set as default a non-privileged user named celo.
+RUN adduser -D -S celo
+USER celo
+
+# Make folders for npm packages.
+RUN mkdir /home/celo/.npm-global
+ENV PATH=/home/celo/.npm-global/bin:$PATH
+ENV NPM_CONFIG_PREFIX=/home/celo/.npm-global
+
+WORKDIR /home/celo/
+
+# Install @celo/celocli from NPM.
+ARG VERSION
+RUN npm install -g @celo/celocli@$VERSION
+RUN celocli config:set --node https://forno.celo.org
+
+ENTRYPOINT ["celocli"]
+CMD ["--help"]


### PR DESCRIPTION
### Description

- Dockerfile for celocli (standalone) container image. This dockerfile installs celocli from npmjs registry
- GitHub Workflow for building the celocli image when a new release with name `@celo/celocli@<VERSION>` is released. If the name does not contain `@celo/celocli` it should not execute. If the release name contains `@celo/celocli` but the format does not match that (with the version) the workflow will fail. If this is intended to change (or potentially change) I can add a sanity check or we can think on a safer trigger to build the image, but considering github workflows does not have the best syntax for doing this kind of checks, if we expect the release to follow that format I'd just avoid adding syntax complexity to the workflow.

The PR configuring the required permissions is https://github.com/celo-org/infrastructure/pull/1621. It is already applied.