### PR TITLE
Fix @celo/connect README code example

### DIFF
--- a/packages/docs/sdk/docs/connect/README.md
+++ b/packages/docs/sdk/docs/connect/README.md
@@ -13,11 +13,6 @@ import { Connection, CeloProvider } from '@celo/connect'
 
 const web3 = new Web3("YOUR_RPC_URL")
 const connection = new Connection(web3)
-
-connection.setProvider()
-
-const connectedChainID =  await connection.chainId()
-
 ```
 
 For a raw transaction:

--- a/packages/sdk/connect/README.md
+++ b/packages/sdk/connect/README.md
@@ -12,11 +12,6 @@ import { Connection, CeloProvider } from '@celo/connect'
 
 const web3 = new Web3("YOUR_RPC_URL")
 const connection = new Connection(web3)
-
-connection.setProvider()
-
-const connectedChainID =  await connection.chainId()
-
 ```
 
 For a raw transaction:


### PR DESCRIPTION
### Description

Fixes the code example in the `@celo/connect` README.

```diff
const web3 = new Web3("YOUR_RPC_URL")
const connection = new Connection(web3)

- connection.setProvider()
```

`connection.setProvider()` doesn't need to be called explicitly with a `CeloProvider`, because `connection` is already configured with a `CeloProvider` in the constructor:

https://github.com/celo-org/developer-tooling/blob/0ad9c011b868c4bf5456f4048cb6d405c9dd8c8e/packages/sdk/connect/src/connection.ts#L77-L93

### Tested

Docs only change

### Backwards compatibility

Yes

### Documentation

Yes