### PR TITLE
Fix CLI 

### DIFF
--- a/packages/cli/bin/dev.js
+++ b/packages/cli/bin/dev.js
@@ -2,5 +2,6 @@
 // eslint-disable-next-line node/shebang, unicorn/prefer-top-level-await
 ;(async () => {
   const oclif = await import('@oclif/core')
+  console.info('Running in development mode')
   await oclif.execute({ development: true, dir: __dirname })
 })()

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,10 @@
   "bugs": "https://github.com/celo-org/developer-tooling/issues?utf8=%E2%9C%93&q=label%3Acli+",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",
-  "bin": "./bin/run",
+  "bin": {
+    "celocli": "./bin/run.js",
+    "dev": ".bin/dev.js"
+  },
   "keywords": [
     "celo",
     "celocli",
@@ -20,12 +23,13 @@
   },
   "scripts": {
     "clean": "tsc -b . --clean",
+    "dev": "ts-node ./bin/dev.js",
     "build": "tsc -b .",
     "docs": "./generate_docs.sh",
     "lint": "yarn run --top-level eslint -c .eslintrc.js ",
     "prepublish": "",
     "prepack": "yarn run build && oclif manifest && oclif readme",
-    "test": "TZ=UTC jest --runInBand"
+    "test": "TZ=UTC yarn node --experimental-vm-modules $(yarn bin jest)"
   },
   "dependencies": {
     "@celo/abis": "10.0.0",
@@ -69,6 +73,7 @@
   "devDependencies": {
     "@celo/celo-devchain": "^6.0.3",
     "@celo/dev-utils": "0.0.1-beta.1",
+    "@celo/typescript": "workspace:^",
     "@types/cli-table": "^0.3.0",
     "@types/debug": "^4.1.4",
     "@types/fs-extra": "^8.0.0",

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -100,7 +100,6 @@ export abstract class BaseCommand extends Command {
 
   private _web3: Web3 | null = null
   private _kit: ContractKit | null = null
-  private _wallet?: ReadOnlyWallet
 
   async getWeb3() {
     if (!this._web3) {
@@ -114,6 +113,14 @@ export abstract class BaseCommand extends Command {
     return this._web3
   }
 
+  get _wallet(): ReadOnlyWallet | undefined {
+    return this._wallet
+  }
+
+  set _wallet(wallet: ReadOnlyWallet | undefined) {
+    this._kit!.connection.wallet = wallet
+  }
+
   async newWeb3() {
     const res = await this.parse()
     const nodeUrl = (res.flags && res.flags.node) || getNodeUrl(this.config.configDir)
@@ -125,7 +132,6 @@ export abstract class BaseCommand extends Command {
   async getKit() {
     if (!this._kit) {
       this._kit = newKitFromWeb3(await this.getWeb3())
-      this._kit.connection.wallet = this._wallet
     }
 
     const res = await this.parse()

--- a/packages/cli/src/commands/account/list.test.ts
+++ b/packages/cli/src/commands/account/list.test.ts
@@ -1,0 +1,68 @@
+import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { AddressValidation } from '@celo/wallet-ledger/lib/ledger-wallet'
+import { LocalWallet } from '@celo/wallet-local'
+import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
+import List from './list'
+process.env.NO_SYNCCHECK = 'true'
+
+jest.mock('@ledgerhq/hw-transport-node-hid', () => {
+  return {
+    default: {
+      open: jest.fn(() => {
+        return {
+          send: jest.fn(() => new Promise(() => {})),
+          decorateAppAPIMethods: jest.fn(),
+          close: jest.fn(),
+        }
+      }),
+    },
+  }
+})
+
+jest.mock('@celo/wallet-ledger', () => {
+  return {
+    AddressValidation,
+    newLedgerWalletWithSetup: jest.fn(() => {
+      const wallet = new LocalWallet()
+      jest.spyOn(wallet, 'getAccounts').mockImplementation(() => {
+        return [
+          '0x7457d5E02197480Db681D3fdF256c7acA21bDc12',
+          '0x91c987bf62D25945dB517BDAa840A6c661374402',
+        ]
+      })
+      return wallet
+    }),
+  }
+})
+
+testWithGanache('account:list', (web3: Web3) => {
+  let account: string
+  let accounts: string[]
+  let kit: ContractKit
+
+  beforeEach(async () => {
+    accounts = await web3.eth.getAccounts()
+    kit = newKitFromWeb3(web3)
+    account = accounts[0]
+
+    const accountsInstance = await kit.contracts.getAccounts()
+    await accountsInstance.createAccount().sendAndWaitForReceipt({ from: account })
+  })
+  test('shows the list of accounts', async () => {
+    const spy = jest.spyOn(console, 'log')
+
+    await testLocally(List, [])
+    expect(spy).toHaveBeenCalledWith('All Addresses: ', accounts)
+  })
+  test.only('shows the list of accounts when --useLedger given', async () => {
+    const spy = jest.spyOn(console, 'log')
+
+    await testLocally(List, ['--useLedger'])
+    expect(spy).toHaveBeenCalledWith('Ledger Addresses: ', [
+      '0x7457d5E02197480Db681D3fdF256c7acA21bDc12',
+      '0x91c987bf62D25945dB517BDAa840A6c661374402',
+    ])
+  })
+})

--- a/packages/cli/src/commands/account/list.ts
+++ b/packages/cli/src/commands/account/list.ts
@@ -16,12 +16,11 @@ export default class AccountList extends BaseCommand {
   async run() {
     const kit = await this.getKit()
     const res = await this.parse(AccountList)
-
-    // Retreive accounts from the connected Celo node.
+    // Retrieve accounts from the connected Celo node.
     const allAddresses = !res.flags.local ? await kit.connection.getAccounts() : []
 
     // Get addresses from the local wallet.
-    const localAddresses = res.flags.local ?? true ? await kit.connection.getLocalAccounts() : []
+    const localAddresses = res.flags.local ?? true ? kit.connection.getLocalAccounts() : []
 
     // Display the addresses.
     const localName = res.flags.useLedger ? 'Ledger' : 'Local'

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@celo/typescript/tsconfig.library.json",
+  "extends": "../typescript/tsconfig.library.json",
   "compilerOptions": {
     "resolveJsonModule": true,
     "moduleResolution": "node16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,7 +880,8 @@ __metadata:
     web3: "npm:1.10.0"
     web3-utils: "npm:^1.10.0"
   bin:
-    celocli: ./bin/run
+    celocli: ./bin/run.js
+    dev: .bin/dev.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION


### Description

ensure the wallet is set on the connection. this is done by making `_wallet` an alias for `connection.wallet` so that setting in the init() works correctly

### Other changes

add yarn dev command for cli

### Tested

added new account:list test
### Related issues

- Fixes #76 

### Backwards compatibility

correct

### Documentation

