### PR TITLE
Fix Jest Long Test Timeouts

### DIFF
--- a/packages/cli/src/commands/lockedgold/lock.test.ts
+++ b/packages/cli/src/commands/lockedgold/lock.test.ts
@@ -1,7 +1,7 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
-import { testLocally } from '../../test-utils/cliUtils'
+import { LONG_TIMEOUT_MS, testLocally } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from './lock'
 import Unlock from './unlock'
@@ -9,18 +9,22 @@ import Unlock from './unlock'
 process.env.NO_SYNCCHECK = 'true'
 
 testWithGanache('lockedgold:lock cmd', (web3: Web3) => {
-  test('can lock with pending withdrawals', async () => {
-    const accounts = await web3.eth.getAccounts()
-    const account = accounts[0]
-    const kit = newKitFromWeb3(web3)
-    const lockedGold = await kit.contracts.getLockedGold()
-    await testLocally(Register, ['--from', account])
-    await testLocally(Lock, ['--from', account, '--value', '100'])
-    await testLocally(Unlock, ['--from', account, '--value', '50'])
-    await testLocally(Lock, ['--from', account, '--value', '75'])
-    await testLocally(Unlock, ['--from', account, '--value', '50'])
-    await testLocally(Lock, ['--from', account, '--value', '50'])
-    const pendingWithdrawalsTotalValue = await lockedGold.getPendingWithdrawalsTotalValue(account)
-    expect(pendingWithdrawalsTotalValue.toFixed()).toBe('0')
-  })
+  test(
+    'can lock with pending withdrawals',
+    async () => {
+      const accounts = await web3.eth.getAccounts()
+      const account = accounts[0]
+      const kit = newKitFromWeb3(web3)
+      const lockedGold = await kit.contracts.getLockedGold()
+      await testLocally(Register, ['--from', account])
+      await testLocally(Lock, ['--from', account, '--value', '100'])
+      await testLocally(Unlock, ['--from', account, '--value', '50'])
+      await testLocally(Lock, ['--from', account, '--value', '75'])
+      await testLocally(Unlock, ['--from', account, '--value', '50'])
+      await testLocally(Lock, ['--from', account, '--value', '50'])
+      const pendingWithdrawalsTotalValue = await lockedGold.getPendingWithdrawalsTotalValue(account)
+      expect(pendingWithdrawalsTotalValue.toFixed()).toBe('0')
+    },
+    LONG_TIMEOUT_MS
+  )
 })

--- a/packages/cli/src/commands/lockedgold/unlock.test.ts
+++ b/packages/cli/src/commands/lockedgold/unlock.test.ts
@@ -2,7 +2,7 @@ import { newKitFromWeb3 } from '@celo/contractkit'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'
-import { testLocally } from '../../test-utils/cliUtils'
+import { LONG_TIMEOUT_MS, testLocally } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Vote from '../election/vote'
 import ValidatorAffiliate from '../validator/affiliate'
