### PR TITLE
GitHub issue templates (bug reports and feature requests link Foundry)

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -1,0 +1,56 @@
+name: Bug report
+description: File a bug report
+labels: ["bug report"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Please ensure that the bug has not already been filed in the issue tracker.
+
+              Thanks for taking the time to report this bug!
+    - type: dropdown
+      attributes:
+          label: Package
+          description: What package is the bug in?
+          multiple: true
+          options:
+              - '@celo/celocli'
+              - '@celo/contractkit'
+              - '@celo/base'
+              - '@celo/connect'
+              - '@celo/wallet-...'
+              - Other (please describe)
+      validations:
+          required: true
+    - type: checkboxes
+      attributes:
+          label: Have you ensured that all of these are up to date?
+          options:
+              - label: the package you are using
+    - type: input
+      attributes:
+          label: What version of the package are you on?
+          description: |
+            For local installations, run: `npm list <package-name>`
+            For global installations, run: `npm list -g <package-name>`
+          placeholder: "Run command above and paste the output here"
+    - type: input
+      attributes:
+          label: What command or function is the bug in?
+          description: Leave empty if not relevant
+          placeholder: "For example: `celocli releasecelo:show`"
+    - type: dropdown
+      attributes:
+          label: Operating System
+          description: What operating system are you on?
+          options:
+              - Windows
+              - macOS (Intel)
+              - macOS (Apple Silicon)
+              - Linux
+    - type: textarea
+      attributes:
+          label: Describe the bug
+          description: Please include relevant code snippets, terminal output, and screenshots if relevant.
+      validations:
+          required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: Suggest a feature
+labels: ["feature request"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Please ensure that the feature has not already been requested in the issue tracker.
+
+              Thanks for helping us improve Celo packages!
+    - type: dropdown
+      attributes:
+          label: Component
+          description: What package is the feature for?
+          multiple: true
+          options:
+              - '@celo/celocli'
+              - '@celo/contractkit'
+              - '@celo/base'
+              - '@celo/connect'
+              - '@celo/wallet-...'
+              - Other (please describe)
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: Describe the feature you would like
+          description: Please also describe what the feature is aiming to solve, if relevant.
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: Additional context
+          description: Add any other context to the feature (like screenshots, code snippets, resources)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Celo Discord
-    url: https://chat.celo.org/
+  - name: Github Discussions
+    url: https://github.com/celo-org/developer-tooling/discussions
     about: Please ask and answer questions here.
-  - name: Celo Docs
+  - name: Docs
     url: https://docs.celo.org/
     about: Documentation on the Celo Platform


### PR DESCRIPTION
### Description

Adds Github templates for bug reports and feature requests.
Updates template chooser, encouraging users to open Github Discussions for Q&A instead of Discord.

### Context from this issue https://github.com/celo-org/developer-tooling/issues/48

The Foundry repo ([foundry-rs/foundry](https://github.com/foundry-rs/foundry)) has great drop-down template for bug reports and feature requests.

This makes it a lot easier for them to review, reproduce, and fix bugs.

Our currently issue template:

* [issue-template.md](https://github.com/celo-org/developer-tooling/blob/master/.github/ISSUE_TEMPLATE/issue-template.md)

Foundry issue templates:

* [BUG-FORM.yml](https://github.com/foundry-rs/foundry/blob/master/.github/ISSUE_TEMPLATE/BUG-FORM.yml)
* [FEATURE-FORM.yml](https://github.com/foundry-rs/foundry/blob/master/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml)

GitHub Docs: 
- [Syntax for issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)
- [Changing the order of templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#changing-the-order-of-templates)

### Tested

Maybe no good way to test this, not terribly important to test this.

### Related issues

- Fixes #48 

### Backwards compatibility

Yes