### PR TITLE
default is master

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,6 @@ jobs:
   open-docs-pr:
     needs: release
     if: ${{ contains(fromJson(needs.release.outputs.publishedPackages).*.name, '@celo/cli') }}
-    uses: celo-org/developer-tooling/.github/workflows/open-docs-pr.yml@main
+    uses: celo-org/developer-tooling/.github/workflows/open-docs-pr.yml@master
     with:
       commit: ${{ github.sha }}


### PR DESCRIPTION
### Description

fixes "branch not valid" error when release flow is ran