@@ -15,41 +15,45 @@ import Unlock from './unlock'
 process.env.NO_SYNCCHECK = 'true'
 
 testWithGanache('lockedgold:unlock cmd', (web3: Web3) => {
-  test('can unlock correctly from registered validator group', async () => {
-    const accounts = await web3.eth.getAccounts()
-    const account = accounts[0]
-    const validator = accounts[1]
-    const kit = newKitFromWeb3(web3)
-    const lockedGold = await kit.contracts.getLockedGold()
-    await testLocally(Register, ['--from', account])
-    await testLocally(Lock, ['--from', account, '--value', '20000000000000000000000'])
-    await testLocally(ValidatorGroupRegister, ['--from', account, '--commission', '0', '--yes'])
-    await testLocally(Register, ['--from', validator])
-    await testLocally(Lock, ['--from', validator, '--value', '20000000000000000000000'])
-    const ecdsaPublicKey = await addressToPublicKey(validator, web3.eth.sign)
-    await testLocally(ValidatorRegister, [
-      '--from',
-      validator,
-      '--ecdsaKey',
-      ecdsaPublicKey,
-      '--blsKey',
-      '0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00',
-      '--blsSignature',
-      '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
-      '--yes',
-    ])
-    await testLocally(ValidatorAffiliate, ['--yes', '--from', validator, account])
-    await testLocally(ValidatorGroupMember, ['--yes', '--from', account, '--accept', validator])
-    await testLocally(Vote, [
-      '--from',
-      account,
-      '--for',
-      account,
-      '--value',
-      '10000000000000000000000',
-    ])
-    await testLocally(Unlock, ['--from', account, '--value', '10000000000000000000000'])
-    const pendingWithdrawalsTotalValue = await lockedGold.getPendingWithdrawalsTotalValue(account)
-    expect(pendingWithdrawalsTotalValue.toFixed()).toBe('10000000000000000000000')
-  })
+  test(
+    'can unlock correctly from registered validator group',
+    async () => {
+      const accounts = await web3.eth.getAccounts()
+      const account = accounts[0]
+      const validator = accounts[1]
+      const kit = newKitFromWeb3(web3)
+      const lockedGold = await kit.contracts.getLockedGold()
+      await testLocally(Register, ['--from', account])
+      await testLocally(Lock, ['--from', account, '--value', '20000000000000000000000'])
+      await testLocally(ValidatorGroupRegister, ['--from', account, '--commission', '0', '--yes'])
+      await testLocally(Register, ['--from', validator])
+      await testLocally(Lock, ['--from', validator, '--value', '20000000000000000000000'])
+      const ecdsaPublicKey = await addressToPublicKey(validator, web3.eth.sign)
+      await testLocally(ValidatorRegister, [
+        '--from',
+        validator,
+        '--ecdsaKey',
+        ecdsaPublicKey,
+        '--blsKey',
+        '0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00',
+        '--blsSignature',
+        '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
+        '--yes',
+      ])
+      await testLocally(ValidatorAffiliate, ['--yes', '--from', validator, account])
+      await testLocally(ValidatorGroupMember, ['--yes', '--from', account, '--accept', validator])
+      await testLocally(Vote, [
+        '--from',
+        account,
+        '--for',
+        account,
+        '--value',
+        '10000000000000000000000',
+      ])
+      await testLocally(Unlock, ['--from', account, '--value', '10000000000000000000000'])
+      const pendingWithdrawalsTotalValue = await lockedGold.getPendingWithdrawalsTotalValue(account)
+      expect(pendingWithdrawalsTotalValue.toFixed()).toBe('10000000000000000000000')
+    },
+    LONG_TIMEOUT_MS * 1.5
+  )
 })

--- a/packages/cli/src/commands/lockedgold/update-delegated-amount.test.ts
+++ b/packages/cli/src/commands/lockedgold/update-delegated-amount.test.ts
@@ -1,6 +1,6 @@
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
-import { testLocally } from '../../test-utils/cliUtils'
+import { LONG_TIMEOUT_MS, testLocally } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Delegate from './delegate'
 import Lock from './lock'
@@ -9,15 +9,19 @@ import UpdateDelegatedAmount from './update-delegated-amount'
 process.env.NO_SYNCCHECK = 'true'
 
 testWithGanache('lockedgold:update-delegated-amount cmd', (web3: Web3) => {
-  test('can update delegated amount', async () => {
-    const accounts = await web3.eth.getAccounts()
-    const account = accounts[0]
-    const account2 = accounts[1]
-    await testLocally(Register, ['--from', account])
-    await testLocally(Register, ['--from', account2])
-    await testLocally(Lock, ['--from', account, '--value', '200'])
-    await testLocally(Delegate, ['--from', account, '--to', account2, '--percent', '100'])
+  test(
+    'can update delegated amount',
+    async () => {
+      const accounts = await web3.eth.getAccounts()
+      const account = accounts[0]
+      const account2 = accounts[1]
+      await testLocally(Register, ['--from', account])
+      await testLocally(Register, ['--from', account2])
+      await testLocally(Lock, ['--from', account, '--value', '200'])
+      await testLocally(Delegate, ['--from', account, '--to', account2, '--percent', '100'])
 
-    await testLocally(UpdateDelegatedAmount, ['--from', account, '--to', account2])
-  })
+      await testLocally(UpdateDelegatedAmount, ['--from', account, '--to', account2])
+    },
+    LONG_TIMEOUT_MS
+  )
 })

