### PR TITLE
Nit: Fixes URL typo in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ getting started or are an expert. We appreciate your interest in contributing.
 >
 > It's never a fun experience to have your pull request declined after investing time and effort
 > into a new feature. To avoid this from happening, we invite contributors to create a
-> [new discussion](https://github.com/wevm/viem/discussions) to discuss API changes or
+> [new discussion](https://github.com/celo-org/developer-tooling/discussions) to discuss API changes or
 > significant new ideas.
 
 ## Basic guide


### PR DESCRIPTION
### Description

Fixes URL typo in CONTRIBUTING

### Tested

N/A, docs-only change

### Related issues

N/A

### Backwards compatibility

Yes, docs-only change.

### Documentation

Yes, it's a docs change.