### PR TITLE
Added Ethereum-compatible legacy TXs support

### DIFF
--- a/.changeset/quick-tips-happen.md
+++ b/.changeset/quick-tips-happen.md
@@ -1,0 +1,6 @@
+---
+"@celo/connect": minor
+"@celo/wallet-base": minor
+---
+
+Add support Type 0 Ethereum-compatible legacy TXs

--- a/packages/docs/sdk/docs/connect/interfaces/types.EncodedTransaction.md
+++ b/packages/docs/sdk/docs/connect/interfaces/types.EncodedTransaction.md
@@ -19,14 +19,14 @@
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:118](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L118)
+[packages/sdk/connect/src/types.ts:123](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L123)
 
 ___
 
 ### tx
 
-• **tx**: [`EIP1559TXProperties`](types.EIP1559TXProperties.md) \| [`CIP64TXProperties`](types.CIP64TXProperties.md) \| [`CIP42TXProperties`](types.CIP42TXProperties.md) \| [`LegacyTXProperties`](types.LegacyTXProperties.md)
+• **tx**: [`EIP1559TXProperties`](types.EIP1559TXProperties.md) \| [`CIP64TXProperties`](types.CIP64TXProperties.md) \| [`CIP42TXProperties`](types.CIP42TXProperties.md) \| [`LegacyTXProperties`](types.LegacyTXProperties.md) \| [`EthereumLegacyTXProperties`](types.EthereumLegacyTXProperties.md)
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:119](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L119)
+[packages/sdk/connect/src/types.ts:124](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L124)

--- a/packages/docs/sdk/docs/connect/interfaces/types.Error.md
+++ b/packages/docs/sdk/docs/connect/interfaces/types.Error.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:153](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L153)
+[packages/sdk/connect/src/types.ts:163](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L163)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:154](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L154)
+[packages/sdk/connect/src/types.ts:164](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L164)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:155](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L155)
+[packages/sdk/connect/src/types.ts:165](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L165)

