### PR TITLE
version bump for cli beta

### DIFF
--- a/.changeset/spotty-brooms-itch.md
+++ b/.changeset/spotty-brooms-itch.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+force beta release


### PR DESCRIPTION

npm is inconsistent on if beta 2 was published so go for beta 3 

running `npm view` shows beta 1 as last published but when trying to publish beta 2 is shown is already published. Usually the best fix for this is just to increment the version which adding a changeset should do 
