### PR TITLE
Compliance + Test

### DIFF
--- a/.changeset/two-poems-complain.md
+++ b/.changeset/two-poems-complain.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Require addresses the cli sends from or to not to be sanctioned

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,6 +61,7 @@
     "bip32": "3.1.0",
     "chalk": "^2.4.2",
     "command-exists": "^1.2.9",
+    "cross-fetch": "3.0.6",
     "debug": "^4.1.1",
     "ethers": "5",
     "fs-extra": "^8.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@celo/abis": "10.0.0",
     "@celo/base": "^6.0.0",
+    "@celo/compliance": "^1.0.15",
     "@celo/connect": "^5.1.2",
     "@celo/contractkit": "^7.0.0",
     "@celo/cryptographic-utils": "^5.0.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@celo/abis": "10.0.0",
     "@celo/base": "^6.0.0",
-    "@celo/compliance": "^1.0.15",
+    "@celo/compliance": "~1.0.17",
     "@celo/connect": "^5.1.2",
     "@celo/contractkit": "^7.0.0",
     "@celo/cryptographic-utils": "^5.0.7",

--- a/packages/cli/src/commands/exchange/celo.ts
+++ b/packages/cli/src/commands/exchange/celo.ts
@@ -49,7 +49,10 @@ export default class ExchangeCelo extends BaseCommand {
     const minBuyAmount = res.flags.forAtLeast
     const stableToken = stableTokenOptions[res.flags.stableToken]
 
-    await newCheckBuilder(this).hasEnoughCelo(res.flags.from, sellAmount).runChecks()
+    await newCheckBuilder(this)
+      .isNotSanctioned(res.flags.from)
+      .hasEnoughCelo(res.flags.from, sellAmount)
+      .runChecks()
 
     const [celoToken, stableTokenAddress, { mento, brokerAddress }] = await Promise.all([
       kit.contracts.getGoldToken(),

--- a/packages/cli/src/commands/lockedgold/withdraw.ts
+++ b/packages/cli/src/commands/lockedgold/withdraw.ts
@@ -20,7 +20,7 @@ export default class Withdraw extends BaseCommand {
     kit.defaultAccount = flags.from
     const lockedgold = await kit.contracts.getLockedGold()
 
-    await newCheckBuilder(this).isAccount(flags.from).runChecks()
+    await newCheckBuilder(this).isAccount(flags.from).isNotSanctioned(flags.from).runChecks()
 
     const currentTime = Math.round(new Date().getTime() / 1000)
     let madeWithdrawal = false

--- a/packages/cli/src/commands/releasecelo/transfer-dollars.ts
+++ b/packages/cli/src/commands/releasecelo/transfer-dollars.ts
@@ -1,3 +1,4 @@
+import { newCheckBuilder } from '../../utils/checks'
 import { displaySendTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
@@ -31,6 +32,7 @@ export default class TransferDollars extends ReleaseGoldBaseCommand {
     kit.defaultAccount = isRevoked
       ? await this.releaseGoldWrapper.getReleaseOwner()
       : await this.releaseGoldWrapper.getBeneficiary()
+    newCheckBuilder(this).isNotSanctioned(kit.defaultAccount).isNotSanctioned(flags.to).runChecks()
     await displaySendTx('transfer', this.releaseGoldWrapper.transfer(flags.to, flags.value))
   }
 }

--- a/packages/cli/src/commands/releasecelo/withdraw.test.ts
+++ b/packages/cli/src/commands/releasecelo/withdraw.test.ts
@@ -45,6 +45,7 @@ testWithGanache('releasegold:withdraw cmd', (web3: Web3) => {
   })
 
   test("can't withdraw the whole balance if there is a cUSD balance", async () => {
+    const spy = jest.spyOn(console, 'log')
     await testLocally(SetLiquidityProvision, ['--contract', contractAddress, '--yesreally'])
     // ReleasePeriod of default contract
     await timeTravel(300000000, web3)
@@ -65,7 +66,9 @@ testWithGanache('releasegold:withdraw cmd', (web3: Web3) => {
     await expect(
       testLocally(Withdraw, ['--contract', contractAddress, '--value', remainingBalance.toString()])
     ).rejects.toThrow()
-
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('The liquidity provision has not already been set')
+    )
     // Move out the cUSD balance
     await testLocally(RGTransferDollars, [
       '--contract',
@@ -84,7 +87,6 @@ testWithGanache('releasegold:withdraw cmd', (web3: Web3) => {
     ])
     const balanceAfter = await kit.getTotalBalance(beneficiary)
     expect(balanceBefore.CELO!.toNumber()).toBeLessThan(balanceAfter.CELO!.toNumber())
-
     // Contract should self-destruct now
     await expect(releaseGoldWrapper.getRemainingUnlockedBalance()).rejects.toThrow()
   })

--- a/packages/cli/src/commands/releasecelo/withdraw.ts
+++ b/packages/cli/src/commands/releasecelo/withdraw.ts
@@ -29,6 +29,7 @@ export default class Withdraw extends ReleaseGoldBaseCommand {
     const remainingUnlockedBalance = await this.releaseGoldWrapper.getRemainingUnlockedBalance()
     const maxDistribution = await this.releaseGoldWrapper.getMaxDistribution()
     const totalWithdrawn = await this.releaseGoldWrapper.getTotalWithdrawn()
+    kit.defaultAccount = await this.releaseGoldWrapper.getBeneficiary()
     await newCheckBuilder(this)
       .addCheck('Value does not exceed available unlocked celo', () =>
         value.lte(remainingUnlockedBalance)
@@ -56,7 +57,6 @@ export default class Withdraw extends ReleaseGoldBaseCommand {
       .isNotSanctioned(kit.defaultAccount as string)
       .runChecks()
 
-    kit.defaultAccount = await this.releaseGoldWrapper.getBeneficiary()
     await displaySendTx('withdrawTx', this.releaseGoldWrapper.withdraw(value))
   }
 }

--- a/packages/cli/src/commands/releasecelo/withdraw.ts
+++ b/packages/cli/src/commands/releasecelo/withdraw.ts
@@ -53,6 +53,7 @@ export default class Withdraw extends ReleaseGoldBaseCommand {
           return true
         }
       )
+      .isNotSanctioned(kit.defaultAccount as string)
       .runChecks()
 
     kit.defaultAccount = await this.releaseGoldWrapper.getBeneficiary()

--- a/packages/cli/src/commands/transfer/celo.test.ts
+++ b/packages/cli/src/commands/transfer/celo.test.ts
@@ -1,0 +1,85 @@
+import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
+import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
+import TransferCelo from './celo'
+
+process.env.NO_SYNCCHECK = 'true'
+
+// Lots of commands, sometimes times out
+jest.setTimeout(15000)
+
+testWithGanache('transfer:celo cmd', (web3: Web3) => {
+  let accounts: string[] = []
+  let kit: ContractKit
+
+  beforeEach(async () => {
+    kit = newKitFromWeb3(web3)
+    accounts = await web3.eth.getAccounts()
+  })
+
+  test('can transfer celo', async () => {
+    const balanceBefore = await kit.getTotalBalance(accounts[0])
+    const receiverBalanceBefore = await kit.getTotalBalance(accounts[1])
+    const amountToTransfer = '500000000000000000000'
+    // Send cUSD to RG contract
+    await testLocally(TransferCelo, [
+      '--from',
+      accounts[0],
+      '--to',
+      accounts[1],
+      '--value',
+      amountToTransfer,
+      '--gasCurrency',
+      'cusd',
+    ])
+    // RG cUSD balance should match the amount sent
+    const receiverBalance = await kit.getTotalBalance(accounts[1])
+    expect(receiverBalance.CELO!.toFixed()).toEqual(
+      receiverBalanceBefore.CELO!.plus(amountToTransfer).toFixed()
+    )
+    // Attempt to send cUSD back
+    await testLocally(TransferCelo, [
+      '--from',
+      accounts[1],
+      '--to',
+      accounts[0],
+      '--value',
+      amountToTransfer,
+      '--gasCurrency',
+      'cusd',
+    ])
+    const balanceAfter = await kit.getTotalBalance(accounts[0])
+    expect(balanceBefore.CELO).toEqual(balanceAfter.CELO)
+  })
+
+  test('should fail if to address is sanctioned', async () => {
+    const spy = jest.spyOn(console, 'log')
+    await expect(
+      testLocally(TransferCelo, [
+        '--from',
+        accounts[1],
+        '--to',
+        SANCTIONED_ADDRESSES[0],
+        '--value',
+        '1',
+      ])
+    ).rejects.toThrow()
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))
+  })
+  test('should fail if from address is sanctioned', async () => {
+    const spy = jest.spyOn(console, 'log')
+    await expect(
+      testLocally(TransferCelo, [
+        '--from',
+        SANCTIONED_ADDRESSES[0],
+        '--to',
+        accounts[0],
+        '--value',
+        '1',
+      ])
+    ).rejects.toThrow()
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))
+  })
+})

--- a/packages/cli/src/commands/transfer/celo.ts
+++ b/packages/cli/src/commands/transfer/celo.ts
@@ -32,7 +32,11 @@ export default class TransferCelo extends BaseCommand {
     kit.defaultAccount = from
     const celoToken = await kit.contracts.getGoldToken()
 
-    await newCheckBuilder(this).hasEnoughCelo(from, value).runChecks()
+    await newCheckBuilder(this)
+      .isNotSanctioned(from)
+      .isNotSanctioned(to)
+      .hasEnoughCelo(from, value)
+      .runChecks()
 
     await (res.flags.comment
       ? displaySendTx(

--- a/packages/cli/src/commands/transfer/dollars.test.ts
+++ b/packages/cli/src/commands/transfer/dollars.test.ts
@@ -1,0 +1,71 @@
+import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
+import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
+import TransferCUSD from './dollars'
+
+process.env.NO_SYNCCHECK = 'true'
+
+// Lots of commands, sometimes times out
+jest.setTimeout(15000)
+
+testWithGanache('transfer:dollars cmd', (web3: Web3) => {
+  let accounts: string[] = []
+  let kit: ContractKit
+
+  beforeEach(async () => {
+    kit = newKitFromWeb3(web3)
+    accounts = await web3.eth.getAccounts()
+  })
+
+  test('can transfer cusd', async () => {
+    const balanceBefore = await kit.getTotalBalance(accounts[0])
+    const receiverBalanceBefore = await kit.getTotalBalance(accounts[1])
+    const amountToTransfer = '500000000000000000000'
+    // Send cUSD to RG contract
+    await testLocally(TransferCUSD, [
+      '--from',
+      accounts[0],
+      '--to',
+      accounts[1],
+      '--value',
+      amountToTransfer,
+      '--gasCurrency',
+      'CELO',
+    ])
+    // RG cUSD balance should match the amount sent
+    const receiverBalance = await kit.getTotalBalance(accounts[1])
+    expect(receiverBalance.cUSD!.toFixed()).toEqual(
+      receiverBalanceBefore.cUSD!.plus(amountToTransfer).toFixed()
+    )
+    // Attempt to send cUSD back
+    await testLocally(TransferCUSD, [
+      '--from',
+      accounts[1],
+      '--to',
+      accounts[0],
+      '--value',
+      amountToTransfer,
+      '--gasCurrency',
+      'CELO',
+    ])
+    const balanceAfter = await kit.getTotalBalance(accounts[0])
+    expect(balanceBefore.cUSD).toEqual(balanceAfter.cUSD)
+  })
+
+  test('should fail if to address is sanctioned', async () => {
+    const spy = jest.spyOn(console, 'log')
+    await expect(
+      testLocally(TransferCUSD, [
+        '--from',
+        accounts[1],
+        '--to',
+        SANCTIONED_ADDRESSES[0],
+        '--value',
+        '1',
+      ])
+    ).rejects.toThrow()
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))
+  })
+})

--- a/packages/cli/src/commands/transfer/erc20.ts
+++ b/packages/cli/src/commands/transfer/erc20.ts
@@ -50,7 +50,11 @@ export default class TransferErc20 extends BaseCommand {
     } catch {
       failWith('Invalid erc20 address')
     }
-    await newCheckBuilder(this).hasEnoughErc20(from, value, res.flags.erc20Address).runChecks()
+    await newCheckBuilder(this)
+      .isNotSanctioned(from)
+      .isNotSanctioned(to)
+      .hasEnoughErc20(from, value, res.flags.erc20Address)
+      .runChecks()
 
     await displaySendTx('transfer', celoToken.transfer(to, value.toFixed()))
   }

--- a/packages/cli/src/commands/transfer/euros.test.ts
+++ b/packages/cli/src/commands/transfer/euros.test.ts
@@ -1,0 +1,71 @@
+import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
+import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import Web3 from 'web3'
+import { testLocally } from '../../test-utils/cliUtils'
+import TransferEURO from './euros'
+
+process.env.NO_SYNCCHECK = 'true'
+
+// Lots of commands, sometimes times out
+jest.setTimeout(15000)
+
+testWithGanache('transfer:euros cmd', (web3: Web3) => {
+  let accounts: string[] = []
+  let kit: ContractKit
+
+  beforeEach(async () => {
+    kit = newKitFromWeb3(web3)
+    accounts = await web3.eth.getAccounts()
+  })
+
+  test('can transfer ceur', async () => {
+    const balanceBefore = await kit.getTotalBalance(accounts[0])
+    const receiverBalanceBefore = await kit.getTotalBalance(accounts[1])
+    const amountToTransfer = '500000000000000000000'
+    // Send cEUR to RG contract
+    await testLocally(TransferEURO, [
+      '--from',
+      accounts[0],
+      '--to',
+      accounts[1],
+      '--value',
+      amountToTransfer,
+      '--gasCurrency',
+      'CELO',
+    ])
+    // RG cEUR balance should match the amount sent
+    const receiverBalance = await kit.getTotalBalance(accounts[1])
+    expect(receiverBalance.cEUR!.toFixed()).toEqual(
+      receiverBalanceBefore.cEUR!.plus(amountToTransfer).toFixed()
+    )
+    // Attempt to send cEUR back
+    await testLocally(TransferEURO, [
+      '--from',
+      accounts[1],
+      '--to',
+      accounts[0],
+      '--value',
+      amountToTransfer,
+      '--gasCurrency',
+      'CELO',
+    ])
+    const balanceAfter = await kit.getTotalBalance(accounts[0])
+    expect(balanceBefore.cEUR).toEqual(balanceAfter.cEUR)
+  })
+
+  test('should fail if to address is sanctioned', async () => {
+    const spy = jest.spyOn(console, 'log')
+    await expect(
+      testLocally(TransferEURO, [
+        '--from',
+        accounts[1],
+        '--to',
+        SANCTIONED_ADDRESSES[0],
+        '--value',
+        '1',
+      ])
+    ).rejects.toThrow()
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))
+  })
+})

--- a/packages/cli/src/exchange-stable-base.ts
+++ b/packages/cli/src/exchange-stable-base.ts
@@ -39,6 +39,7 @@ export default class ExchangeStableBase extends BaseCommand {
     }
     await newCheckBuilder(this)
       .hasEnoughStable(res.flags.from, sellAmount, this._stableCurrency)
+      .isNotSanctioned(res.flags.from)
       .runChecks()
 
     const [stableToken, celoNativeTokenAddress, { mento, brokerAddress }] = await Promise.all([

--- a/packages/cli/src/transfer-stable-base.ts
+++ b/packages/cli/src/transfer-stable-base.ts
@@ -47,6 +47,8 @@ export abstract class TransferStableBase extends BaseCommand {
 
     await newCheckBuilder(this)
       .hasEnoughStable(from, value, this._stableCurrency)
+      .isNotSanctioned(from)
+      .isNotSanctioned(to)
       .addConditionalCheck(
         `Account can afford transfer and gas paid in ${this._stableCurrency}`,
         kit.connection.defaultFeeCurrency === stableToken.address,

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -13,6 +13,8 @@ import chalk from 'chalk'
 import utils from 'web3-utils'
 import { BaseCommand } from '../base'
 import { printValueMapRecursive } from './cli'
+import { SANCTIONED_ADDRESSES, COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
+import { isSanctioned } from './helpers'
 
 export interface CommandCheck {
   name: string
@@ -266,6 +268,13 @@ class CheckBuilder {
         validators.meetsValidatorGroupBalanceRequirements(account)
       )
     )
+  isNotSanctioned = (address: Address) => {
+    return this.addCheck(
+      'Compliant Address',
+      () => !isSanctioned(address),
+      COMPLIANT_ERROR_RESPONSE
+    )
+  }
 
   isValidAddress = (address: Address) =>
     this.addCheck(`${address} is a valid address`, () => isValidAddress(address))

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -1,4 +1,5 @@
 import { eqAddress, NULL_ADDRESS } from '@celo/base/lib/address'
+import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
 import { Address } from '@celo/connect'
 import { StableToken } from '@celo/contractkit'
 import { AccountsWrapper } from '@celo/contractkit/lib/wrappers/Accounts'
@@ -13,7 +14,6 @@ import chalk from 'chalk'
 import utils from 'web3-utils'
 import { BaseCommand } from '../base'
 import { printValueMapRecursive } from './cli'
-import { SANCTIONED_ADDRESSES, COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
 import { isSanctioned } from './helpers'
 
 export interface CommandCheck {

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -514,26 +514,22 @@ class CheckBuilder {
   }
 
   private async fetchIsSanctioned(address: string) {
-    if (this.SANCTIONED_SET.data.has(address)) {
-      return true
-      // Would like to avoid calling this EVERY run. but at least calling
-      // twice in a row (such as when checking from and to addresses) should be cached
-      // using boolean because either it's been refreshed or this is the first run of the invocation. its short lived
-    } else if (!this.SANCTIONED_SET.wasRefreshed) {
+    // Would like to avoid calling this EVERY run. but at least calling
+    // twice in a row (such as when checking from and to addresses) should be cached
+    // using boolean because either it's been refreshed or this is the first run of the invocation. its short lived
+    if (!this.SANCTIONED_SET.wasRefreshed) {
       try {
         const result = await fetch(OFAC_SANCTIONS_LIST_URL)
         const data = await result.json()
         if (Array.isArray(data)) {
           this.SANCTIONED_SET.data = new Set(data)
           this.SANCTIONED_SET.wasRefreshed = true
-          return this.SANCTIONED_SET.data.has(address)
         }
       } catch (e) {
         console.error('Error fetching OFAC sanctions list', e)
-        return false
       }
     }
-    return false
+    return this.SANCTIONED_SET.data.has(address)
   }
 
   // async executeValidatorTx(

--- a/packages/cli/src/utils/helpers.ts
+++ b/packages/cli/src/utils/helpers.ts
@@ -1,6 +1,4 @@
-import { OFAC_SANCTIONS_LIST_URL, SANCTIONED_ADDRESSES } from '@celo/compliance'
 import { Block } from '@celo/connect'
-import { fetch } from 'cross-fetch'
 import Web3 from 'web3'
 import { failWith } from './cli'
 
@@ -54,29 +52,4 @@ export async function requireNodeIsSynced(web3: Web3) {
   if (!(await nodeIsSynced(web3))) {
     failWith('Node is not currently synced. Run node:synced to check its status.')
   }
-}
-
-// SANCTIONED_ADDRESSES is so well typed that if you call includes with a string it gives a type error.
-// same if you make it a set or use indexOf so concat it with an empty string to give type without needing to ts-ignore
-const SANCTIONED_SET = { data: new Set([''].concat(SANCTIONED_ADDRESSES)), lastUpdated: Date.now() }
-const CACHE_DURATION_MS = 1000 * 60 * 60 * 24 // 1 day
-export async function isSanctioned(address: string) {
-  if (SANCTIONED_SET.data.has(address)) {
-    return true
-    // Wwould like to avoid calling this EVERY run. but at least calling
-    // twice in a row (such as when checking from and to addresses) should be cached
-  } else if (Date.now() - SANCTIONED_SET.lastUpdated < CACHE_DURATION_MS) {
-    try {
-      const result = await fetch(OFAC_SANCTIONS_LIST_URL)
-      const data = await result.json()
-      if (Array.isArray(data)) {
-        SANCTIONED_SET.data = new Set(data)
-        SANCTIONED_SET.lastUpdated = Date.now()
-        return SANCTIONED_SET.data.has(address)
-      }
-    } finally {
-      return false
-    }
-  }
-  return false
 }

--- a/packages/cli/src/utils/helpers.ts
+++ b/packages/cli/src/utils/helpers.ts
@@ -1,3 +1,4 @@
+import { SANCTIONED_ADDRESSES } from '@celo/compliance'
 import { Block } from '@celo/connect'
 import Web3 from 'web3'
 import { failWith } from './cli'
@@ -52,4 +53,12 @@ export async function requireNodeIsSynced(web3: Web3) {
   if (!(await nodeIsSynced(web3))) {
     failWith('Node is not currently synced. Run node:synced to check its status.')
   }
+}
+
+// SANCTIONED_ADDRESSES is so well typed that if you call includes with a string it gives a type error.
+// same if you make it a set or use indexOf so concat it with an empty string to give type without needing to ts-ignore
+const SANCTIONED_SET = new Set([''].concat(SANCTIONED_ADDRESSES))
+
+export function isSanctioned(address: string) {
+  return SANCTIONED_SET.has(address)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1630,6 +1630,7 @@ __metadata:
     bip32: "npm:3.1.0"
     chalk: "npm:^2.4.2"
     command-exists: "npm:^1.2.9"
+    cross-fetch: "npm:3.0.6"
     debug: "npm:^4.1.1"
     ethers: "npm:5"
     fs-extra: "npm:^8.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,6 +1593,7 @@ __metadata:
     "@celo/abis": "npm:10.0.0"
     "@celo/base": "npm:^6.0.0"
     "@celo/celo-devchain": "npm:^6.0.3"
+    "@celo/compliance": "npm:^1.0.15"
     "@celo/connect": "npm:^5.1.2"
     "@celo/contractkit": "npm:^7.0.0"
     "@celo/cryptographic-utils": "npm:^5.0.7"
@@ -1649,6 +1650,13 @@ __metadata:
     dev: .bin/dev.js
   languageName: unknown
   linkType: soft
+
+"@celo/compliance@npm:^1.0.15":
+  version: 1.0.15
+  resolution: "@celo/compliance@npm:1.0.15"
+  checksum: 1bffb6ff0a09a225d97a1b44262001489ad187c1d47291046c24e4ee72f0cd68d79583476a85524ca99cdf299f670ab9c0d34d1bdc4818cfe2462c074527fad5
+  languageName: node
+  linkType: hard
 
 "@celo/connect@npm:^5.1.1":
   version: 5.1.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,7 +1593,7 @@ __metadata:
     "@celo/abis": "npm:10.0.0"
     "@celo/base": "npm:^6.0.0"
     "@celo/celo-devchain": "npm:^6.0.3"
-    "@celo/compliance": "npm:^1.0.15"
+    "@celo/compliance": "npm:~1.0.17"
     "@celo/connect": "npm:^5.1.2"
     "@celo/contractkit": "npm:^7.0.0"
     "@celo/cryptographic-utils": "npm:^5.0.7"
@@ -1652,10 +1652,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@celo/compliance@npm:^1.0.15":
-  version: 1.0.15
-  resolution: "@celo/compliance@npm:1.0.15"
-  checksum: 1bffb6ff0a09a225d97a1b44262001489ad187c1d47291046c24e4ee72f0cd68d79583476a85524ca99cdf299f670ab9c0d34d1bdc4818cfe2462c074527fad5
+"@celo/compliance@npm:~1.0.17":
+  version: 1.0.17
+  resolution: "@celo/compliance@npm:1.0.17"
+  checksum: d38bcff8468066e348afba47747f4300533e90351ef9f7ae1de92df3979dd8072127d053f32bc36e0d0008c8a232d5f5bb522dd5aea8a48e05eeff361c7e44fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Adds the @celo/compliance package to ensure commands which transfer tokens do not work with OFAC sanctioned addresses. 

### Other changes

As transfer commands did not have tests this adds tests for basic case and for non compliant case.

### Tested

New Tests. 

### Related issues

- Fixes #145 

### Backwards compatibility

yep
### Documentation

n/a