### PR TITLE
Automatically register account if needed when locking

### DIFF
--- a/.changeset/early-geckos-rescue.md
+++ b/.changeset/early-geckos-rescue.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+feat: Running celocli lockedgold:lock will now automatically register the eoa as an account if needed before locking

--- a/packages/cli/src/commands/lockedgold/lock.test.ts
+++ b/packages/cli/src/commands/lockedgold/lock.test.ts
@@ -1,7 +1,13 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { ux } from '@oclif/core'
+import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
-import { LONG_TIMEOUT_MS, testLocally } from '../../test-utils/cliUtils'
+import {
+  LONG_TIMEOUT_MS,
+  stripAnsiCodesFromNestedArray,
+  testLocally,
+} from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from './lock'
 import Unlock from './unlock'
@@ -27,4 +33,69 @@ testWithGanache('lockedgold:lock cmd', (web3: Web3) => {
     },
     LONG_TIMEOUT_MS
   )
+  describe('when EOA is not yet an account', () => {
+    it('performs the registration and locks the value', async () => {
+      const eoaAddresses = await web3.eth.getAccounts()
+      const eoa = eoaAddresses[1]
+      const kit = newKitFromWeb3(web3)
+      const accountsContract = await kit.contracts.getAccounts()
+      const lockedGoldContract = await kit.contracts.getLockedGold()
+
+      const logSpy = jest.spyOn(console, 'log')
+      const actionSpy = jest.spyOn(ux.action, 'stop')
+
+      // pre check
+      expect(await accountsContract.isAccount(eoa)).toBe(false)
+
+      await testLocally(Lock, ['--from', eoa, '--value', '100'])
+
+      expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
+        [
+          [
+            "Running Checks:",
+          ],
+          [
+            "   ✔  Value [100] is > 0 ",
+          ],
+          [
+            "All checks passed",
+          ],
+          [
+            "SendTransaction: register",
+          ],
+          [
+            "txHash: 0x9322aba7cf28f466f1377b1da9a1e7ed94c3109aa5fd2f4ea23caab371f1cb0f",
+          ],
+          [
+            "Running Checks:",
+          ],
+          [
+            "   ✔  Account has at least 0.0000000000000001 CELO ",
+          ],
+          [
+            "All checks passed",
+          ],
+          [
+            "SendTransaction: lock",
+          ],
+          [
+            "txHash: 0x947e5f8c97fdfabf688b3879f5856e1165c3578f2741d2481c3c961aa83bba51",
+          ],
+        ]
+      `)
+
+      expect(actionSpy.mock.calls).toMatchInlineSnapshot(`
+        [
+          [],
+          [],
+        ]
+      `)
+
+      expect(await accountsContract.isAccount(eoa)).toBe(true)
+
+      expect(await lockedGoldContract.getAccountTotalLockedGold(eoa)).toEqBigNumber(
+        new BigNumber('100')
+      )
+    })
+  })
 })

--- a/packages/cli/src/commands/lockedgold/lock.test.ts
+++ b/packages/cli/src/commands/lockedgold/lock.test.ts
@@ -61,7 +61,7 @@ testWithGanache('lockedgold:lock cmd', (web3: Web3) => {
             "All checks passed",
           ],
           [
-            "Address will be registered with Account contract to lock.",
+            "Address will be registered with Account contract to enable locking.",
           ],
           [
             "SendTransaction: register",

--- a/packages/cli/src/commands/lockedgold/lock.test.ts
+++ b/packages/cli/src/commands/lockedgold/lock.test.ts
@@ -61,6 +61,9 @@ testWithGanache('lockedgold:lock cmd', (web3: Web3) => {
             "All checks passed",
           ],
           [
+            "Address will be registered with Account contract to lock.",
+          ],
+          [
             "SendTransaction: register",
           ],
           [

--- a/packages/cli/src/commands/lockedgold/lock.ts
+++ b/packages/cli/src/commands/lockedgold/lock.ts
@@ -42,6 +42,7 @@ export default class Lock extends BaseCommand {
     const isAccount = await accountsContract.isAccount(address)
 
     if (!isAccount) {
+      console.log('Address will be registered with Account contract to enable locking.')
       await displaySendTx('register', accountsContract.createAccount())
     }
 


### PR DESCRIPTION
Rather than failing of EOA is not registered with Account contract, just do the registration

simplify the process of voting by registering eoa as given that account is often used a synonym for eoa it was not clear from error messages that one must run account:register. this way it happens automatically for a nicer ux


This is slightly different than plan specified in #142 which was to register and lock while voting. but i think now that locking and voting in same might be a bit much

<img width="537" alt="Screenshot 2024-04-02 at 11 50 19 AM" src="https://github.com/celo-org/developer-tooling/assets/3814795/33249c21-40f7-49a2-85bf-ffca36a73564">


### Other changes

n/a

### Tested

add new test

### Related issues

- Fixes #142
### Backwards compatibility

yes

### Documentation

n/a