--- a/packages/docs/sdk/docs/connect/interfaces/types.EthereumLegacyTXProperties.md
+++ b/packages/docs/sdk/docs/connect/interfaces/types.EthereumLegacyTXProperties.md
@@ -1,0 +1,177 @@
+[@celo/connect](../README.md) / [Exports](../modules.md) / [types](../modules/types.md) / EthereumLegacyTXProperties
+
+# Interface: EthereumLegacyTXProperties
+
+[types](../modules/types.md).EthereumLegacyTXProperties
+
+## Hierarchy
+
+- `CommonTXProperties`
+
+  ↳ **`EthereumLegacyTXProperties`**
+
+## Table of contents
+
+### Properties
+
+- [gas](types.EthereumLegacyTXProperties.md#gas)
+- [gasPrice](types.EthereumLegacyTXProperties.md#gasprice)
+- [hash](types.EthereumLegacyTXProperties.md#hash)
+- [input](types.EthereumLegacyTXProperties.md#input)
+- [nonce](types.EthereumLegacyTXProperties.md#nonce)
+- [r](types.EthereumLegacyTXProperties.md#r)
+- [s](types.EthereumLegacyTXProperties.md#s)
+- [to](types.EthereumLegacyTXProperties.md#to)
+- [type](types.EthereumLegacyTXProperties.md#type)
+- [v](types.EthereumLegacyTXProperties.md#v)
+- [value](types.EthereumLegacyTXProperties.md#value)
+
+## Properties
+
+### gas
+
+• **gas**: `string`
+
+#### Inherited from
+
+CommonTXProperties.gas
+
+#### Defined in
+
+[packages/sdk/connect/src/types.ts:73](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L73)
+
+___
+
+### gasPrice
+
+• **gasPrice**: `string`
+
+#### Defined in
+
+[packages/sdk/connect/src/types.ts:118](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L118)
+
+___
+
+### hash
+
+• **hash**: `string`
+
+#### Inherited from
+
+CommonTXProperties.hash
+
+#### Defined in
+
+[packages/sdk/connect/src/types.ts:80](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L80)
+
+___
+
+### input
+
+• **input**: `string`
+
+#### Inherited from
+
+CommonTXProperties.input
+
+#### Defined in
+
+[packages/sdk/connect/src/types.ts:76](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L76)
+
+___
+
+### nonce
+
+• **nonce**: `string`
+
+#### Inherited from
+
+CommonTXProperties.nonce
+
+#### Defined in
+
+[packages/sdk/connect/src/types.ts:72](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L72)
+
+___
+
+### r
+
+• **r**: `string`
+
+#### Inherited from
+
+CommonTXProperties.r
+
+#### Defined in
+
+[packages/sdk/connect/src/types.ts:77](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L77)
+
+___
+
+### s
+
+• **s**: `string`
+
+#### Inherited from
+
+CommonTXProperties.s
+
+#### Defined in
+
+[packages/sdk/connect/src/types.ts:78](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L78)
+
+___
+
+### to
+
+• **to**: `string`
+
+#### Inherited from
+
+CommonTXProperties.to
+
+#### Defined in
+
+[packages/sdk/connect/src/types.ts:74](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L74)
+
+___
+
+### type
+
+• **type**: ``"ethereum-legacy"``
+
+#### Overrides
+
+CommonTXProperties.type
+
+#### Defined in
+
+[packages/sdk/connect/src/types.ts:119](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L119)
+
+___
+
+### v
+
+• **v**: `string`
+
+#### Inherited from
+
+CommonTXProperties.v
+
+#### Defined in
+
+[packages/sdk/connect/src/types.ts:79](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L79)
+
+___
+
+### value
+
+• **value**: `string`
+
+#### Inherited from
+
+CommonTXProperties.value
+
+#### Defined in
+
+[packages/sdk/connect/src/types.ts:75](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L75)

--- a/packages/docs/sdk/docs/connect/interfaces/types.HttpProvider.md
+++ b/packages/docs/sdk/docs/connect/interfaces/types.HttpProvider.md
@@ -29,4 +29,4 @@
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:159](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L159)
+[packages/sdk/connect/src/types.ts:169](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L169)

--- a/packages/docs/sdk/docs/connect/interfaces/types.JsonRpcPayload.md
+++ b/packages/docs/sdk/docs/connect/interfaces/types.JsonRpcPayload.md
@@ -21,7 +21,7 @@
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:142](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L142)
+[packages/sdk/connect/src/types.ts:152](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L152)
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:139](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L139)
+[packages/sdk/connect/src/types.ts:149](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L149)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:140](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L140)
+[packages/sdk/connect/src/types.ts:150](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L150)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:141](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L141)
+[packages/sdk/connect/src/types.ts:151](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L151)

--- a/packages/docs/sdk/docs/connect/interfaces/types.JsonRpcResponse.md
+++ b/packages/docs/sdk/docs/connect/interfaces/types.JsonRpcResponse.md
@@ -29,7 +29,7 @@
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:131](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L131)
+[packages/sdk/connect/src/types.ts:141](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L141)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:129](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L129)
+[packages/sdk/connect/src/types.ts:139](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L139)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:128](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L128)
+[packages/sdk/connect/src/types.ts:138](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L138)
 
 ___
 
@@ -59,4 +59,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:130](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L130)
+[packages/sdk/connect/src/types.ts:140](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L140)

--- a/packages/docs/sdk/docs/connect/interfaces/types.Provider.md
+++ b/packages/docs/sdk/docs/connect/interfaces/types.Provider.md
@@ -33,4 +33,4 @@
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:146](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L146)
+[packages/sdk/connect/src/types.ts:156](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L156)

--- a/packages/docs/sdk/docs/connect/interfaces/types.RLPEncodedTx.md
+++ b/packages/docs/sdk/docs/connect/interfaces/types.RLPEncodedTx.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:167](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L167)
+[packages/sdk/connect/src/types.ts:177](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L177)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:166](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L166)
+[packages/sdk/connect/src/types.ts:176](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L176)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:168](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L168)
+[packages/sdk/connect/src/types.ts:178](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L178)

