### PR TITLE
remove outdated extensions from recs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,9 +8,7 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "redhat.vscode-yaml",
-    "smkamranqadri.vscode-bolt-language",
-    "davidanson.vscode-markdownlint",
-    "coenraads.bracket-pair-colorizer-2",
+    "davidanson.vscode-markdownlint", 
     "markis.code-coverage"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,19 +25,19 @@
   "[javascriptreact]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     }
   },
   "[typescript]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     }
   },
   "[typescriptreact]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     }
   },
   "javascript.format.enable": false,


### PR DESCRIPTION
## dev only

vs code keeps recommending to install this deprecated extension. so lets not do that