--- a/packages/cli/src/commands/releasecelo/locked-gold.test.ts
+++ b/packages/cli/src/commands/releasecelo/locked-gold.test.ts
@@ -1,7 +1,7 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { getContractFromEvent, testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import Web3 from 'web3'
-import { testLocally } from '../../test-utils/cliUtils'
+import { LONG_TIMEOUT_MS, testLocally } from '../../test-utils/cliUtils'
 import CreateAccount from './create-account'
 import LockedGold from './locked-gold'
 
@@ -20,43 +20,47 @@ testWithGanache('releasegold:locked-gold cmd', (web3: Web3) => {
     await testLocally(CreateAccount, ['--contract', contractAddress])
   })
 
-  test('can lock celo with pending withdrawals', async () => {
-    const lockedGold = await kit.contracts.getLockedGold()
-    await testLocally(LockedGold, [
-      '--contract',
-      contractAddress,
-      '--action',
-      'lock',
-      '--value',
-      '100',
-    ])
-    await testLocally(LockedGold, [
-      '--contract',
-      contractAddress,
-      '--action',
-      'unlock',
-      '--value',
-      '50',
-    ])
-    await testLocally(LockedGold, [
-      '--contract',
-      contractAddress,
-      '--action',
-      'lock',
-      '--value',
-      '75',
-    ])
-    await testLocally(LockedGold, [
-      '--contract',
-      contractAddress,
-      '--action',
-      'unlock',
-      '--value',
-      '50',
-    ])
-    const pendingWithdrawalsTotalValue = await lockedGold.getPendingWithdrawalsTotalValue(
-      contractAddress
-    )
-    await expect(pendingWithdrawalsTotalValue.toFixed()).toBe('50')
-  })
+  test(
+    'can lock celo with pending withdrawals',
+    async () => {
+      const lockedGold = await kit.contracts.getLockedGold()
+      await testLocally(LockedGold, [
+        '--contract',
+        contractAddress,
+        '--action',
+        'lock',
+        '--value',
+        '100',
+      ])
+      await testLocally(LockedGold, [
+        '--contract',
+        contractAddress,
+        '--action',
+        'unlock',
+        '--value',
+        '50',
+      ])
+      await testLocally(LockedGold, [
+        '--contract',
+        contractAddress,
+        '--action',
+        'lock',
+        '--value',
+        '75',
+      ])
+      await testLocally(LockedGold, [
+        '--contract',
+        contractAddress,
+        '--action',
+        'unlock',
+        '--value',
+        '50',
+      ])
+      const pendingWithdrawalsTotalValue = await lockedGold.getPendingWithdrawalsTotalValue(
+        contractAddress
+      )
+      expect(pendingWithdrawalsTotalValue.toFixed()).toBe('50')
+    },
+    LONG_TIMEOUT_MS * 2
+  )
 })

--- a/packages/cli/src/test-utils/cliUtils.ts
+++ b/packages/cli/src/test-utils/cliUtils.ts
@@ -14,3 +14,5 @@ export async function testLocally(
   const extendedArgv = [...argv, '--node', 'local']
   return command.run(extendedArgv, config)
 }
+
+export const LONG_TIMEOUT_MS = 10 * 1000


### PR DESCRIPTION


### Description

Fix 'Jest did not exit one second after the test run has completed.This usually means that there are asynchronous operations that weren't stopped in your tests.'

### Other changes
n/a

### Tested

ran locally



