### PR TITLE
CLI notice

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -168,7 +168,8 @@
     },
     "repositoryPrefix": "https://github.com/celo-org/developer-tooling/tree/master/packages/cli/<%- commandPath %>",
     "hooks": {
-      "prerun": "./lib/hooks/prerun/plugin-warning"
+      "prerun": "./lib/hooks/prerun/plugin-warning",
+      "postrun": "./lib/hooks/postrun/feedback"
     }
   }
 }

--- a/packages/cli/src/hooks/postrun/feedback.ts
+++ b/packages/cli/src/hooks/postrun/feedback.ts
@@ -1,0 +1,11 @@
+import { Hook, ux } from '@oclif/core'
+
+const hook: Hook<'postrun'> = async function (options) {
+  ux.info(`Thanks for using the celocli!
+We want to know which commands are most useful to the community.
+Is '${options.Command.id}' a command you use often?
+Let us know at https://github.com/celo-org/developer-tooling/discussions/92
+`)
+}
+
+export default hook


### PR DESCRIPTION

### Description

 add notice which runs after each command to let people know to give feedback


### Other changes


### Tested
<img width="566" alt="Screenshot 2024-02-21 at 10 07 30 AM" src="https://github.com/celo-org/developer-tooling/assets/3814795/da24c92f-35ba-4587-81b0-3bfcb06ab1a2">


### Related issues

- Fixes #91

### Backwards compatibility

yes
### Documentation

n/a