### PR TITLE
feat: ignores gasCurrency when passed to the config

### DIFF
--- a/.changeset/eight-dragons-behave.md
+++ b/.changeset/eight-dragons-behave.md
@@ -1,0 +1,9 @@
+---
+'@celo/celocli': major
+---
+
+The following changes are related to adding support for more fee currencies in the @celo packages.
+
+(BREAKING): global flag `--gasCurrency` changed to accept only whitelisted addresses instead of previously accepting a StableToken or 'auto'
+(BREAKING): `config:set --gasCurrency` is now ignored and not saved to a default config and prints a warning instead
+(ADDED): `celocli network:whitelist` prints the whitelisted feeCurrencies

--- a/.changeset/khaki-lies-wait.md
+++ b/.changeset/khaki-lies-wait.md
@@ -1,9 +1,0 @@
----
-'@celo/celocli': major
----
-
-The following changes are related to adding support for more fee currencies in the @celo packages.
-
-(BREAKING): `--gasCurrency` changed to accept only whitelisted addresses or the string `CELO` instead of previously accepting a StableToken or 'auto'
-(ADDED): `celocli network:whitelist` prints the whitelisted feeCurrencies
-(ADDED): the cli will automagically convert the previous gasCurrency such as cEUR, cUSD, cREAL, CELO into its address if necessary

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -10,7 +10,7 @@ import chalk from 'chalk'
 import net from 'net'
 import Web3 from 'web3'
 import { CustomFlags } from './utils/command'
