### PR TITLE
Activate votes from any account 

### DIFF
--- a/.changeset/happy-rice-camp.md
+++ b/.changeset/happy-rice-camp.md
@@ -1,0 +1,6 @@
+---
+'@celo/contractkit': minor
+'@celo/celocli': minor
+---
+
+Activate votes from any account, new optional parameter to specify for account in ElectionWrapper:activate

--- a/packages/docs/sdk/docs/contractkit/classes/wrappers_Election.ElectionWrapper.md
+++ b/packages/docs/sdk/docs/contractkit/classes/wrappers_Election.ElectionWrapper.md
@@ -494,7 +494,7 @@ BaseWrapperForGoverning.address
 
 ### activate
 
-▸ **activate**(`account`): `Promise`\<`CeloTransactionObject`\<`boolean`\>[]\>
+▸ **activate**(`account`, `onBehalfOfAccount?`): `Promise`\<`CeloTransactionObject`\<`boolean`\>[]\>
 
 Activates any activatable pending votes.
 
@@ -503,6 +503,7 @@ Activates any activatable pending votes.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `account` | `string` | The account with pending votes to activate. |
+| `onBehalfOfAccount?` | `boolean` | - |
 
 #### Returns
 
@@ -510,7 +511,7 @@ Activates any activatable pending votes.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:332](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L332)
+[packages/sdk/contractkit/src/wrappers/Election.ts:334](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L334)
 
 ___
 
@@ -578,7 +579,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:444](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L444)
+[packages/sdk/contractkit/src/wrappers/Election.ts:451](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L451)
 
 ___
 
@@ -641,7 +642,7 @@ Retrieves the set of validatorsparticipating in BFT at epochNumber.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:473](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L473)
+[packages/sdk/contractkit/src/wrappers/Election.ts:480](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L480)
 
 ___
 
@@ -657,7 +658,7 @@ Returns the current eligible validator groups and their total votes.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:429](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L429)
+[packages/sdk/contractkit/src/wrappers/Election.ts:436](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L436)
 
 ___
 
@@ -680,7 +681,7 @@ Retrieves GroupVoterRewards at epochNumber.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:485](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L485)
+[packages/sdk/contractkit/src/wrappers/Election.ts:492](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L492)
 
 ___
 
@@ -838,7 +839,7 @@ Retrieves VoterRewards for address at epochNumber.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:519](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L519)
+[packages/sdk/contractkit/src/wrappers/Election.ts:526](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L526)
 
 ___
 
@@ -861,7 +862,7 @@ Retrieves a voter's share of active votes.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:553](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L553)
+[packages/sdk/contractkit/src/wrappers/Election.ts:560](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L560)
 
 ___
 
@@ -949,7 +950,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:390](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L390)
+[packages/sdk/contractkit/src/wrappers/Election.ts:397](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L397)
 
 ___
 
@@ -979,7 +980,7 @@ Must pass both `lesserAfterVote` and `greaterAfterVote` or neither.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:365](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L365)
+[packages/sdk/contractkit/src/wrappers/Election.ts:372](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L372)
 
 ___
 
@@ -1001,7 +1002,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:341](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L341)
+[packages/sdk/contractkit/src/wrappers/Election.ts:348](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L348)
 
 ___
 
@@ -1042,4 +1043,4 @@ Increments the number of total and pending votes for `group`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:417](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L417)
+[packages/sdk/contractkit/src/wrappers/Election.ts:424](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L424)

--- a/packages/docs/sdk/docs/contractkit/modules/wrappers_Election.md
+++ b/packages/docs/sdk/docs/contractkit/modules/wrappers_Election.md
@@ -30,4 +30,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:569](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L569)
+[packages/sdk/contractkit/src/wrappers/Election.ts:576](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L576)

--- a/packages/sdk/contractkit/src/wrappers/Election.ts
+++ b/packages/sdk/contractkit/src/wrappers/Election.ts
@@ -325,17 +325,24 @@ export class ElectionWrapper extends BaseWrapperForGoverning<Election> {
 
   private _activate = proxySend(this.connection, this.contract.methods.activate)
 
+  private _activateForAccount = proxySend(this.connection, this.contract.methods.activateForAccount)
+
   /**
    * Activates any activatable pending votes.
    * @param account The account with pending votes to activate.
    */
-  async activate(account: Address): Promise<CeloTransactionObject<boolean>[]> {
+  async activate(
+    account: Address,
+    onBehalfOfAccount?: boolean
+  ): Promise<Array<CeloTransactionObject<boolean>>> {
     const groups = await this.contract.methods.getGroupsVotedForByAccount(account).call()
     const isActivatable = await Promise.all(
       groups.map((g) => this.contract.methods.hasActivatablePendingVotes(account, g).call())
     )
     const groupsActivatable = groups.filter((_, i) => isActivatable[i])
-    return groupsActivatable.map((g) => this._activate(g))
+    return groupsActivatable.map((g) =>
+      onBehalfOfAccount ? this._activateForAccount(g, account) : this._activate(g)
+    )
   }
 
   async revokePending(


### PR DESCRIPTION
### Description

New `--for` parameter and matching plumbing in ContractKit to allow pending votes to be activated from any account, not just from msg.sender. 

```
packages/cli/bin/run.js election:activate --help
Activate pending votes in validator elections to begin earning rewards. To earn rewards as a voter, it is required to activate your pending votes at some point after the end of the epoch in which they were made.

USAGE
  $ celocli election:activate --from <value> [--globalHelp] [--for <value>] [--wait]

FLAGS
  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   Optional: use this to activate votes for another address
  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address sending transaction (and voter's address if --for not specified)
  --globalHelp                                       View all available global flags
  --wait                                             Wait until all pending votes can be activated

DESCRIPTION
  Activate pending votes in validator elections to begin earning rewards. To earn rewards as a voter, it is required to activate your pending votes at
  some point after the end of the epoch in which they were made.

EXAMPLES
  activate --from 0x4443d0349e8b3075cba511a0a87796597602a0f1

  activate --from 0x4443d0349e8b3075cba511a0a87796597602a0f1 --for 0x5409ed021d9299bf6814279a6a1411a7e866a631

  activate --from 0x4443d0349e8b3075cba511a0a87796597602a0f1 --wait
```

### Other changes

None.

### Tested

By activating votes on testnet and mainnet. 

### Related issues

Note.

### Backwards compatibility

Yes. New parameter in ContractKit's `ElectionWrapper` `activate` method is optional.

### Documentation

Updated CLI docs.