### PR TITLE
Fixes small typos and improves clarity in changesets

### DIFF
--- a/.changeset/curly-pianos-applaud.md
+++ b/.changeset/curly-pianos-applaud.md
@@ -2,6 +2,6 @@
 '@celo/contractkit': patch
 ---
 
-Re-removes MetaTransaction wallets (as previously removed in 6.0)
+Re-removes MetaTransaction wallets, as previously removed in 6.0.0 (9ab9d00eb).
 
-*previous messsage for removal* - 9ab9d00eb: Remove Support for deprecated MetaTransactionWallet and MetaTransactionWalletDeployer. IF absolutely needed the contracts can be accessed directly or an alternative such as account abstraction should be used
+Remove support for deprecated `MetaTransactionWallet` and `MetaTransactionWalletDeployer`. If absolutely needed the contracts can be accessed directly or an alternative such as account abstraction should be used.

--- a/.changeset/plenty-bananas-shop.md
+++ b/.changeset/plenty-bananas-shop.md
@@ -2,8 +2,8 @@
 '@celo/contractkit': patch
 ---
 
-Reremoves grandamento
+Re-removes `grandamento`
 
-While 9ab9d00eb previously removed grandamento it was added back temporarily because the celo cli required the wrappers to be available in order to execute the proposal to remove it from governance. It is now gone for good. RIP.
+  While 6.0.0 (9ab9d00eb) previously removed `grandamento` it was added back temporarily because `@celo/celocli` required the wrappers to be available in order to execute the proposal to remove it from governance. It is now gone for good. RIP.
 
-Due to previous removal this is not considered a breaking change. 
+  Due to previous removal this is not considered a breaking change.

--- a/.changeset/real-rabbits-grab.md
+++ b/.changeset/real-rabbits-grab.md
@@ -2,4 +2,4 @@
 '@celo/celocli': major
 ---
 
-Removes releasegold commnand topic. use releasecelo
+Removes the `releasegold` command in favour of `releasecelo`.

--- a/.changeset/tough-gorillas-invent.md
+++ b/.changeset/tough-gorillas-invent.md
@@ -2,4 +2,4 @@
 '@celo/celocli': major
 ---
 
-Remove Grandamento from CLI
+Remove `grandamento` commands from CLI.


### PR DESCRIPTION
### Description

Fixes small typos and improves clarity in changesets created in this PR: 
- https://github.com/celo-org/developer-tooling/pull/66

Left [comments](https://github.com/celo-org/developer-tooling/pull/66#pullrequestreview-1818582129) in #66 a couple of seconds after it was merged. This small PR applies those changes retrospectively.

### Tested

No code change

### Related issues

- #66 

### Backwards compatibility

No code change