### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,15 +3,4 @@
 # For details on acceptable file patterns, please refer to the [Github Documentation](https://help.github.com/articles/about-codeowners/)
 
 # default owners, overridden by package specific owners below
-* @celo-org/default-owners
-
-# directory and file-level owners. Feel free to add to this!
-
-.github/actions/ @celo-org/devopsre
-.github/workflows/ @celo-org/devopsre
-
-
-/packages/cli/ @celo-org/devtooling
-/packages/docs/ @celo-org/devtooling @celo-org/primitives @celo-org/devrel
-/packages/metadata-crawler/ @celo-org/devopsre
-/packages/sdk/ @celo-org/devtooling
+* @celo-org/devtooling


### PR DESCRIPTION
### Description

Updates the CODEOWNERS file. The previous [CODEOWNERS](https://github.com/celo-org/developer-tooling/blob/0f633883fb67d8951d548f37eb107ff94f8ec573/.github/CODEOWNERS) file had settings from the monorepo.

### Tested

N/A

### Related issues

- Fixes #49 

### Backwards compatibility

N/A

### Documentation

N/A