-import { getGasCurrency, getNodeUrl } from './utils/config'
+import { getNodeUrl } from './utils/config'
 import { requireNodeIsSynced } from './utils/helpers'
 
 export abstract class BaseCommand extends Command {
@@ -43,8 +43,7 @@ export abstract class BaseCommand extends Command {
     }),
     gasCurrency: CustomFlags.gasCurrency({
       description:
-        'Use a specific gas currency for transaction fees (defaults to CELO if no gas currency is supplied)',
-      hidden: true,
+        'Use a specific gas currency for transaction fees (defaults to CELO if no gas currency is supplied). It must be a whitelisted token.',
     }),
     useLedger: Flags.boolean({
       default: false,
@@ -195,10 +194,9 @@ export abstract class BaseCommand extends Command {
       kit.defaultAccount = res.flags.from
     }
 
-    const gasCurrencyFlag = (res.flags.gasCurrency ??
-      (await getGasCurrency(this.config.configDir, kit))) as StrongAddress | 'CELO' | undefined
+    const gasCurrencyFlag = res.flags.gasCurrency as StrongAddress | undefined
 
-    if (gasCurrencyFlag && gasCurrencyFlag !== 'CELO') {
+    if (gasCurrencyFlag) {
       const feeCurrencyWhitelist = await kit.contracts.getFeeCurrencyWhitelist()
       const validFeeCurrencies = await feeCurrencyWhitelist.getWhitelist()
 

--- a/packages/cli/src/commands/config/set.test.ts
+++ b/packages/cli/src/commands/config/set.test.ts
@@ -1,0 +1,34 @@
+import { ux } from '@oclif/core'
+import { testLocally } from '../../test-utils/cliUtils'
+import * as config from '../../utils/config'
+import Set from './set'
+
+process.env.NO_SYNCCHECK = 'true'
+
+afterEach(async () => {
+  jest.clearAllMocks()
+  jest.restoreAllMocks()
+})
+
+describe('config:set cmd', () => {
+  it('shows a warning if gasCurrency is passed', async () => {
+    const consoleMock = jest.spyOn(ux, 'warn')
+    const writeMock = jest.spyOn(config, 'writeConfig')
+
+    await testLocally(Set, ['--gasCurrency', '0x5315e44798395d4a952530d131249fE00f554565'])
+    expect(consoleMock.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "
+      Setting a default gasCurrency has been removed from the config, you may still use the --gasCurrency on every command.
+      Did you value this feature a lot and would like to see it back? Let us know at [36m[1mhttps://github.com/celo-org/developer-tooling/discussions/92[22m[39m",
+        ],
+      ]
+    `)
+    expect(writeMock.mock.calls[0][1]).toMatchInlineSnapshot(`
+      {
+        "node": "http://localhost:8545",
+      }
+    `)
+  })
+})

--- a/packages/cli/src/commands/config/set.test.ts
+++ b/packages/cli/src/commands/config/set.test.ts
@@ -1,5 +1,5 @@
 import { ux } from '@oclif/core'
-import { testLocally } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocally } from '../../test-utils/cliUtils'
 import * as config from '../../utils/config'
 import Set from './set'
 
@@ -16,12 +16,13 @@ describe('config:set cmd', () => {
     const writeMock = jest.spyOn(config, 'writeConfig')
 
     await testLocally(Set, ['--gasCurrency', '0x5315e44798395d4a952530d131249fE00f554565'])
-    expect(consoleMock.mock.calls).toMatchInlineSnapshot(`
+    expect(stripAnsiCodesFromNestedArray(consoleMock.mock.calls as string[][]))
+      .toMatchInlineSnapshot(`
       [
         [
           "
       Setting a default gasCurrency has been removed from the config, you may still use the --gasCurrency on every command.
-      Did you value this feature a lot and would like to see it back? Let us know at [36m[1mhttps://github.com/celo-org/developer-tooling/discussions/92[22m[39m",
+      Did you value this feature a lot and would like to see it back? Let us know at https://github.com/celo-org/developer-tooling/discussions/92",
         ],
       ]
     `)

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -1,7 +1,9 @@
+import { ux } from '@oclif/core'
+import chalk from 'chalk'
 import { BaseCommand } from '../../base'
 import { CeloConfig, readConfig, writeConfig } from '../../utils/config'
 export default class Set extends BaseCommand {
-  static description = 'Configure running node information for propogating transactions to network'
+  static description = 'Configure running node information for propagating transactions to network'
 
   static flags = {
     ...BaseCommand.flags,
@@ -11,11 +13,7 @@ export default class Set extends BaseCommand {
     },
   }
 
-  static examples = [
-    'set --node ws://localhost:2500',
-    'set --node <geth-location>/geth.ipc',
-    'set --gasCurrency 0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-  ]
+  static examples = ['set --node ws://localhost:2500', 'set --node <geth-location>/geth.ipc']
 
   requireSynced = false
 
@@ -23,15 +21,18 @@ export default class Set extends BaseCommand {
     const res = await this.parse(Set)
     const curr = readConfig(this.config.configDir)
     const node = res.flags.node ?? curr.node
-    const gasCurrency = res.flags.gasCurrency ?? curr.gasCurrency
+    const gasCurrency = res.flags.gasCurrency
 
-    await writeConfig(
-      this.config.configDir,
-      {
-        node,
-        gasCurrency,
-      } as CeloConfig,
-      await this.getKit()
-    )
+    if (gasCurrency) {
+      ux.warn(
+        `\nSetting a default gasCurrency has been removed from the config, you may still use the --gasCurrency on every command.\nDid you value this feature a lot and would like to see it back? Let us know at ${chalk.cyan(
+          chalk.bold(`https://github.com/celo-org/developer-tooling/discussions/92`)
+        )}`
+      )
+    }
+
+    await writeConfig(this.config.configDir, {
+      node,
+    } as CeloConfig)
   }
 }

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -13,7 +13,16 @@ export default class Set extends BaseCommand {
     },
   }
 
-  static examples = ['set --node ws://localhost:2500', 'set --node <geth-location>/geth.ipc']
+  static examples = [
+    'set --node mainnet # alias for `forno`',
+    'set --node forno # alias for https://forno.celo.org',
+    'set --node baklava # alias for https://baklava-forno.celo-testnet.org',
+    'set --node alfajores # alias for https://alfajores-forno.celo-testnet.org',
+    'set --node localhost # alias for `local`',
+    'set --node local # alias for http://localhost:8545',
+    'set --node ws://localhost:2500',
+    'set --node <geth-location>/geth.ipc',
+  ]
 
   requireSynced = false
 

--- a/packages/cli/src/utils/command.ts
+++ b/packages/cli/src/utils/command.ts
@@ -48,10 +48,7 @@ const parseAddress: ParseFn<StrongAddress> = async (input) => {
     throw new CLIError(`${input} is not a valid address`)
   }
 }
-const parseGasCurrency: ParseFn<StrongAddress | 'CELO'> = async (input) => {
-  if (input.toUpperCase() === 'CELO') {
-    return 'CELO'
-  }
+const parseGasCurrency: ParseFn<StrongAddress> = async (input) => {
   if (Web3.utils.isAddress(input)) {
     return input as StrongAddress
   } else {
@@ -166,10 +163,10 @@ export const CustomFlags = {
     description: 'Account Address',
     helpValue: '0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d',
   }),
-  gasCurrency: Flags.custom<StrongAddress | 'CELO'>({
+  gasCurrency: Flags.custom<StrongAddress>({
     parse: parseGasCurrency,
-    description: 'A whitelisted feeCurrency or CELO to use native eip1559 transactions',
-    helpValue: '0',
+    description: 'A whitelisted feeCurrency',
+    helpValue: '0x1234567890123456789012345678901234567890',
   }),
   ecdsaPublicKey: Flags.custom({
     parse: parseEcdsaPublicKey,

--- a/packages/cli/src/utils/config.test.ts
+++ b/packages/cli/src/utils/config.test.ts
@@ -35,12 +35,4 @@ describe('writeConfig', () => {
         }
       `)
   })
-  it('ignores gasCurrency (legacy)', async () => {
-    await writeConfig(PATH, { node: 'SOME_URL' })
-    expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
-      {
-        "node": "SOME_URL",
-      }
-    `)
-  })
 })

--- a/packages/cli/src/utils/config.test.ts
+++ b/packages/cli/src/utils/config.test.ts
@@ -1,13 +1,17 @@
 import * as fs from 'fs-extra'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { CeloConfig, writeConfig } from './config'
+import { CeloConfig, readConfig, writeConfig } from './config'
 
 // NOTE: for some reason if I don't mock the whole module, jest fails
 // to spy on outputJSONSync
 jest.mock('fs-extra', () => ({ __esModule: true, ...jest.requireActual('fs-extra') }))
 
-const PATH = tmpdir()
+const getPaths = () => {
+  const dir = tmpdir()
+  return [dir, join(dir, 'config.json')]
+}
+
 const spy = jest.spyOn(fs, 'outputJSONSync')
 
 beforeEach(() => {
@@ -16,11 +20,12 @@ beforeEach(() => {
 
 describe('writeConfig', () => {
   it('accepts an empty config', async () => {
-    writeConfig(PATH, {} as CeloConfig)
+    const [dir, file] = getPaths()
+    writeConfig(dir, {} as CeloConfig)
 
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy.mock.calls[0]).toHaveLength(2)
-    expect(spy.mock.calls[0][0]).toEqual(join(PATH, 'config.json'))
+    expect(spy.mock.calls[0][0]).toEqual(file)
     expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
         {
           "node": "http://localhost:8545",
@@ -28,11 +33,43 @@ describe('writeConfig', () => {
       `)
   })
   it('accepts node', async () => {
-    await writeConfig(PATH, { node: 'SOME_URL' })
+    const [dir] = getPaths()
+    await writeConfig(dir, { node: 'SOME_URL' })
     expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
         {
           "node": "SOME_URL",
         }
       `)
+  })
+})
+
+describe('readConfig', () => {
+  it('reads arbitrary JSON at the file location', () => {
+    const [dir, file] = getPaths()
+    fs.writeJsonSync(file, { foo: 'bar' })
+    expect(readConfig(dir)).toMatchInlineSnapshot(`
+      {
+        "foo": "bar",
+        "node": "http://localhost:8545",
+      }
+    `)
+  })
+  it('translates legacy values into their new aliases', () => {
+    const [dir, file] = getPaths()
+    fs.writeJsonSync(file, { nodeUrl: 'bar' })
+    expect(readConfig(dir)).toMatchInlineSnapshot(`
+      {
+        "node": "bar",
+      }
+    `)
+  })
+  it('translates legacy values into their new aliases', () => {
+    const [dir, file] = getPaths()
+    fs.writeJsonSync(file, { gasCurrency: 'CELO' })
+    expect(readConfig(dir)).toMatchInlineSnapshot(`
+      {
+        "node": "http://localhost:8545",
+      }
+    `)
   })
 })

--- a/packages/cli/src/utils/config.test.ts
+++ b/packages/cli/src/utils/config.test.ts
@@ -1,10 +1,7 @@
-import { StableToken, StrongAddress } from '@celo/base'
-import { newKitFromWeb3 } from '@celo/contractkit'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import * as fs from 'fs-extra'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { CeloConfig, LegacyCeloConfig, getGasCurrency, writeConfig } from './config'
+import { CeloConfig, writeConfig } from './config'
 
 // NOTE: for some reason if I don't mock the whole module, jest fails
 // to spy on outputJSONSync
@@ -17,113 +14,33 @@ beforeEach(() => {
   spy.mockClear()
 })
 
-testWithGanache('config', (web3) => {
-  const kit = newKitFromWeb3(web3)
-  describe('writeConfig', () => {
-    test('empty config', async () => {
-      writeConfig(PATH, {} as CeloConfig, kit)
+describe('writeConfig', () => {
+  it('accepts an empty config', async () => {
+    writeConfig(PATH, {} as CeloConfig)
 
-      expect(spy).toHaveBeenCalledTimes(1)
-      expect(spy.mock.calls[0]).toHaveLength(2)
-      expect(spy.mock.calls[0][0]).toEqual(join(PATH, 'config.json'))
-      expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]).toHaveLength(2)
+    expect(spy.mock.calls[0][0]).toEqual(join(PATH, 'config.json'))
+    expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
         {
           "node": "http://localhost:8545",
         }
       `)
-    })
-    test('node', async () => {
-      await writeConfig(PATH, { node: 'SOME_URL' }, kit)
-      expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
+  })
+  it('accepts node', async () => {
+    await writeConfig(PATH, { node: 'SOME_URL' })
+    expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
         {
           "node": "SOME_URL",
         }
       `)
-    })
-    test('gasCurrency auto (legacy)', async () => {
-      await writeConfig(PATH, { gasCurrency: 'auto' } as LegacyCeloConfig, kit)
-      expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
-        {
-          "node": "http://localhost:8545",
-        }
-      `)
-    })
-    test('gasCurrency StableToken (legacy)', async () => {
-      await writeConfig(PATH, { gasCurrency: 'cUSD' } as LegacyCeloConfig, kit)
-      expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
-        {
-          "gasCurrency": "0x5315e44798395d4a952530d131249fE00f554565",
-          "node": "http://localhost:8545",
-        }
-      `)
-    })
-    test('gasCurrency CELO', async () => {
-      await writeConfig(PATH, { gasCurrency: 'CELO' } as LegacyCeloConfig, kit)
-      expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
-        {
-          "node": "http://localhost:8545",
-        }
-      `)
-    })
-    test('gasCurrency badly formatted address', async () => {
-      await expect(
-        writeConfig(PATH, { gasCurrency: '0x123' as StrongAddress } as CeloConfig, kit)
-      ).rejects.toMatchInlineSnapshot(`[Error: Invalid address 0x123]`)
-    })
-    test('gasCurrency wrong address', async () => {
-      await expect(
-        writeConfig(
-          PATH,
-          {
-            gasCurrency: '0x0000000000000000000000000000000000000000' as StrongAddress,
-          } as CeloConfig,
-          kit
-        )
-      ).rejects.toMatchInlineSnapshot(`
-        [Error: 0x0000000000000000000000000000000000000000 is not a valid fee currency. Available currencies:
-        0x5315e44798395d4a952530d131249fE00f554565 - Celo Dollar (cUSD)
-        0x965D352283a3C8A016b9BBbC9bf6306665d495E7 - Celo Brazilian Real (cREAL)
-        0xdD66C23e07b4D6925b6089b5Fe6fc9E62941aFE8 - Celo Euro (cEUR)]
-      `)
-    })
-
-    test('gasCurrency address', async () => {
-      await writeConfig(
-        PATH,
-        {
-          gasCurrency: (await kit.contracts.getStableToken(StableToken.cEUR)).address,
-        } as CeloConfig,
-        kit
-      )
-      expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
-        {
-          "gasCurrency": "0xdD66C23e07b4D6925b6089b5Fe6fc9E62941aFE8",
-          "node": "http://localhost:8545",
-        }
-      `)
-    })
   })
-
-  describe('getGasCurrency', () => {
-    test('empty', async () => {
-      fs.outputJSONSync(join(PATH, 'config.json'), {})
-      expect(await getGasCurrency(PATH, kit)).toBe(undefined)
-    })
-    test('CELO', async () => {
-      fs.outputJSONSync(join(PATH, 'config.json'), { getGasCurrency: 'CELO' })
-      expect(await getGasCurrency(PATH, kit)).toBe(undefined)
-    })
-    test('address', async () => {
-      fs.outputJSONSync(join(PATH, 'config.json'), {
-        gasCurrency: '0x0000000000000000000000000000000000000000',
-      })
-      expect(await getGasCurrency(PATH, kit)).toBe('0x0000000000000000000000000000000000000000')
-    })
-    test('legacy', async () => {
-      fs.outputJSONSync(join(PATH, 'config.json'), { gasCurrency: 'cEUR' })
-      expect(await getGasCurrency(PATH, kit)).toBe(
-        (await kit.contracts.getStableToken(StableToken.cEUR)).address
-      )
-    })
+  it('ignores gasCurrency (legacy)', async () => {
+    await writeConfig(PATH, { node: 'SOME_URL' })
+    expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
+      {
+        "node": "SOME_URL",
+      }
+    `)
   })
 })

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -1,19 +1,8 @@
-import { StableToken, StrongAddress, Token } from '@celo/base'
-import { ContractKit } from '@celo/contractkit'
-import { isValidAddress } from '@celo/utils/lib/address'
 import * as fs from 'fs-extra'
 import * as path from 'path'
 
 export interface CeloConfig {
   node: string
-  gasCurrency?: StrongAddress
-}
-
-// This interface handles compatibility with previous version of the CLI where
-// gas currency was passed differently
-export interface LegacyCeloConfig {
-  node: string
-  gasCurrency?: StableToken | Token | 'auto'
 }
 
 export const defaultConfig: CeloConfig = {
@@ -28,11 +17,18 @@ export function configPath(configDir: string) {
 
 export function readConfig(configDir: string): CeloConfig {
   if (fs.pathExistsSync(configPath(configDir))) {
-    const existingConfig = fs.readJSONSync(configPath(configDir))
+    const { gasCurrency, existingConfig } = fs.readJSONSync(configPath(configDir))
     const combinedConfig = { ...defaultConfig, ...existingConfig }
     if (combinedConfig.hasOwnProperty('nodeUrl')) {
       combinedConfig.node = combinedConfig.nodeUrl
     }
+
+    // NOTE: make sure we don't confuse the user by printing a gasCurrency
+    // that's not being used
+    if (gasCurrency) {
+      writeConfig(configDir, combinedConfig)
+    }
+
     return combinedConfig
   } else {
     return defaultConfig
@@ -43,71 +39,8 @@ export function getNodeUrl(configDir: string): string {
   return readConfig(configDir).node
 }
 
-export async function getGasCurrency(
-  configDir: string,
-  kit: ContractKit
-): Promise<StrongAddress | undefined> {
-  const config = readConfig(configDir) as CeloConfig | LegacyCeloConfig
-  const { gasCurrency } = config
-
-  if (!gasCurrency) return
-  if (isValidAddress(gasCurrency)) return gasCurrency
-
-  // Force rewriting the config with Token->Address conversion
-  await writeConfig(configDir, config, kit)
-
-  return getGasCurrency(configDir, kit)
-}
-
-export async function writeConfig(
-  configDir: string,
-  configObj: CeloConfig | LegacyCeloConfig,
-  kit: ContractKit
-) {
+export async function writeConfig(configDir: string, configObj: CeloConfig) {
   const config = { ...defaultConfig, ...configObj }
-  const { gasCurrency } = config
-
-  if (gasCurrency) {
-    if (gasCurrency.startsWith('0x')) {
-      if (isValidAddress(gasCurrency)) {
-        const feeCurrencyWhitelist = await kit.contracts.getFeeCurrencyWhitelist()
-        const validFeeCurrencies = await feeCurrencyWhitelist.getWhitelist()
-
-        if (!validFeeCurrencies.includes(gasCurrency)) {
-          const pairs = (
-            await feeCurrencyWhitelist.getFeeCurrencyInformation(validFeeCurrencies)
-          ).map(
-            ({ name, symbol, address, adaptedToken }) =>
-              `${address} - ${name || 'unknown name'} (${symbol || 'N/A'})${
-                adaptedToken ? ` (adapted token: ${adaptedToken})` : ''
-              }`
-          )
-          throw new Error(
-            `${config.gasCurrency} is not a valid fee currency. Available currencies:\n${pairs.join(
-              '\n'
-            )}`
-          )
-        }
-      } else {
-        throw new Error(`Invalid address ${gasCurrency}`)
-      }
-    } else {
-      // NOTE: This handles a legacy version of celocli where the gasCurrency
-      // was passed as cEUR, cUSD, or cREAL
-      switch (gasCurrency) {
-        case 'auto':
-        case Token.CELO:
-          delete config.gasCurrency
-          break
-        case StableToken.cEUR:
-        case StableToken.cUSD:
-        case StableToken.cREAL:
-          const { address } = await kit.contracts.getStableToken(gasCurrency as StableToken)
-          ;(config as CeloConfig).gasCurrency = address
-          break
-      }
-    }
-  }
 
   fs.outputJSONSync(configPath(configDir), config)
 }

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -23,7 +23,7 @@ export function configPath(configDir: string) {
 
 export function readConfig(configDir: string): CeloConfig {
   if (fs.pathExistsSync(configPath(configDir))) {
-    const { existingConfig } = fs.readJSONSync(configPath(configDir))
+    const existingConfig = fs.readJSONSync(configPath(configDir))
     const combinedConfig = { ...defaultConfig, ...existingConfig }
 
     // NOTE: make sure we don't confuse the user by printing legacy config elements

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -28,8 +28,8 @@ export function readConfig(configDir: string): CeloConfig {
 
     // NOTE: make sure we don't confuse the user by printing legacy config elements
     for (const [legacyKey, newKey] of Object.entries(LEGACY_MAPPING)) {
-      if (newKey) {
-        combinedConfig[newKey] = legacyKey
+      if (newKey && combinedConfig[legacyKey]) {
+        combinedConfig[newKey] = combinedConfig[legacyKey]
       }
       delete combinedConfig[legacyKey]
     }


### PR DESCRIPTION
Following the discussion we had, this:
- ignores --gasCurrency when passed to `config:set` but prints a warning linking to a discussion
- change `StrongAddress | 'CELO'` type to `StrongAddress` as `CELO` is the default if no flag is passed
- adds a test for `config:set`
- fix `packages/cli/src/transfer-stable-base.ts` to use the kit.connection.defaultFeeCurrency instead of reimplementing the same logic as `packages/cli/src/base.ts`