--- a/packages/docs/sdk/docs/connect/modules/index.md
+++ b/packages/docs/sdk/docs/connect/modules/index.md
@@ -32,6 +32,7 @@
 - [EIP1559TXProperties](index.md#eip1559txproperties)
 - [EncodedTransaction](index.md#encodedtransaction)
 - [Error](index.md#error)
+- [EthereumLegacyTXProperties](index.md#ethereumlegacytxproperties)
 - [FormattedCeloTx](index.md#formattedcelotx)
 - [Hex](index.md#hex)
 - [HexOrMissing](index.md#hexormissing)
@@ -232,6 +233,12 @@ ___
 ### Error
 
 Re-exports [Error](../interfaces/types.Error.md)
+
+___
+
+### EthereumLegacyTXProperties
+
+Re-exports [EthereumLegacyTXProperties](../interfaces/types.EthereumLegacyTXProperties.md)
 
 ___
 

--- a/packages/docs/sdk/docs/connect/modules/types.md
+++ b/packages/docs/sdk/docs/connect/modules/types.md
@@ -27,6 +27,7 @@
 - [EIP1559TXProperties](../interfaces/types.EIP1559TXProperties.md)
 - [EncodedTransaction](../interfaces/types.EncodedTransaction.md)
 - [Error](../interfaces/types.Error.md)
+- [EthereumLegacyTXProperties](../interfaces/types.EthereumLegacyTXProperties.md)
 - [FormattedCeloTx](../interfaces/types.FormattedCeloTx.md)
 - [HttpProvider](../interfaces/types.HttpProvider.md)
 - [JsonRpcPayload](../interfaces/types.JsonRpcPayload.md)
@@ -163,7 +164,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:125](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L125)
+[packages/sdk/connect/src/types.ts:135](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L135)
 
 ___
 
@@ -183,7 +184,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:122](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L122)
+[packages/sdk/connect/src/types.ts:132](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L132)
 
 ___
 
@@ -193,7 +194,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/connect/src/types.ts:123](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L123)
+[packages/sdk/connect/src/types.ts:133](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/connect/src/types.ts#L133)
 
 ___
 
@@ -229,7 +230,7 @@ ___
 
 ### TransactionTypes
 
-Ƭ **TransactionTypes**: ``"eip1559"`` \| ``"celo-legacy"`` \| ``"cip42"`` \| ``"cip64"``
+Ƭ **TransactionTypes**: ``"ethereum-legacy"`` \| ``"eip1559"`` \| ``"celo-legacy"`` \| ``"cip42"`` \| ``"cip64"``
 
 #### Defined in
 

--- a/packages/docs/sdk/docs/wallet-base/classes/wallet_base.WalletBase.md
+++ b/packages/docs/sdk/docs/wallet-base/classes/wallet_base.WalletBase.md
@@ -72,7 +72,7 @@ ReadOnlyWallet.computeSharedSecret
 
 #### Defined in
 
-[wallets/wallet-base/src/wallet-base.ts:141](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/wallet-base.ts#L141)
+[wallets/wallet-base/src/wallet-base.ts:143](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/wallet-base.ts#L143)
 
 ___
 
@@ -97,7 +97,7 @@ ReadOnlyWallet.decrypt
 
 #### Defined in
 
-[wallets/wallet-base/src/wallet-base.ts:133](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/wallet-base.ts#L133)
+[wallets/wallet-base/src/wallet-base.ts:135](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/wallet-base.ts#L135)
 
 ___
 
@@ -198,7 +198,7 @@ ReadOnlyWallet.signPersonalMessage
 
 #### Defined in
 
-[wallets/wallet-base/src/wallet-base.ts:97](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/wallet-base.ts#L97)
+[wallets/wallet-base/src/wallet-base.ts:99](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/wallet-base.ts#L99)
 
 ___
 
@@ -253,4 +253,4 @@ ReadOnlyWallet.signTypedData
 
 #### Defined in
 
-[wallets/wallet-base/src/wallet-base.ts:114](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/wallet-base.ts#L114)
+[wallets/wallet-base/src/wallet-base.ts:116](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/wallet-base.ts#L116)

--- a/packages/docs/sdk/docs/wallet-base/modules/signing_utils.md
+++ b/packages/docs/sdk/docs/wallet-base/modules/signing_utils.md
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[wallets/wallet-base/src/signing-utils.ts:697](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L697)
+[wallets/wallet-base/src/signing-utils.ts:774](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L774)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[wallets/wallet-base/src/signing-utils.ts:322](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L322)
+[wallets/wallet-base/src/signing-utils.ts:348](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L348)
 
 ___
 
@@ -150,7 +150,7 @@ ___
 
 #### Defined in
 
-[wallets/wallet-base/src/signing-utils.ts:405](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L405)
+[wallets/wallet-base/src/signing-utils.ts:445](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L445)
 
 ___
 
@@ -190,7 +190,7 @@ ___
 
 #### Defined in
 
-[wallets/wallet-base/src/signing-utils.ts:500](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L500)
+[wallets/wallet-base/src/signing-utils.ts:518](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L518)
 
 ___
 
@@ -210,7 +210,7 @@ ___
 
 #### Defined in
 
-[wallets/wallet-base/src/signing-utils.ts:271](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L271)
+[wallets/wallet-base/src/signing-utils.ts:290](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L290)
 
 ___
 
@@ -231,7 +231,7 @@ ___
 
 #### Defined in
 
-[wallets/wallet-base/src/signing-utils.ts:665](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L665)
+[wallets/wallet-base/src/signing-utils.ts:742](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L742)
 
 ___
 
@@ -251,7 +251,7 @@ ___
 
 #### Defined in
 
-[wallets/wallet-base/src/signing-utils.ts:439](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L439)
+[wallets/wallet-base/src/signing-utils.ts:479](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L479)
 
 ___
 
@@ -313,7 +313,7 @@ ___
 
 #### Defined in
 
-[wallets/wallet-base/src/signing-utils.ts:675](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L675)
+[wallets/wallet-base/src/signing-utils.ts:752](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L752)
 
 ___
 
@@ -335,4 +335,4 @@ ___
 
 #### Defined in
 
-[wallets/wallet-base/src/signing-utils.ts:684](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L684)
+[wallets/wallet-base/src/signing-utils.ts:761](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-base/src/signing-utils.ts#L761)

--- a/packages/sdk/connect/src/types.ts
+++ b/packages/sdk/connect/src/types.ts
@@ -66,7 +66,7 @@ export { BlockNumber, EventLog, Log, PromiEvent, Sign } from 'web3-core'
 export { Block, BlockHeader, Syncing } from 'web3-eth'
 export { Contract, ContractSendMethod, PastEventOptions } from 'web3-eth-contract'
 
-export type TransactionTypes = 'eip1559' | 'celo-legacy' | 'cip42' | 'cip64'
+export type TransactionTypes = 'ethereum-legacy' | 'eip1559' | 'celo-legacy' | 'cip42' | 'cip64'
 
 interface CommonTXProperties {
   nonce: string
@@ -114,9 +114,19 @@ export interface LegacyTXProperties extends CommonTXProperties {
   type: 'celo-legacy'
 }
 
+export interface EthereumLegacyTXProperties extends CommonTXProperties {
+  gasPrice: string
+  type: 'ethereum-legacy'
+}
+
 export interface EncodedTransaction {
   raw: Hex
-  tx: LegacyTXProperties | CIP42TXProperties | EIP1559TXProperties | CIP64TXProperties
+  tx:
+    | EthereumLegacyTXProperties
+    | LegacyTXProperties
+    | CIP42TXProperties
+    | EIP1559TXProperties
+    | CIP64TXProperties
 }
 
 export type CeloTxPending = Transaction & Partial<CeloParams>

--- a/packages/sdk/wallets/wallet-base/src/signing-utils.test.ts
+++ b/packages/sdk/wallets/wallet-base/src/signing-utils.test.ts
@@ -16,7 +16,7 @@ const PRIVATE_KEY1 = '0x1234567890abcdef1234567890abcdef1234567890abcdef12345678
 const ACCOUNT_ADDRESS1 = normalizeAddressWith0x(privateKeyToAddress(PRIVATE_KEY1)) as `0x${string}`
 
 describe('rlpEncodedTx', () => {
-  describe('legacy', () => {
+  describe('Celo legacy', () => {
     const legacyTransaction = {
       feeCurrency: '0x5409ED021D9299bf6814279A6A1411A7e866A631',
       from: ACCOUNT_ADDRESS1,
@@ -99,6 +99,43 @@ describe('rlpEncodedTx', () => {
   describe('when no gas fields are provided', () => {
     it('throws an error', () => {
       expect(() => rlpEncodedTx({})).toThrowErrorMatchingInlineSnapshot(`""gas" is missing"`)
+    })
+  })
+
+  describe('Ethereum legacy', () => {
+    const legacyTransaction = {
+      from: '0x1daf825EB5C0D9d9FeC33C444e413452A08e04A6',
+      to: '0x43d72ff17701b2da814620735c39c620ce0ea4a1',
+      chainId: 42220,
+      value: Web3.utils.toWei('0', 'ether'),
+      nonce: 619,
+      gas: '504830',
+      gasPrice: '5000000000',
+      data: '0x4e71d92d',
+    }
+    it('convert CeloTx into RLP', () => {
+      const transaction = {
+        ...legacyTransaction,
+      }
+      const result = rlpEncodedTx(transaction)
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "rlpEncode": "0xed82026b85012a05f2008307b3fe9443d72ff17701b2da814620735c39c620ce0ea4a180844e71d92d82a4ec8080",
+          "transaction": {
+            "chainId": 42220,
+            "data": "0x4e71d92d",
+            "from": "0x1daf825eb5c0d9d9fec33c444e413452a08e04a6",
+            "gas": "0x07b3fe",
+            "gasPrice": "0x012a05f200",
+            "maxFeePerGas": "0x",
+            "maxPriorityFeePerGas": "0x",
+            "nonce": 619,
+            "to": "0x43d72ff17701b2da814620735c39c620ce0ea4a1",
+            "value": "0x",
+          },
+          "type": "ethereum-legacy",
+        }
+      `)
     })
   })
 
@@ -369,6 +406,25 @@ describe('recoverTransaction', () => {
       ]
     `)
   })
+  it('handles ethereum-legacy transactions', () => {
+    const ethereumLegacyTx =
+      '0xf86e82026b85012a05f2008307b3fe9443d72ff17701b2da814620735c39c620ce0ea4a180844e71d92d830149fba0f616cf0a105a0b117b178f6aaa5dc79b9b2aa3898811f99a8f48fb70cece8a33a032a158ab09e32747044e62bd3facd9abd746df23df306dbc31305668da2c7937'
+    expect(recoverTransaction(ethereumLegacyTx)).toMatchInlineSnapshot(`
+      [
+        {
+          "chainId": "0xa4ec",
+          "data": "0x4e71d92d",
+          "gas": 504830,
+          "gasPrice": 5000000000,
+          "nonce": 619,
+          "to": "0x43d72ff17701b2da814620735c39c620ce0ea4a1",
+          "type": "ethereum-legacy",
+          "value": "0x",
+        },
+        "0x1daf825EB5C0D9d9FeC33C444e413452A08e04A6",
+      ]
+    `)
+  })
   it('handles cip64 transactions', () => {
     const cip64TX =
       '0x7bf88282ad5a8063630a94588e4b68193001e4d10928660ab4165b813717c0880de0b6b3a764000083abcdefc094cd2a3d9f938e13cd947ec05abc7fe734df8dd82680a091b5504a59e529e7efa42dbb97fbc3311a91d035c873a94ab0789441fc989f84a02e8254d6b3101b63417e5d496833bc84f4832d4a8bf8a2b83e291d8f38c0f62d'
@@ -567,7 +623,7 @@ describe('extractSignature', () => {
   })
   it('fails when length is wrong', () => {
     expect(() => extractSignature('0x')).toThrowErrorMatchingInlineSnapshot(
-      `"@extractSignature: provided transaction has 0 elements but celo-legacy txs with a signature have 12 []"`
+      `"@extractSignature: provided transaction has 0 elements but ethereum-legacy txs with a signature have 9 []"`
     )
   })
 })

--- a/packages/sdk/wallets/wallet-base/src/wallet-base.ts
+++ b/packages/sdk/wallets/wallet-base/src/wallet-base.ts
@@ -78,7 +78,9 @@ export abstract class WalletBase<TSigner extends Signer> implements ReadOnlyWall
     }
     const rlpEncoded = rlpEncodedTx(txParams)
     const addToV =
-      rlpEncoded.type === 'celo-legacy' ? chainIdTransformationForSigning(txParams.chainId!) : 27
+      rlpEncoded.type === 'celo-legacy' || rlpEncoded.type === 'ethereum-legacy'
+        ? chainIdTransformationForSigning(txParams.chainId!)
+        : 27
 
     // Get the signer from the 'from' field
     const fromAddress = txParams.from!.toString()


### PR DESCRIPTION
### Description

Celo legacy Type 0 transactions were deprecated in the Gingerbread hardfork. As a first step, transactions that don't require alternative fee currencies should fallback to Ethereum-compatible TXs that are still supported.

### Other changes

Fixed a typo in the check.

### Tested

Added tests.

### Backwards compatibility

Yes.