### PR TITLE
use celo verison of ganache (rather than random soloseng version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript": "5.3.3"
   },
   "resolutions": {
-    "ganache": "npm:@soloseng/ganache@7.8.0-beta.1",
+    "ganache": "npm:@celo/ganache@7.8.0-unofficial.0",
     "bip39": "https://github.com/bitcoinjs/bip39#a7ecbfe2e60d0214ce17163d610cad9f7b23140c",
     "blind-threshold-bls": "npm:@celo/blind-threshold-bls@1.0.0-beta",
     "@types/bn.js": "4.11.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12253,9 +12253,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ganache@npm:@soloseng/ganache@7.8.0-beta.1":
-  version: 7.8.0-beta.1
-  resolution: "@soloseng/ganache@npm:7.8.0-beta.1"
+"ganache@npm:@celo/ganache@7.8.0-unofficial.0":
+  version: 7.8.0-unofficial.0
+  resolution: "@celo/ganache@npm:7.8.0-unofficial.0"
   dependencies:
     "@trufflesuite/bigint-buffer": "npm:*"
     "@trufflesuite/uws-js-unofficial": "npm:20.10.0-unofficial.2"
@@ -12279,7 +12279,7 @@ __metadata:
   bin:
     ganache: dist/node/cli.js
     ganache-cli: dist/node/cli.js
-  checksum: c5637ff3c72498a44d49f8eeceef1d9adb17d058135072c6d9d9a8fe4724e78c7b17f6c96d95a869f7ded73b3e0bd7d80911ad0ca5f02ac317196d6cd4e5e02d
+  checksum: f925d809d2f53f91ef249a318aebaed54ce34a876f4ce56481de62464370599c6f0191af22ece71df960d5b36e4ed0f075fcd8432ac6f8326bcf8e9527a147eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

@soloseng  noticed that monorepo was using wrong fork of ganache and fixed on monorepo  https://github.com/celo-org/celo-monorepo/pull/10917 this does the same here
### Other changes

n/a
### Tested


### Related issues

- parrallel to https://github.com/celo-org/celo-monorepo/pull/10917
### Backwards compatibility

yep
_Brief explanation of why these changes are/are not backwards compatible._

