### PR TITLE
set up base config for renovate on developer tooling repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,3 +325,18 @@ jobs:
           cd $RUNNER_TEMP
           npm install $RUNNER_WORKSPACE/developer-tooling/packages/sdk/base/*.tgz
           npm install $RUNNER_WORKSPACE/developer-tooling/packages/sdk/utils/*.tgz
+
+  validate-renovate-config:
+    name: Validate Renovate Config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Validate Renovate Config
+        run: |
+          npm install --global renovate
+          renovate-config-validator

--- a/dt-renovate-base.json
+++ b/dt-renovate-base.json
@@ -6,6 +6,9 @@
   "prCreation": "approval",
   "prConcurrentLimit": 2,
   "minimumReleaseAge": "5 days",
+  "major": {
+    "minimumReleaseAge": "14 days"
+  },
   "packageRules": [
     {
       "matchManagers": ["github-actions"],

--- a/dt-renovate-base.json
+++ b/dt-renovate-base.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>celo-org/.github:renovate-config"
+  ],
+  "prCreation": "approval",
+  "prConcurrentLimit": 2,
+  "minimumReleaseAge": "5 days",
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "autoApprove": "true",
+      "prCreation": "status-success"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>celo-org/.github:renovate-config"
+    "local>celo-org/.github:renovate-config",
+    "local>celo-org/developer-tooling:dt-renovate-base"
   ]
 }


### PR DESCRIPTION
### Description

ideally we can use this config as the base for all team repos. 

* turns off automatic opening of prs -- instead we will use the dashboard to approve them to be opened. 
* for github actions the it will open prs AND will merge  them automatically if everything passes. This is safe since github actions are for ci so if ci passes the upgrade is safe. 
* sets minimum age for major version to 2 weeks to give enough time for big bugs to be sorted out. and 4 days for minor and patch which is typically enough for evil hijack type updates to be found and removed. 
*  set max concurrent prs to 2. each pr that is open will rebase automatically on each merge so having more open just creates noise and actually slows down the merge process.


### Other changes

add the same renovate validate ci step used on faucet repo

### Tested


### Related issues

- Fixes tbd

