### PR TITLE
Adds "how we work" section across READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ for the Celo community.
 ## How we work
 
 We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
-
 Please use GitHub to:
 
 🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
@@ -15,16 +14,14 @@ Please use GitHub to:
 
 ✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
 
-🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
-
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 
-We actively monitor GitHub, and will get back to you shortly.
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 > [!WARNING]
 > 
-> Please avoid messaging us via Slack, Telegram, or email. 
-> **Github > \[ Slack | Telegram | Email \]** (in our opinion)
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟
 
 ## Code
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please use GitHub to:
 
 🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
-> [!WARNING]
+> [!TIP]
 > 
 > Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
 > GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/README.md
+++ b/README.md
@@ -1,12 +1,34 @@
 # Developer Tooling
 
-> **NOTE** This is a relatively new repository and is still under active development.
-> Some of the packages and release processes may not be fully documented yet.
-
 This repository contains the source code for various JS/TS developer tools and CLI(s) released by cLabs 
 for the Celo community. 
 
-This includes: 
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+We actively monitor GitHub, and will get back to you shortly.
+
+> [!WARNING]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. 
+> **Github > \[ Slack | Telegram | Email \]** (in our opinion)
+
+## Code
+
+This repository contains source code for: 
 
 - [`@celo/celocli`](https://www.npmjs.com/package/@celo/celocli)
 - [`@celo/base`](https://www.npmjs.com/package/@celo/base)
@@ -17,7 +39,7 @@ This includes:
 - [`@celo/governance`](https://www.npmjs.com/package/@celo/governance)
 - [`@celo/keystore`](https://www.npmjs.com/package/@celo/keystores)
 - [`@celo/network-utils`](https://www.npmjs.com/package/@celo/network-utils)
-- [`@celo/phone-utils`](https://www.npmjs.com/package/@celo/phone-utils) (may be deprecated soon ⚠️)
+- [`@celo/phone-utils`](https://www.npmjs.com/package/@celo/phone-utils)
 - [`@celo/transaction-uri`](https://www.npmjs.com/package/@celo/transactions-uri)
 - Wallet related packages including:
   - [`@celo/wallet-base`](https://www.npmjs.com/package/@celo/wallet-base)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,6 +14,26 @@ npm install -g @celo/celocli
 
 If you have trouble installing globally (i.e. with the `-g` flag), try installing to a local directory instead with `npm install @celo/celocli` and run with `npx celocli`.
 
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟
+
 ### Plugins
 
 Additional plugins can be installed which make the CLI experience smoother. Currently, `celocli` only supports installing plugins published on NPM within the `@celo/*` and `@clabs/*` scopes.

--- a/packages/docs/sdk/docs/connect/README.md
+++ b/packages/docs/sdk/docs/connect/README.md
@@ -4,6 +4,26 @@
 
 *Connect to the Celo Blockchain.*  `Connection` provides the core of what you need to interact with Celo blockchain. The Core Difference between it and ContractKit is that it provides zero Contract Wrappers, and therefore leaves out convenience methods for example for setting FeeCurrency, or getting configs.
 
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟
+
 ## Examples
 
 ### Basic

--- a/packages/docs/sdk/docs/contractkit/README.md
+++ b/packages/docs/sdk/docs/contractkit/README.md
@@ -21,6 +21,26 @@ You might not need the full ContractKit. Consider using `@celo/connect` which po
 
 :::
 
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟
+
 ### Getting Started
 
 To install:

--- a/packages/docs/sdk/docs/cryptographic-utils/README.md
+++ b/packages/docs/sdk/docs/cryptographic-utils/README.md
@@ -7,3 +7,23 @@ Here you can find cryptographic functions for
 * Celo mnemonics
 * BLS
 * encrypting/decrypting messages sent in transfers like Valora does
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/docs/sdk/docs/phone-utils/README.md
+++ b/packages/docs/sdk/docs/phone-utils/README.md
@@ -2,6 +2,28 @@
 
 # @celo/phone-utils
 
-These are A collection of functions for formatting and reading phonenumbers used by the v1 Attestation Service and wallets such as Valora. It uses `google-lib-phonenumber`,  under the hood.
+These are a collection of functions for formatting and reading phone numbers used by the 
+validator-run attestation service and (formerly) wallets such as Valora. 
+It uses `google-lib-phonenumber`, under the hood.
 
 It may be deprecated in the future.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/base/README.MD
+++ b/packages/sdk/base/README.MD
@@ -3,6 +3,25 @@
 
 This package contains shared classes and functions used by other celo packages. It was designed to have minimal external dependencies. (for shared celo functions that have big external dependencies see the @celo/utils, @celo/cryptographic-utils, @celo/phone-utils, @celo/network-utils packages)
 
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟
 
 ## Notable Types
 

--- a/packages/sdk/connect/README.md
+++ b/packages/sdk/connect/README.md
@@ -1,7 +1,26 @@
 # @celo/connect
 
-
 *Connect to the Celo Blockchain.*  `Connection` provides the core of what you need to interact with Celo blockchain. The Core Difference between it and ContractKit is that it provides zero Contract Wrappers, and therefore leaves out convenience methods for example for setting FeeCurrency, or getting configs.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟
 
 ## Examples
 

--- a/packages/sdk/contractkit/README.md
+++ b/packages/sdk/contractkit/README.md
@@ -19,6 +19,26 @@ You might not need the full ContractKit. Consider using `@celo/connect` which po
 
 :::
 
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟
+
 ### Getting Started
 
 To install:

--- a/packages/sdk/cryptographic-utils/README.md
+++ b/packages/sdk/cryptographic-utils/README.md
@@ -5,3 +5,23 @@ Here you can find cryptographic functions for
 * Celo mnemonics
 * BLS
 * encrypting/decrypting messages sent in transfers like Valora does
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/explorer/README.md
+++ b/packages/sdk/explorer/README.md
@@ -1,5 +1,23 @@
-
-
 # @celo/explorer
 
 Explorer depends on contractkit and connect. It provides some utility functions that make it easy to listen for new block and log information.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/governance/README.md
+++ b/packages/sdk/governance/README.md
@@ -6,3 +6,22 @@ It provides functions to read and interact with Celo Governance Proposals (CGPs)
 
 Construct Celo Governance Proposals using either the `InteractiveProposalBuilder` class (for CLI apps) or `ProposalBuilder` (consumable via JS)
 
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/keystores/README.md
+++ b/packages/sdk/keystores/README.md
@@ -1,3 +1,21 @@
-
-
 # @celo/keystores
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/network-utils/README.md
+++ b/packages/sdk/network-utils/README.md
@@ -1,4 +1,23 @@
-
 # @celo/network-utils
 
  @celo/network-utils provides utilities for getting genesis block and static node information.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/phone-utils/README.md
+++ b/packages/sdk/phone-utils/README.md
@@ -1,6 +1,27 @@
 # @celo/phone-utils
 
-These are A collection of functions for formatting and reading phonenumbers used by the v1 Attestation Service and wallets such as Valora. It uses `google-lib-phonenumber`,  under the hood.
-
+These are a collection of functions for formatting and reading phone numbers used by the 
+validator-run attestation service and (formerly) wallets such as Valora. 
+It uses `google-lib-phonenumber`, under the hood.
 
 It may be deprecated in the future.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/transactions-uri/README.md
+++ b/packages/sdk/transactions-uri/README.md
@@ -1,6 +1,23 @@
-
-
 # @celo/transactions-uri
 
-
 Makes it easy to generate Celo transaction URIs and QR codes.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/utils/README.md
+++ b/packages/sdk/utils/README.md
@@ -1,5 +1,23 @@
-
-
 # @celo/utils
 
-Various utility functions used across celo sdks
+Various utility functions used across Celo SDKs.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/wallets/wallet-base/Readme.md
+++ b/packages/sdk/wallets/wallet-base/Readme.md
@@ -1,3 +1,23 @@
-
+# @celo/wallet-base
 
 Wallet-base provides base utilities for creating Celo wallets.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/wallets/wallet-hsm-aws/README.MD
+++ b/packages/sdk/wallets/wallet-hsm-aws/README.MD
@@ -1,1 +1,23 @@
+# @celo/wallet-hsm-aws
+
 Wallet-hsm-aws allows you to easily interact with a cloud HSM wallet built on AWS KMS.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/wallets/wallet-hsm-azure/README.md
+++ b/packages/sdk/wallets/wallet-hsm-azure/README.md
@@ -1,1 +1,23 @@
+# @celo/wallet-hsm-azure
+
 Wallet-hsm-azure is a Azure Key Vault implementation of a RemoteWallet.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/wallets/wallet-hsm-gcp/README.md
+++ b/packages/sdk/wallets/wallet-hsm-gcp/README.md
@@ -1,0 +1,21 @@
+# @celo/wallet-hsm-gcp
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/wallets/wallet-hsm/README.md
+++ b/packages/sdk/wallets/wallet-hsm/README.md
@@ -1,1 +1,23 @@
+# @celo/wallet-hsm
+
 Wallet-hsm provides signature utilities for using HSMs.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/wallets/wallet-ledger/README.MD
+++ b/packages/sdk/wallets/wallet-ledger/README.MD
@@ -1,1 +1,23 @@
+# @celo/wallet-ledger
+
 Wallet-ledger provides utilities for interacting with a Ledger hardware wallet.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/wallets/wallet-local/Readme.MD
+++ b/packages/sdk/wallets/wallet-local/Readme.MD
@@ -1,1 +1,23 @@
+# @celo/wallet-local
+
 Wallet-localprovides utilities for locally managing wallet by importing a private key string.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/wallets/wallet-remote/README.md
+++ b/packages/sdk/wallets/wallet-remote/README.md
@@ -1,1 +1,23 @@
+# @celo/wallet-remote
+
 Wallet-remote provides utilities for interacting with remote wallets. This is useful for interacting with wallets on secure remote servers.
+
+## How we work
+
+We are a GitHub-first team, which means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟

--- a/packages/sdk/wallets/wallet-rpc/README.md
+++ b/packages/sdk/wallets/wallet-rpc/README.md
@@ -1,1 +1,23 @@
+# @celo/wallet-rpc
+
 Wallet-rpc provides utilities for performing wallet functions via RPC.
+
+## How we work
+
+We are a GitHub-first team, wihich means we have a strong preference for communicating via GitHub. 
+Please use GitHub to:
+
+🐞 [File a bug report](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
+
+✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+
+🧑‍💻 [Contribute!](/CONTRIBUTING.md)
+
+🚔 [Report a security vulnerability](https://github.com/celo-org/developer-tooling/issues/new/choose)
+
+> [!TIP]
+> 
+> Please avoid messaging us via Slack, Telegram, or email. We are more likely to respond to you on 
+> GitHub than if you message us anywhere else. We actively monitor GitHub, and will get back to you shortly 🌟


### PR DESCRIPTION
### Description

Adds "how we work" section in various READMEs. 

Based on [feedback](https://clabsco.slack.com/archives/C014SRL4URY/p1708973042787839?thread_ts=1708971223.840439&cid=C014SRL4URY) from the Celo Foundation and external contributors, it's not clear how to reach us.  

My goal with this PR is to be (particularly) explicit that we have a strong preference for GitHub.

My goal is to display this information on npmjs.org (for each package) and celo.docs.org, which is where most of our users interface with our products. I hypothesize that most folks don't know that [celo-org/developer-tooling](https://github.com/celo-org/developer-tooling) is where we work and encourage communication.

### Tested

Docs-only changes

### Related issues

N/A

### Backwards compatibility

Yes, docs-only change

### Documentation

Yes, docs change