### PR TITLE
Enforce Package dep version bump

### DIFF
--- a/dt-renovate-base.json
+++ b/dt-renovate-base.json
@@ -9,6 +9,12 @@
   "major": {
     "minimumReleaseAge": "14 days"
   },
+  "minor": {
+    "rangeStrategy": "bump"
+  },
+  "patch": {
+    "rangeStrategy": "bump"
+  },
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
### Descriptionset update range strategy to bump to ensure that package.jsons are up dated and not just the lockfile

https://docs.renovatebot.com/configuration-options/#rangestrategy


This is inresponse to renovate commits like https://github.com/celo-org/developer-tooling/commit/cbfedf0849a69e347a6ee3647b301ca0e7a11cac which only updated the yarn lock which isnt good for us as we are publishing libraries