### PR TITLE
Big Swap Feedback

### DIFF
--- a/packages/cli/src/commands/exchange/celo.ts
+++ b/packages/cli/src/commands/exchange/celo.ts
@@ -10,7 +10,7 @@ import { checkNotDangerousExchange } from '../../utils/exchange'
 import { enumEntriesDupWithLowercase } from '../../utils/helpers'
 import { getMentoBroker } from '../../utils/mento-broker-adaptor'
 
-const depeggedPricePercentage = 20
+const MAX_DEPEG_PRICE_PERCENTAGE = 20
 
 const stableTokenOptions = enumEntriesDupWithLowercase(Object.entries(StableToken))
 export default class ExchangeCelo extends BaseCommand {
@@ -75,7 +75,7 @@ export default class ExchangeCelo extends BaseCommand {
         kit,
         sellAmount,
         new BigNumber(expectedAmountToReceive.toString()),
-        depeggedPricePercentage,
+        MAX_DEPEG_PRICE_PERCENTAGE,
         stableTokenInfos[stableToken]
       )
       if (!check) {

--- a/packages/cli/src/exchange-stable-base.ts
+++ b/packages/cli/src/exchange-stable-base.ts
@@ -8,7 +8,7 @@ import { binaryPrompt, displaySendEthersTxViaCK, displaySendTx } from './utils/c
 import { CustomFlags } from './utils/command'
 import { checkNotDangerousExchange } from './utils/exchange'
 import { getMentoBroker } from './utils/mento-broker-adaptor'
-const depeggedPricePercentage = 20
+const MAX_DEPEG_PRICE_PERCENTAGE = 20
 export default class ExchangeStableBase extends BaseCommand {
   static flags = {
     ...BaseCommand.flags,
@@ -68,7 +68,7 @@ export default class ExchangeStableBase extends BaseCommand {
         kit,
         sellAmount,
         new BigNumber(expectedAmountToReceive.toString()),
-        depeggedPricePercentage,
+        MAX_DEPEG_PRICE_PERCENTAGE,
         stableTokenInfos[this._stableCurrency as StableToken],
         true
       )

--- a/packages/cli/src/utils/exchange.ts
+++ b/packages/cli/src/utils/exchange.ts
@@ -37,7 +37,7 @@ export async function checkNotDangerousExchange(
     quotedAmountToReceiveWithBuffer,
     oracleMedianRate
   )
-  if (expectedSlippage > depeggedPricePercentage) {
+  if (Math.abs(expectedSlippage) > depeggedPricePercentage) {
     const check = await binaryPrompt(
       `Warning ${
         stableTokenInfo.symbol

--- a/packages/cli/src/utils/exchange.ts
+++ b/packages/cli/src/utils/exchange.ts
@@ -23,7 +23,7 @@ export async function checkNotDangerousExchange(
   kit: ContractKit,
   sellAmount: BigNumber,
   quotedAmountToReceiveWithBuffer: BigNumber,
-  depeggedPricePercentage: number,
+  maxDepegPricePercentage: number,
   stableTokenInfo: StableTokenInfo = stableTokenInfos[StableToken.cUSD],
   flipOracle = false
 ): Promise<boolean> {
@@ -37,7 +37,7 @@ export async function checkNotDangerousExchange(
     quotedAmountToReceiveWithBuffer,
     oracleMedianRate
   )
-  if (Math.abs(expectedSlippage) > depeggedPricePercentage) {
+  if (Math.abs(expectedSlippage) > Math.abs(maxDepegPricePercentage)) {
     const check = await binaryPrompt(
       `Warning ${
         stableTokenInfo.symbol

--- a/packages/cli/src/utils/exchange.ts
+++ b/packages/cli/src/utils/exchange.ts
@@ -41,7 +41,7 @@ export async function checkNotDangerousExchange(
     const check = await binaryPrompt(
       `Warning ${
         stableTokenInfo.symbol
-      } price here (i.e. on-chain) is depegged by ${expectedSlippage}% which is >${depeggedPricePercentage}% from the oracle prices ${oracleMedianRate.toString()} (i.e. swap prices). Are you sure you want to continue?`,
+      } price here (i.e. on-chain) would be depegged by ${expectedSlippage}% from the oracle prices ${oracleMedianRate.toString()} (i.e. swap prices). Are you sure you want to continue?`,
       true
     )
     return check


### PR DESCRIPTION
### Description

When performing a swap that would significantly alter the price (de-peg) be sure to check the absolute difference (-25% is just as bad as 25%) 

make warning more concise (saying that 24% is greater than 20% is not really useful) 

