### PR TITLE
docs ci: manually copy the files rather than use the postinstall hook

### DIFF
--- a/.github/workflows/open-docs-pr.yml
+++ b/.github/workflows/open-docs-pr.yml
@@ -67,7 +67,7 @@ jobs:
           git fetch --all
           git checkout $COMMIT
           cd ../..
-          ./scripts/copy-generated-docs.sh
+          cp -R ./submodules/developer-tooling/packages/docs/command-line-interface/* ./docs/cli/
 
           git status
           git add submodules/developer-tooling

--- a/packages/cli/bin/run.js
+++ b/packages/cli/bin/run.js
@@ -2,6 +2,6 @@
 
 // eslint-disable-next-line unicorn/prefer-top-level-await
 ;(async () => {
-  const oclif = await import('@oclif/core')
+  const oclif = require('@oclif/core')
   await oclif.execute({ development: false, dir: __dirname })
 })()

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -10,5 +10,8 @@
     "esModuleInterop": true,
     "target": "es2020"
   },
-  "include": ["src/**/*", "src/commands/dkg/DKG.json"]
+  "include": ["src/**/*", "src/commands/dkg/DKG.json"],
+  "ts-node": {
+    "esm": true
+  }
 }

--- a/packages/docs/command-line-interface/account.md
+++ b/packages/docs/command-line-interface/account.md
@@ -41,28 +41,37 @@ Keep your locked Gold more secure by authorizing alternative keys to be used for
 ```
 USAGE
   $ celocli account:authorize --from <value> -r vote|validator|attestation --signature
-    <value> --signer <value> [--globalHelp] [--blsKey <value> --blsPop <value>]
+    <value> --signer <value> [--gasCurrency <value>] [--globalHelp] [--blsKey <value>
+    --blsPop <value>]
 
 FLAGS
-  -r, --role=<option>                                      (required) Role to delegate
-                                                           <options:
-                                                           vote|validator|attestation>
-      --blsKey=0x                                          The BLS public key that the
-                                                           validator is using for
-                                                           consensus, should pass proof
-                                                           of possession. 96 bytes.
-      --blsPop=0x                                          The BLS public key
-                                                           proof-of-possession, which
-                                                           consists of a signature on
-                                                           the account address. 48
-                                                           bytes.
-      --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Account Address
-      --globalHelp                                         View all available global
-                                                           flags
-      --signature=0x                                       (required) Signature (a.k.a
-                                                           proof-of-possession) of the
-                                                           signer key
-      --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
+  -r, --role=<option>
+      (required) Role to delegate
+      <options: vote|validator|attestation>
+
+  --blsKey=0x
+      The BLS public key that the validator is using for consensus, should pass proof of
+      possession. 96 bytes.
+
+  --blsPop=0x
+      The BLS public key proof-of-possession, which consists of a signature on the account
+      address. 48 bytes.
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --signature=0x
+      (required) Signature (a.k.a proof-of-possession) of the signer key
+
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
 
 DESCRIPTION
   Keep your locked Gold more secure by authorizing alternative keys to be used for
@@ -85,14 +94,19 @@ View Celo Stables and CELO balances for an address
 
 ```
 USAGE
-  $ celocli account:balance ARG1 [--globalHelp] [--erc20Address <value>]
+  $ celocli account:balance ARG1 [--gasCurrency <value>] [--globalHelp]
+    [--erc20Address <value>]
 
 FLAGS
-  --erc20Address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Address of generic ERC-20
-                                                             token to also check balance
-                                                             for
-  --globalHelp                                               View all available global
-                                                             flags
+  --erc20Address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Address of generic ERC-20 token to also check balance for
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
 
 DESCRIPTION
   View Celo Stables and CELO balances for an address
@@ -111,23 +125,31 @@ Claim another account, and optionally its public key, and add the claim to a loc
 
 ```
 USAGE
-  $ celocli account:claim-account ARG1 --from <value> --address <value> [--globalHelp]
-    [--publicKey <value>]
+  $ celocli account:claim-account ARG1 --from <value> --address <value> [--gasCurrency
+    <value>] [--globalHelp] [--publicKey <value>]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
-  --address=<value>                                  (required) The address of the
-                                                     account you want to claim
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account
-                                                     to set metadata for or an
-                                                     authorized signer for the address
-                                                     in the metadata
-  --globalHelp                                       View all available global flags
-  --publicKey=<value>                                The public key of the account that
-                                                     others may use to send you
-                                                     encrypted messages
+  --address=<value>                                         (required) The address of
+                                                            the account you want to
+                                                            claim
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            account to set metadata for
+                                                            or an authorized signer for
+                                                            the address in the metadata
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --publicKey=<value>                                       The public key of the
+                                                            account that others may use
+                                                            to send you encrypted
+                                                            messages
 
 DESCRIPTION
   Claim another account, and optionally its public key, and add the claim to a local
@@ -145,25 +167,32 @@ Claim a domain and add the claim to a local metadata file
 
 ```
 USAGE
-  $ celocli account:claim-domain ARG1 --from <value> --domain <value> [--globalHelp]
+  $ celocli account:claim-domain ARG1 --from <value> --domain <value> [--gasCurrency
+    <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
-  --domain=<value>                                   (required) The domain you want to
-                                                     claim
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account
-                                                     to set metadata for or an
-                                                     authorized signer for the address
-                                                     in the metadata
-  --globalHelp                                       View all available global flags
+  --domain=<value>                                          (required) The domain you
+                                                            want to claim
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            account to set metadata for
+                                                            or an authorized signer for
+                                                            the address in the metadata
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Claim a domain and add the claim to a local metadata file
 
 EXAMPLES
-  claim-domain ~/metadata.json --domain test.com --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+  claim-domain ~/metadata.json --domain example.com --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
 ```
 
 _See code: [src/commands/account/claim-domain.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/claim-domain.ts)_
@@ -174,19 +203,26 @@ Claim a keybase username and add the claim to a local metadata file
 
 ```
 USAGE
-  $ celocli account:claim-keybase ARG1 --from <value> --username <value> [--globalHelp]
+  $ celocli account:claim-keybase ARG1 --from <value> --username <value> [--gasCurrency
+    <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account
-                                                     to set metadata for or an
-                                                     authorized signer for the address
-                                                     in the metadata
-  --globalHelp                                       View all available global flags
-  --username=<value>                                 (required) The keybase username you
-                                                     want to claim
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            account to set metadata for
+                                                            or an authorized signer for
+                                                            the address in the metadata
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --username=<value>                                        (required) The keybase
+                                                            username you want to claim
 
 DESCRIPTION
   Claim a keybase username and add the claim to a local metadata file
@@ -203,19 +239,26 @@ Claim a name and add the claim to a local metadata file
 
 ```
 USAGE
-  $ celocli account:claim-name ARG1 --from <value> --name <value> [--globalHelp]
+  $ celocli account:claim-name ARG1 --from <value> --name <value> [--gasCurrency
+    <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account
-                                                     to set metadata for or an
-                                                     authorized signer for the address
-                                                     in the metadata
-  --globalHelp                                       View all available global flags
-  --name=<value>                                     (required) The name you want to
-                                                     claim
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            account to set metadata for
+                                                            or an authorized signer for
+                                                            the address in the metadata
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --name=<value>                                            (required) The name you want
+                                                            to claim
 
 DESCRIPTION
   Claim a name and add the claim to a local metadata file
@@ -232,25 +275,33 @@ Claim a storage root and add the claim to a local metadata file
 
 ```
 USAGE
-  $ celocli account:claim-storage ARG1 --from <value> --url <value> [--globalHelp]
+  $ celocli account:claim-storage ARG1 --from <value> --url <value> [--gasCurrency <value>]
+    [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account
-                                                     to set metadata for or an
-                                                     authorized signer for the address
-                                                     in the metadata
-  --globalHelp                                       View all available global flags
-  --url=https://www.celo.org                         (required) The URL of the storage
-                                                     root you want to claim
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            account to set metadata for
+                                                            or an authorized signer for
+                                                            the address in the metadata
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --url=https://www.celo.org                                (required) The URL of the
+                                                            storage root you want to
+                                                            claim
 
 DESCRIPTION
   Claim a storage root and add the claim to a local metadata file
 
 EXAMPLES
-  claim-storage ~/metadata.json --url http://test.com/myurl --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+  claim-storage ~/metadata.json --url http://example.com/myurl --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
 ```
 
 _See code: [src/commands/account/claim-storage.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/claim-storage.ts)_
@@ -261,17 +312,24 @@ Create an empty identity metadata file. Use this metadata file to store claims a
 
 ```
 USAGE
-  $ celocli account:create-metadata ARG1 --from <value> [--globalHelp]
+  $ celocli account:create-metadata ARG1 --from <value> [--gasCurrency <value>]
+  [--globalHelp]
 
 ARGUMENTS
   ARG1  Path where the metadata should be saved
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account
-                                                     to set metadata for or an
-                                                     authorized signer for the address
-                                                     in the metadata
-  --globalHelp                                       View all available global flags
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            account to set metadata for
+                                                            or an authorized signer for
+                                                            the address in the metadata
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Create an empty identity metadata file. Use this metadata file to store claims
@@ -291,15 +349,25 @@ Remove an account's authorized attestation signer role.
 ```
 USAGE
   $ celocli account:deauthorize --from <value> -r attestation --signer <value>
-    [--globalHelp]
+    [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  -r, --role=<option>                                      (required) Role to remove
-                                                           <options: attestation>
-      --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Account Address
-      --globalHelp                                         View all available global
-                                                           flags
-      --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
+  -r, --role=<option>
+      (required) Role to remove
+      <options: attestation>
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
 
 DESCRIPTION
   Remove an account's authorized attestation signer role.
@@ -316,11 +384,18 @@ Removes a validator's payment delegation by setting benficiary and fraction to 0
 
 ```
 USAGE
-  $ celocli account:delete-payment-delegation --account <value> [--globalHelp]
+  $ celocli account:delete-payment-delegation --account <value> [--gasCurrency <value>]
+  [--globalHelp]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-  --globalHelp                                          View all available global flags
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Account Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Removes a validator's payment delegation by setting benficiary and fraction to 0.
@@ -337,24 +412,45 @@ Show information about an address. Retreives the metadata URL for an account fro
 
 ```
 USAGE
-  $ celocli account:get-metadata ARG1 [--globalHelp] [--columns <value> | -x] [--filter
-    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
-    [--sort <value>]
+  $ celocli account:get-metadata ARG1 [--gasCurrency <value>] [--globalHelp] [--columns
+    <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
+    csv|json|yaml |  | ] [--sort <value>]
 
 ARGUMENTS
   ARG1  Address to get metadata for
 
 FLAGS
-  -x, --extended         show extra columns
-      --columns=<value>  only show provided columns (comma-separated)
-      --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
-      --globalHelp       View all available global flags
-      --no-header        hide table header from output
-      --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
-      --sort=<value>     property to sort by (prepend '-' for descending)
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Show information about an address. Retreives the metadata URL for an account from the
@@ -372,31 +468,45 @@ Get the payment delegation account beneficiary and fraction allocated from a val
 
 ```
 USAGE
-  $ celocli account:get-payment-delegation --account <value> [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli account:get-payment-delegation --account <value> [--gasCurrency <value>] [--globalHelp]
+    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
+    [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -x, --extended                                            show extra columns
-      --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-      --columns=<value>                                     only show provided columns
-                                                            (comma-separated)
-      --csv                                                 output is csv format [alias:
-                                                            --output=csv]
-      --filter=<value>                                      filter property by partial
-                                                            string matching, ex:
-                                                            name=foo
-      --globalHelp                                          View all available global
-                                                            flags
-      --no-header                                           hide table header from
-                                                            output
-      --no-truncate                                         do not truncate output to
-                                                            fit screen
-      --output=<option>                                     output in a more machine
-                                                            friendly format
-                                                            <options: csv|json|yaml>
-      --sort=<value>                                        property to sort by (prepend
-                                                            '-' for descending)
+  -x, --extended
+      show extra columns
+
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Get the payment delegation account beneficiary and fraction allocated from a
@@ -414,12 +524,20 @@ List the addresses from the node and the local instance
 
 ```
 USAGE
-  $ celocli account:list [--globalHelp] [--local]
+  $ celocli account:list [--gasCurrency <value>] [--globalHelp] [--local]
 
 FLAGS
-  --globalHelp  View all available global flags
-  --[no-]local  If set, only show local and hardware wallet accounts. Use no-local to
-                only show keystore addresses.
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --[no-]local                                              If set, only show local and
+                                                            hardware wallet accounts.
+                                                            Use no-local to only show
+                                                            keystore addresses.
 
 DESCRIPTION
   List the addresses from the node and the local instance
@@ -433,13 +551,19 @@ Lock an account which was previously unlocked
 
 ```
 USAGE
-  $ celocli account:lock ARG1 [--globalHelp]
+  $ celocli account:lock ARG1 [--gasCurrency <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  Account address
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Lock an account which was previously unlocked
@@ -456,10 +580,10 @@ Creates a new account locally using the Celo Derivation Path (m/44'/52752'/0/cha
 
 ```
 USAGE
-  $ celocli account:new [--globalHelp] [--passphrasePath <value>] [--changeIndex
-    <value>] [--addressIndex <value>] [--language chinese_simplified|chinese_traditional
-    |english|french|italian|japanese|korean|spanish] [--mnemonicPath <value>]
-    [--derivationPath <value>]
+  $ celocli account:new [--gasCurrency <value>] [--globalHelp] [--passphrasePath
+    <value>] [--changeIndex <value>] [--addressIndex <value>] [--language chinese_simpli
+    fied|chinese_traditional|english|french|italian|japanese|korean|spanish]
+    [--mnemonicPath <value>] [--derivationPath <value>]
 
 FLAGS
   --addressIndex=<value>
@@ -473,6 +597,10 @@ FLAGS
       as an alias of the Ethereum derivation path ("m/44'/60'/0'"). Recreating the same
       account requires knowledge of the mnemonic, passphrase (if any), and the derivation
       path
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
 
   --globalHelp
       View all available global flags
@@ -521,20 +649,29 @@ DEV: Reads the name from offchain storage
 
 ```
 USAGE
-  $ celocli account:offchain-read ARG1 [--globalHelp] [--directory <value>] [--bucket
-    <value> --provider git|aws|gcp] [--from <value>] [--privateDEK <value>]
+  $ celocli account:offchain-read ARG1 [--gasCurrency <value>] [--globalHelp] [--directory
+    <value>] [--bucket <value> --provider git|aws|gcp] [--from <value>] [--privateDEK
+    <value>]
 
 FLAGS
-  --bucket=<value>                                   If using a GCP or AWS storage
-                                                     bucket this parameter is required
-  --directory=<value>                                [default: .] To which directory
-                                                     data should be written
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Account Address
-  --globalHelp                                       View all available global flags
+  --bucket=<value>                                          If using a GCP or AWS
+                                                            storage bucket this
+                                                            parameter is required
+  --directory=<value>                                       [default: .] To which
+                                                            directory data should be
+                                                            written
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         Account Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
   --privateDEK=<value>
-  --provider=<option>                                If the CLI should attempt to push
-                                                     to the cloud
-                                                     <options: git|aws|gcp>
+  --provider=<option>                                       If the CLI should attempt to
+                                                            push to the cloud
+                                                            <options: git|aws|gcp>
 
 DESCRIPTION
   DEV: Reads the name from offchain storage
@@ -553,20 +690,31 @@ DEV: Writes a name to offchain storage
 
 ```
 USAGE
-  $ celocli account:offchain-write --name <value> [--globalHelp] [--directory <value>]
-    [--bucket <value> --provider git|aws|gcp] (--privateDEK <value> --privateKey <value>
-    --encryptTo <value>)
+  $ celocli account:offchain-write --name <value> [--gasCurrency <value>] [--globalHelp]
+    [--directory <value>] [--bucket <value> --provider git|aws|gcp] (--privateDEK
+    <value> --privateKey <value> --encryptTo <value>)
 
 FLAGS
-  --bucket=<value>      If using a GCP or AWS storage bucket this parameter is required
-  --directory=<value>   [default: .] To which directory data should be written
+  --bucket=<value>                                          If using a GCP or AWS
+                                                            storage bucket this
+                                                            parameter is required
+  --directory=<value>                                       [default: .] To which
+                                                            directory data should be
+                                                            written
   --encryptTo=<value>
-  --globalHelp          View all available global flags
-  --name=<value>        (required)
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --name=<value>                                            (required)
   --privateDEK=<value>
-  --privateKey=<value>  (required)
-  --provider=<option>   If the CLI should attempt to push to the cloud
-                        <options: git|aws|gcp>
+  --privateKey=<value>                                      (required)
+  --provider=<option>                                       If the CLI should attempt to
+                                                            push to the cloud
+                                                            <options: git|aws|gcp>
 
 DESCRIPTION
   DEV: Writes a name to offchain storage
@@ -585,16 +733,24 @@ Generate proof-of-possession to be used to authorize a signer. See the "account:
 
 ```
 USAGE
-  $ celocli account:proof-of-possession --signer <value> --account <value>
-  [--globalHelp]
+  $ celocli account:proof-of-possession --signer <value> --account <value> [--gasCurrency
+    <value>] [--globalHelp]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                        account that needs to prove
-                                                        possession of the signer key.
-  --globalHelp                                          View all available global flags
-  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) Address of the signer
-                                                        key to prove possession of.
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Address of the
+                                                            account that needs to prove
+                                                            possession of the signer
+                                                            key.
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Address of the
+                                                            signer key to prove
+                                                            possession of.
 
 DESCRIPTION
   Generate proof-of-possession to be used to authorize a signer. See the
@@ -612,35 +768,46 @@ Recovers the Valora old account and print out the key information. The old Valor
 
 ```
 USAGE
-  $ celocli account:recover-old --mnemonicPath <value> [--globalHelp] [--passphrasePath
-    <value>] [--changeIndex <value>] [--addressIndex <value>] [--language chinese_simpli
-    fied|chinese_traditional|english|french|italian|japanese|korean|spanish]
-    [--derivationPath <value>]
+  $ celocli account:recover-old --mnemonicPath <value> [--gasCurrency <value>]
+    [--globalHelp] [--passphrasePath <value>] [--changeIndex <value>] [--addressIndex
+    <value>] [--language chinese_simplified|chinese_traditional|english|french|italian|j
+    apanese|korean|spanish] [--derivationPath <value>]
 
 FLAGS
-  --addressIndex=<value>    Choose the address index for the derivation path
-  --changeIndex=<value>     Choose the change index for the derivation path
-  --derivationPath=<value>  Choose a different derivation Path (Celo's default is
-                            "m/44'/52752'/0'"). Use "eth" as an alias of the Ethereum
-                            derivation path ("m/44'/60'/0'"). Recreating the same
-                            account requires knowledge of the mnemonic, passphrase (if
-                            any), and the derivation path
-  --globalHelp              View all available global flags
-  --language=<option>       [default: english] Language for the mnemonic words.
-                            **WARNING**, some hardware wallets don't support other
-                            languages
-                            <options: chinese_simplified|chinese_traditional|english|fre
-                            nch|italian|japanese|korean|spanish>
-  --mnemonicPath=<value>    (required) Path to a file that contains all the mnemonic
-                            words separated by a space (example: "word1 word2 word3 ...
-                            word24"). If the words are a language other than English,
-                            the --language flag must be used. Only BIP39 mnemonics are
-                            supported
-  --passphrasePath=<value>  Path to a file that contains the BIP39 passphrase to combine
-                            with the mnemonic specified using the mnemonicPath flag and
-                            the index specified using the addressIndex flag. Every
-                            passphrase generates a different private key and wallet
-                            address.
+  --addressIndex=<value>
+      Choose the address index for the derivation path
+
+  --changeIndex=<value>
+      Choose the change index for the derivation path
+
+  --derivationPath=<value>
+      Choose a different derivation Path (Celo's default is "m/44'/52752'/0'"). Use "eth"
+      as an alias of the Ethereum derivation path ("m/44'/60'/0'"). Recreating the same
+      account requires knowledge of the mnemonic, passphrase (if any), and the derivation
+      path
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --language=<option>
+      [default: english] Language for the mnemonic words. **WARNING**, some hardware
+      wallets don't support other languages
+      <options: chinese_simplified|chinese_traditional|english|french|italian|japanese|kor
+      ean|spanish>
+
+  --mnemonicPath=<value>
+      (required) Path to a file that contains all the mnemonic words separated by a space
+      (example: "word1 word2 word3 ... word24"). If the words are a language other than
+      English, the --language flag must be used. Only BIP39 mnemonics are supported
+
+  --passphrasePath=<value>
+      Path to a file that contains the BIP39 passphrase to combine with the mnemonic
+      specified using the mnemonicPath flag and the index specified using the addressIndex
+      flag. Every passphrase generates a different private key and wallet address.
 
 DESCRIPTION
   Recovers the Valora old account and print out the key information. The old Valora app
@@ -668,11 +835,18 @@ Register an account on-chain. This allows you to lock Gold, which is a pre-requi
 
 ```
 USAGE
-  $ celocli account:register --from <value> [--globalHelp] [--name <value>]
+  $ celocli account:register --from <value> [--gasCurrency <value>] [--globalHelp]
+    [--name <value>]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-  --globalHelp                                       View all available global flags
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
   --name=<value>
 
 DESCRIPTION
@@ -694,15 +868,22 @@ Register a data encryption key for an account on chain. This key can be used to 
 
 ```
 USAGE
-  $ celocli account:register-data-encryption-key --from <value> --publicKey <value>
-  [--globalHelp]
+  $ celocli account:register-data-encryption-key --from <value> --publicKey <value> [--gasCurrency
+    <value>] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Addess of the account to
-                                                     set the data encryption key for
-  --globalHelp                                       View all available global flags
-  --publicKey=<value>                                (required) The public key you want
-                                                     to register
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Addess of the
+                                                            account to set the data
+                                                            encryption key for
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --publicKey=<value>                                       (required) The public key
+                                                            you want to register
 
 DESCRIPTION
   Register a data encryption key for an account on chain. This key can be used to
@@ -720,32 +901,51 @@ Register metadata URL for an account where users will be able to retieve the met
 
 ```
 USAGE
-  $ celocli account:register-metadata --from <value> --url <value> [--globalHelp] [--force]
-    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
-    [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli account:register-metadata --from <value> --url <value> [--gasCurrency <value>]
+    [--globalHelp] [--force] [--columns <value> | -x] [--filter <value>] [--no-header |
+    [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -x, --extended                                         show extra columns
-      --columns=<value>                                  only show provided columns
-                                                         (comma-separated)
-      --csv                                              output is csv format [alias:
-                                                         --output=csv]
-      --filter=<value>                                   filter property by partial
-                                                         string matching, ex: name=foo
-      --force                                            Ignore metadata validity checks
-      --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Addess of the
-                                                         account to set metadata for
-      --globalHelp                                       View all available global flags
-      --no-header                                        hide table header from output
-      --no-truncate                                      do not truncate output to fit
-                                                         screen
-      --output=<option>                                  output in a more machine
-                                                         friendly format
-                                                         <options: csv|json|yaml>
-      --sort=<value>                                     property to sort by (prepend
-                                                         '-' for descending)
-      --url=<value>                                      (required) The url to the
-                                                         metadata you want to register
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --force
+      Ignore metadata validity checks
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Addess of the account to set metadata for
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
+
+  --url=<value>
+      (required) The url to the metadata you want to register
 
 DESCRIPTION
   Register metadata URL for an account where users will be able to retieve the metadata
@@ -763,12 +963,19 @@ Sets the name of a registered account on-chain. An account's name is an optional
 
 ```
 USAGE
-  $ celocli account:set-name --account <value> --name <value> [--globalHelp]
+  $ celocli account:set-name --account <value> --name <value> [--gasCurrency <value>]
+    [--globalHelp]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-  --globalHelp                                          View all available global flags
-  --name=<value>                                        (required)
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Account Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --name=<value>                                            (required)
 
 DESCRIPTION
   Sets the name of a registered account on-chain. An account's name is an optional human
@@ -787,12 +994,17 @@ Sets a payment delegation beneficiary, an account address to receive a fraction 
 ```
 USAGE
   $ celocli account:set-payment-delegation --account <value> --beneficiary <value> --fraction
-    <value> [--globalHelp]
+    <value> [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
   --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Account Address
   --beneficiary=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
   --fraction=<value>                                        (required)
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
   --globalHelp                                              View all available global
                                                             flags
 
@@ -812,18 +1024,24 @@ Sets the wallet of a registered account on-chain. An account's wallet is an opti
 
 ```
 USAGE
-  $ celocli account:set-wallet --account <value> --wallet <value> [--globalHelp]
-    [--signature <value>] [--signer <value>]
+  $ celocli account:set-wallet --account <value> --wallet <value> [--gasCurrency
+    <value>] [--globalHelp] [--signature <value>] [--signer <value>]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-  --globalHelp                                          View all available global flags
-  --signature=0x                                        Signature (a.k.a.
-                                                        proof-of-possession) of the
-                                                        signer key
-  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   Address of the signer key to
-                                                        verify proof of possession.
-  --wallet=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) Account Address
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Account Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --signature=0x                                            Signature (a.k.a.
+                                                            proof-of-possession) of the
+                                                            signer key
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       Address of the signer key to
+                                                            verify proof of possession.
+  --wallet=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Account Address
 
 DESCRIPTION
   Sets the wallet of a registered account on-chain. An account's wallet is an optional
@@ -843,10 +1061,16 @@ Show information for an account, including name, authorized vote, validator, and
 
 ```
 USAGE
-  $ celocli account:show ARG1 [--globalHelp]
+  $ celocli account:show ARG1 [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Show information for an account, including name, authorized vote, validator, and
@@ -866,10 +1090,16 @@ Show information about claimed accounts
 
 ```
 USAGE
-  $ celocli account:show-claimed-accounts ARG1 [--globalHelp]
+  $ celocli account:show-claimed-accounts ARG1 [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Show information about claimed accounts
@@ -886,24 +1116,45 @@ Show the data in a local metadata file
 
 ```
 USAGE
-  $ celocli account:show-metadata ARG1 [--globalHelp] [--columns <value> | -x] [--filter
-    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
-    [--sort <value>]
+  $ celocli account:show-metadata ARG1 [--gasCurrency <value>] [--globalHelp] [--columns
+    <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
+    csv|json|yaml |  | ] [--sort <value>]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
-  -x, --extended         show extra columns
-      --columns=<value>  only show provided columns (comma-separated)
-      --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
-      --globalHelp       View all available global flags
-      --no-header        hide table header from output
-      --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
-      --sort=<value>     property to sort by (prepend '-' for descending)
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Show the data in a local metadata file
@@ -920,18 +1171,28 @@ Unlock an account address to send transactions or validate blocks
 
 ```
 USAGE
-  $ celocli account:unlock ARG1 [--globalHelp] [--password <value>] [--duration
-    <value>]
+  $ celocli account:unlock ARG1 [--gasCurrency <value>] [--globalHelp] [--password
+    <value>] [--duration <value>]
 
 ARGUMENTS
   ARG1  Account address
 
 FLAGS
-  --duration=<value>  Duration in seconds to leave the account unlocked. Unlocks until
-                      the node exits by default.
-  --globalHelp        View all available global flags
-  --password=<value>  Password used to unlock the account. If not specified, you will be
-                      prompted for a password.
+  --duration=<value>                                        Duration in seconds to leave
+                                                            the account unlocked.
+                                                            Unlocks until the node exits
+                                                            by default.
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --password=<value>                                        Password used to unlock the
+                                                            account. If not specified,
+                                                            you will be prompted for a
+                                                            password.
 
 DESCRIPTION
   Unlock an account address to send transactions or validate blocks
@@ -951,19 +1212,26 @@ Verify a proof-of-possession. See the "account:proof-of-possession" command for 
 ```
 USAGE
   $ celocli account:verify-proof-of-possession --signer <value> --account <value> --signature <value>
-    [--globalHelp]
+    [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                        account that needs to prove
-                                                        possession of the signer key.
-  --globalHelp                                          View all available global flags
-  --signature=0x                                        (required) Signature (a.k.a.
-                                                        proof-of-possession) of the
-                                                        signer key
-  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) Address of the signer
-                                                        key to verify proof of
-                                                        possession.
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Address of the
+                                                            account that needs to prove
+                                                            possession of the signer
+                                                            key.
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --signature=0x                                            (required) Signature (a.k.a.
+                                                            proof-of-possession) of the
+                                                            signer key
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Address of the
+                                                            signer key to verify proof
+                                                            of possession.
 
 DESCRIPTION
   Verify a proof-of-possession. See the "account:proof-of-possession" command for more

--- a/packages/docs/command-line-interface/config.md
+++ b/packages/docs/command-line-interface/config.md
@@ -12,10 +12,16 @@ Output network node configuration
 
 ```
 USAGE
-  $ celocli config:get [--globalHelp]
+  $ celocli config:get [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Output network node configuration
@@ -25,33 +31,42 @@ _See code: [src/commands/config/get.ts](https://github.com/celo-org/developer-to
 
 ## `celocli config:set`
 
-Configure running node information for propogating transactions to network
+Configure running node information for propagating transactions to network
 
 ```
 USAGE
-  $ celocli config:set [-n <value>] [--gasCurrency
-    auto|Auto|CELO|celo|cUSD|cusd|cEUR|ceur|cREAL|creal] [--globalHelp]
+  $ celocli config:set [-n <value>] [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  -n, --node=<value>          URL of the node to run commands against (defaults to
-                              'http://localhost:8545')
-      --gasCurrency=<option>  Use a specific gas currency for transaction fees (defaults
-                              to 'auto' which uses whatever feeCurrency is available)
-                              <options:
-                              auto|Auto|CELO|celo|cUSD|cusd|cEUR|ceur|cREAL|creal>
-      --globalHelp            View all available global flags
+  -n, --node=<value>
+      URL of the node to run commands against (defaults to 'http://localhost:8545')
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
 
 DESCRIPTION
-  Configure running node information for propogating transactions to network
+  Configure running node information for propagating transactions to network
 
 EXAMPLES
+  set --node mainnet # alias for `forno`
+
+  set --node forno # alias for https://forno.celo.org
+
+  set --node baklava # alias for https://baklava-forno.celo-testnet.org
+
+  set --node alfajores # alias for https://alfajores-forno.celo-testnet.org
+
+  set --node localhost # alias for `local`
+
+  set --node local # alias for http://localhost:8545
+
   set --node ws://localhost:2500
 
   set --node <geth-location>/geth.ipc
-
-  set --gasCurrency cUSD
-
-  set --gasCurrency CELO
 ```
 
 _See code: [src/commands/config/set.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/config/set.ts)_

--- a/packages/docs/command-line-interface/dkg.md
+++ b/packages/docs/command-line-interface/dkg.md
@@ -17,14 +17,22 @@ Allowlist an address in the DKG
 ```
 USAGE
   $ celocli dkg:allowlist --participantAddress <value> --address <value> --from
-    <value> [--globalHelp]
+    <value> [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) DKG Contract Address
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the sender
-  --globalHelp                                          View all available global flags
-  --participantAddress=<value>                          (required) Address of the
-                                                        participant to allowlist
+  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) DKG Contract
+                                                            Address
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            sender
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --participantAddress=<value>                              (required) Address of the
+                                                            participant to allowlist
 
 DESCRIPTION
   Allowlist an address in the DKG
@@ -39,15 +47,22 @@ Deploys the DKG smart contract
 ```
 USAGE
   $ celocli dkg:deploy --phaseDuration <value> --threshold <value> --from
-    <value> [--globalHelp]
+    <value> [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
-  --globalHelp                                       View all available global flags
-  --phaseDuration=<value>                            (required) Duration of each DKG
-                                                     phase in blocks
-  --threshold=<value>                                (required) The threshold to use for
-                                                     the DKG
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            sender
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --phaseDuration=<value>                                   (required) Duration of each
+                                                            DKG phase in blocks
+  --threshold=<value>                                       (required) The threshold to
+                                                            use for the DKG
 
 DESCRIPTION
   Deploys the DKG smart contract
@@ -63,15 +78,23 @@ Gets data from the contract to run the next phase
 USAGE
   $ celocli dkg:get --method
     shares|responses|justifications|participants|phase|group --address <value>
-    [--globalHelp]
+    [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) DKG Contract Address
-  --globalHelp                                          View all available global flags
-  --method=<option>                                     (required) Getter method to call
-                                                        <options:
-                                                        shares|responses|justifications|
-                                                        participants|phase|group>
+  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) DKG Contract
+                                                            Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --method=<option>                                         (required) Getter method to
+                                                            call
+                                                            <options: shares|responses|j
+                                                            ustifications|participants|p
+                                                            hase|group>
 
 DESCRIPTION
   Gets data from the contract to run the next phase
@@ -86,14 +109,22 @@ Publishes data for each phase of the DKG
 ```
 USAGE
   $ celocli dkg:publish --data <value> --address <value> --from <value>
-    [--globalHelp]
+    [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) DKG Contract Address
-  --data=<value>                                        (required) Path to the data
-                                                        being published
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the sender
-  --globalHelp                                          View all available global flags
+  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) DKG Contract
+                                                            Address
+  --data=<value>                                            (required) Path to the data
+                                                            being published
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            sender
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Publishes data for each phase of the DKG
@@ -108,13 +139,21 @@ Register a public key in the DKG
 ```
 USAGE
   $ celocli dkg:register --blsKey <value> --address <value> --from <value>
-    [--globalHelp]
+    [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) DKG Contract Address
-  --blsKey=<value>                                      (required)
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the sender
-  --globalHelp                                          View all available global flags
+  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) DKG Contract
+                                                            Address
+  --blsKey=<value>                                          (required)
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            sender
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Register a public key in the DKG
@@ -128,12 +167,21 @@ Starts the DKG
 
 ```
 USAGE
-  $ celocli dkg:start --address <value> --from <value> [--globalHelp]
+  $ celocli dkg:start --address <value> --from <value> [--gasCurrency <value>]
+    [--globalHelp]
 
 FLAGS
-  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) DKG Contract Address
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the sender
-  --globalHelp                                          View all available global flags
+  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) DKG Contract
+                                                            Address
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            sender
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Starts the DKG

--- a/packages/docs/command-line-interface/election.md
+++ b/packages/docs/command-line-interface/election.md
@@ -17,17 +17,26 @@ Activate pending votes in validator elections to begin earning rewards. To earn 
 
 ```
 USAGE
-  $ celocli election:activate --from <value> [--globalHelp] [--for <value>] [--wait]
+  $ celocli election:activate --from <value> [--gasCurrency <value>] [--globalHelp]
+    [--for <value>] [--wait]
 
 FLAGS
-  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   Optional: use this to activate
-                                                     votes for another address
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address sending
-                                                     transaction (and voter's address if
-                                                     --for not specified)
-  --globalHelp                                       View all available global flags
-  --wait                                             Wait until all pending votes can be
-                                                     activated
+  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d          Optional: use this to
+                                                            activate votes for another
+                                                            address
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address sending
+                                                            transaction (and voter's
+                                                            address if --for not
+                                                            specified)
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --wait                                                    Wait until all pending votes
+                                                            can be activated
 
 DESCRIPTION
   Activate pending votes in validator elections to begin earning rewards. To earn
@@ -50,24 +59,46 @@ Outputs the set of validators currently participating in BFT to create blocks. A
 
 ```
 USAGE
-  $ celocli election:current [--globalHelp] [--valset] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli election:current [--gasCurrency <value>] [--globalHelp] [--valset]
+    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
+    [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -x, --extended         show extra columns
-      --columns=<value>  only show provided columns (comma-separated)
-      --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
-      --globalHelp       View all available global flags
-      --no-header        hide table header from output
-      --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
-      --sort=<value>     property to sort by (prepend '-' for descending)
-      --valset           Show currently used signers from valset (by default the
-                         authorized validator signers are shown). Useful for checking if
-                         keys have been rotated.
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
+
+  --valset
+      Show currently used signers from valset (by default the authorized validator signers
+      are shown). Useful for checking if keys have been rotated.
 
 DESCRIPTION
   Outputs the set of validators currently participating in BFT to create blocks. An
@@ -82,21 +113,42 @@ Prints the list of validator groups, the number of votes they have received, the
 
 ```
 USAGE
-  $ celocli election:list [--globalHelp] [--columns <value> | -x] [--filter
-    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
-    [--sort <value>]
+  $ celocli election:list [--gasCurrency <value>] [--globalHelp] [--columns <value>
+    | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
+    csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -x, --extended         show extra columns
-      --columns=<value>  only show provided columns (comma-separated)
-      --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
-      --globalHelp       View all available global flags
-      --no-header        hide table header from output
-      --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
-      --sort=<value>     property to sort by (prepend '-' for descending)
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Prints the list of validator groups, the number of votes they have received, the
@@ -116,13 +168,21 @@ Revoke votes for a Validator Group in validator elections.
 ```
 USAGE
   $ celocli election:revoke --from <value> --for <value> --value <value>
-    [--globalHelp]
+    [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) ValidatorGroup's address
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Voter's address
-  --globalHelp                                       View all available global flags
-  --value=<value>                                    (required) Value of votes to revoke
+  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d          (required) ValidatorGroup's
+                                                            address
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Voter's address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --value=<value>                                           (required) Value of votes to
+                                                            revoke
 
 DESCRIPTION
   Revoke votes for a Validator Group in validator elections.
@@ -139,21 +199,42 @@ Runs a "mock" election and prints out the validators that would be elected if th
 
 ```
 USAGE
-  $ celocli election:run [--globalHelp] [--columns <value> | -x] [--filter
-    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
-    [--sort <value>]
+  $ celocli election:run [--gasCurrency <value>] [--globalHelp] [--columns <value>
+    | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
+    csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -x, --extended         show extra columns
-      --columns=<value>  only show provided columns (comma-separated)
-      --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
-      --globalHelp       View all available global flags
-      --no-header        hide table header from output
-      --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
-      --sort=<value>     property to sort by (prepend '-' for descending)
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Runs a "mock" election and prints out the validators that would be elected if the
@@ -168,15 +249,26 @@ Show election information about a voter or registered Validator Group
 
 ```
 USAGE
-  $ celocli election:show ARG1 [--globalHelp] [--voter | --group]
+  $ celocli election:show ARG1 [--gasCurrency <value>] [--globalHelp] [--voter |
+    --group]
 
 ARGUMENTS
   ARG1  Voter or Validator Groups's address
 
 FLAGS
-  --globalHelp  View all available global flags
-  --group       Show information about a group running in Validator elections
-  --voter       Show information about an account voting in Validator elections
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --group                                                   Show information about a
+                                                            group running in Validator
+                                                            elections
+  --voter                                                   Show information about an
+                                                            account voting in Validator
+                                                            elections
 
 DESCRIPTION
   Show election information about a voter or registered Validator Group
@@ -196,14 +288,21 @@ Vote for a Validator Group in validator elections.
 ```
 USAGE
   $ celocli election:vote --from <value> --for <value> --value <value>
-    [--globalHelp]
+    [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) ValidatorGroup's address
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Voter's address
-  --globalHelp                                       View all available global flags
-  --value=<value>                                    (required) Amount of Gold used to
-                                                     vote for group
+  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d          (required) ValidatorGroup's
+                                                            address
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Voter's address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --value=<value>                                           (required) Amount of Gold
+                                                            used to vote for group
 
 DESCRIPTION
   Vote for a Validator Group in validator elections.

--- a/packages/docs/command-line-interface/exchange.md
+++ b/packages/docs/command-line-interface/exchange.md
@@ -6,6 +6,7 @@ Exchange Celo Dollars and CELO via Mento
 * [`celocli exchange:celo`](#celocli-exchangecelo)
 * [`celocli exchange:dollars`](#celocli-exchangedollars)
 * [`celocli exchange:euros`](#celocli-exchangeeuros)
+* [`celocli exchange:gold`](#celocli-exchangegold)
 * [`celocli exchange:reals`](#celocli-exchangereals)
 * [`celocli exchange:show`](#celocli-exchangeshow)
 * [`celocli exchange:stable`](#celocli-exchangestable)
@@ -16,22 +17,31 @@ Exchange CELO for StableTokens via Mento. (Note: this is the equivalent of the o
 
 ```
 USAGE
-  $ celocli exchange:celo --from <value> --value <value> [--globalHelp]
-    [--forAtLeast <value>] [--stableToken cUSD|cusd|cEUR|ceur|cREAL|creal]
+  $ celocli exchange:celo --from <value> --value <value> [--gasCurrency <value>]
+    [--globalHelp] [--forAtLeast <value>] [--stableToken
+    cUSD|cusd|cEUR|ceur|cREAL|creal]
 
 FLAGS
-  --forAtLeast=10000000000000000000000               [default: 0] Optional, the minimum
-                                                     value of StableTokens to receive in
-                                                     return
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address with CELO to
-                                                     exchange
-  --globalHelp                                       View all available global flags
-  --stableToken=<option>                             [default: cusd] Name of the stable
-                                                     to receive
-                                                     <options:
-                                                     cUSD|cusd|cEUR|ceur|cREAL|creal>
-  --value=10000000000000000000000                    (required) The value of CELO to
-                                                     exchange for a StableToken
+  --forAtLeast=10000000000000000000000                      [default: 0] Optional, the
+                                                            minimum value of
+                                                            StableTokens to receive in
+                                                            return
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
+                                                            CELO to exchange
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --stableToken=<option>                                    [default: cusd] Name of the
+                                                            stable to receive
+                                                            <options: cUSD|cusd|cEUR|ceu
+                                                            r|cREAL|creal>
+  --value=10000000000000000000000                           (required) The value of CELO
+                                                            to exchange for a
+                                                            StableToken
 
 DESCRIPTION
   Exchange CELO for StableTokens via Mento. (Note: this is the equivalent of the old
@@ -51,17 +61,24 @@ Exchange Celo Dollars for CELO via Mento
 
 ```
 USAGE
-  $ celocli exchange:dollars --from <value> --value <value> [--globalHelp]
-    [--forAtLeast <value>]
+  $ celocli exchange:dollars --from <value> --value <value> [--gasCurrency <value>]
+    [--globalHelp] [--forAtLeast <value>]
 
 FLAGS
-  --forAtLeast=10000000000000000000000               [default: 0] Optional, the minimum
-                                                     value of CELO to receive in return
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address with Celo
-                                                     Dollars to exchange
-  --globalHelp                                       View all available global flags
-  --value=10000000000000000000000                    (required) The value of Celo
-                                                     Dollars to exchange for CELO
+  --forAtLeast=10000000000000000000000                      [default: 0] Optional, the
+                                                            minimum value of CELO to
+                                                            receive in return
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
+                                                            Celo Dollars to exchange
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --value=10000000000000000000000                           (required) The value of Celo
+                                                            Dollars to exchange for CELO
 
 DESCRIPTION
   Exchange Celo Dollars for CELO via Mento
@@ -80,17 +97,24 @@ Exchange Celo Euros for CELO via Mento
 
 ```
 USAGE
-  $ celocli exchange:euros --from <value> --value <value> [--globalHelp]
-    [--forAtLeast <value>]
+  $ celocli exchange:euros --from <value> --value <value> [--gasCurrency <value>]
+    [--globalHelp] [--forAtLeast <value>]
 
 FLAGS
-  --forAtLeast=10000000000000000000000               [default: 0] Optional, the minimum
-                                                     value of CELO to receive in return
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address with Celo
-                                                     Euros to exchange
-  --globalHelp                                       View all available global flags
-  --value=10000000000000000000000                    (required) The value of Celo Euros
-                                                     to exchange for CELO
+  --forAtLeast=10000000000000000000000                      [default: 0] Optional, the
+                                                            minimum value of CELO to
+                                                            receive in return
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
+                                                            Celo Euros to exchange
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --value=10000000000000000000000                           (required) The value of Celo
+                                                            Euros to exchange for CELO
 
 DESCRIPTION
   Exchange Celo Euros for CELO via Mento
@@ -103,23 +127,74 @@ EXAMPLES
 
 _See code: [src/commands/exchange/euros.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/exchange/euros.ts)_
 
+## `celocli exchange:gold`
+
+Exchange CELO for StableTokens via the stability mechanism. *DEPRECATION WARNING* Use the "exchange:celo" command instead
+
+```
+USAGE
+  $ celocli exchange:gold --from <value> --value <value> [--gasCurrency <value>]
+    [--globalHelp] [--forAtLeast <value>] [--stableToken
+    cUSD|cusd|cEUR|ceur|cREAL|creal]
+
+FLAGS
+  --forAtLeast=10000000000000000000000                      [default: 0] Optional, the
+                                                            minimum value of
+                                                            StableTokens to receive in
+                                                            return
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
+                                                            CELO to exchange
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --stableToken=<option>                                    [default: cusd] Name of the
+                                                            stable to receive
+                                                            <options: cUSD|cusd|cEUR|ceu
+                                                            r|cREAL|creal>
+  --value=10000000000000000000000                           (required) The value of CELO
+                                                            to exchange for a
+                                                            StableToken
+
+DESCRIPTION
+  Exchange CELO for StableTokens via the stability mechanism. *DEPRECATION WARNING* Use
+  the "exchange:celo" command instead
+
+EXAMPLES
+  gold --value 5000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+
+  gold --value 5000000000000 --forAtLeast 100000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --stableToken cUSD
+```
+
 ## `celocli exchange:reals`
 
 Exchange Celo Brazilian Real (cREAL) for CELO via Mento
 
 ```
 USAGE
-  $ celocli exchange:reals --from <value> --value <value> [--globalHelp]
-    [--forAtLeast <value>]
+  $ celocli exchange:reals --from <value> --value <value> [--gasCurrency <value>]
+    [--globalHelp] [--forAtLeast <value>]
 
 FLAGS
-  --forAtLeast=10000000000000000000000               [default: 0] Optional, the minimum
-                                                     value of CELO to receive in return
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address with Celo
-                                                     Brazilian Real to exchange
-  --globalHelp                                       View all available global flags
-  --value=10000000000000000000000                    (required) The value of Celo
-                                                     Brazilian Real to exchange for CELO
+  --forAtLeast=10000000000000000000000                      [default: 0] Optional, the
+                                                            minimum value of CELO to
+                                                            receive in return
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
+                                                            Celo Brazilian Real to
+                                                            exchange
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --value=10000000000000000000000                           (required) The value of Celo
+                                                            Brazilian Real to exchange
+                                                            for CELO
 
 DESCRIPTION
   Exchange Celo Brazilian Real (cREAL) for CELO via Mento
@@ -138,12 +213,20 @@ Show the current exchange rates offered by the Broker
 
 ```
 USAGE
-  $ celocli exchange:show [--globalHelp] [--amount <value>]
+  $ celocli exchange:show [--gasCurrency <value>] [--globalHelp] [--amount <value>]
 
 FLAGS
-  --amount=<value>  [default: 1000000000000000000] Amount of the token being exchanged
-                    to report rates for
-  --globalHelp      View all available global flags
+  --amount=<value>                                          [default:
+                                                            1000000000000000000] Amount
+                                                            of the token being exchanged
+                                                            to report rates for
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Show the current exchange rates offered by the Broker
@@ -160,21 +243,30 @@ Exchange Stable Token for CELO via Mento
 
 ```
 USAGE
-  $ celocli exchange:stable --from <value> --value <value> [--globalHelp]
-    [--forAtLeast <value>] [--stableToken cUSD|cusd|cEUR|ceur|cREAL|creal]
+  $ celocli exchange:stable --from <value> --value <value> [--gasCurrency <value>]
+    [--globalHelp] [--forAtLeast <value>] [--stableToken
+    cUSD|cusd|cEUR|ceur|cREAL|creal]
 
 FLAGS
-  --forAtLeast=10000000000000000000000               [default: 0] Optional, the minimum
-                                                     value of CELO to receive in return
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address with the
-                                                     Stable Token to exchange
-  --globalHelp                                       View all available global flags
-  --stableToken=<option>                             Name of the stable token to be
-                                                     transfered
-                                                     <options:
-                                                     cUSD|cusd|cEUR|ceur|cREAL|creal>
-  --value=10000000000000000000000                    (required) The value of Stable
-                                                     Tokens to exchange for CELO
+  --forAtLeast=10000000000000000000000                      [default: 0] Optional, the
+                                                            minimum value of CELO to
+                                                            receive in return
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
+                                                            the Stable Token to exchange
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --stableToken=<option>                                    Name of the stable token to
+                                                            be transfered
+                                                            <options: cUSD|cusd|cEUR|ceu
+                                                            r|cREAL|creal>
+  --value=10000000000000000000000                           (required) The value of
+                                                            Stable Tokens to exchange
+                                                            for CELO
 
 DESCRIPTION
   Exchange Stable Token for CELO via Mento

--- a/packages/docs/command-line-interface/governance.md
+++ b/packages/docs/command-line-interface/governance.md
@@ -31,16 +31,23 @@ Approve a dequeued governance proposal (or hotfix)
 
 ```
 USAGE
-  $ celocli governance:approvehotfix --from <value> [--globalHelp] [--proposalID <value> |
-    --hotfix <value>] [--useMultiSig]
+  $ celocli governance:approvehotfix --from <value> [--gasCurrency <value>] [--globalHelp]
+    [--proposalID <value> | --hotfix <value>] [--useMultiSig]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Approver's address
-  --globalHelp                                       View all available global flags
-  --hotfix=<value>                                   Hash of hotfix proposal
-  --proposalID=<value>                               UUID of proposal to approve
-  --useMultiSig                                      True means the request will be sent
-                                                     through multisig.
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Approver's
+                                                            address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --hotfix=<value>                                          Hash of hotfix proposal
+  --proposalID=<value>                                      UUID of proposal to approve
+  --useMultiSig                                             True means the request will
+                                                            be sent through multisig.
 
 DESCRIPTION
   Approve a dequeued governance proposal (or hotfix)
@@ -63,16 +70,27 @@ Interactively build a governance proposal
 
 ```
 USAGE
-  $ celocli governance:build-proposal [--globalHelp] [--output <value>]
+  $ celocli governance:build-proposal [--gasCurrency <value>] [--globalHelp] [--output <value>]
     [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --afterExecutingID=<value>        Governance proposal identifier which will be
-                                    executed prior to proposal being built
-  --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
-                                    proposal being built
-  --globalHelp                      View all available global flags
-  --output=<value>                  [default: proposalTransactions.json] Path to output
+  --afterExecutingID=<value>                                Governance proposal
+                                                            identifier which will be
+                                                            executed prior to proposal
+                                                            being built
+  --afterExecutingProposal=<value>                          Path to proposal which will
+                                                            be executed prior to
+                                                            proposal being built
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --output=<value>                                          [default:
+                                                            proposalTransactions.json]
+                                                            Path to output
 
 DESCRIPTION
   Interactively build a governance proposal
@@ -89,11 +107,17 @@ Try to dequeue governance proposal
 
 ```
 USAGE
-  $ celocli governance:dequeue --from <value> [--globalHelp]
+  $ celocli governance:dequeue --from <value> [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) From address
-  --globalHelp                                       View all available global flags
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) From address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Try to dequeue governance proposal
@@ -110,13 +134,21 @@ Execute a passing governance proposal
 
 ```
 USAGE
-  $ celocli governance:execute --proposalID <value> --from <value> [--globalHelp]
+  $ celocli governance:execute --proposalID <value> --from <value> [--gasCurrency
+    <value>] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Executor's address
-  --globalHelp                                       View all available global flags
-  --proposalID=<value>                               (required) UUID of proposal to
-                                                     execute
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Executor's
+                                                            address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --proposalID=<value>                                      (required) UUID of proposal
+                                                            to execute
 
 DESCRIPTION
   Execute a passing governance proposal
@@ -134,15 +166,22 @@ Execute a governance hotfix prepared for the current epoch
 ```
 USAGE
   $ celocli governance:executehotfix --from <value> --jsonTransactions <value> --salt <value>
-    [--globalHelp]
+    [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Executors's address
-  --globalHelp                                       View all available global flags
-  --jsonTransactions=<value>                         (required) Path to json
-                                                     transactions
-  --salt=<value>                                     (required) Secret salt associated
-                                                     with hotfix
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Executors's
+                                                            address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --jsonTransactions=<value>                                (required) Path to json
+                                                            transactions
+  --salt=<value>                                            (required) Secret salt
+                                                            associated with hotfix
 
 DESCRIPTION
   Execute a governance hotfix prepared for the current epoch
@@ -159,14 +198,22 @@ Hash a governance hotfix specified by JSON and a salt
 
 ```
 USAGE
-  $ celocli governance:hashhotfix --jsonTransactions <value> --salt <value> [--globalHelp]
-    [--force]
+  $ celocli governance:hashhotfix --jsonTransactions <value> --salt <value> [--gasCurrency
+    <value>] [--globalHelp] [--force]
 
 FLAGS
-  --force                     Skip execution check
-  --globalHelp                View all available global flags
-  --jsonTransactions=<value>  (required) Path to json transactions of the hotfix
-  --salt=<value>              (required) Secret salt associated with hotfix
+  --force                                                   Skip execution check
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --jsonTransactions=<value>                                (required) Path to json
+                                                            transactions of the hotfix
+  --salt=<value>                                            (required) Secret salt
+                                                            associated with hotfix
 
 DESCRIPTION
   Hash a governance hotfix specified by JSON and a salt
@@ -183,21 +230,42 @@ List live governance proposals (queued and ongoing)
 
 ```
 USAGE
-  $ celocli governance:list [--globalHelp] [--columns <value> | -x] [--filter
-    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
-    [--sort <value>]
+  $ celocli governance:list [--gasCurrency <value>] [--globalHelp] [--columns <value>
+    | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
+    csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -x, --extended         show extra columns
-      --columns=<value>  only show provided columns (comma-separated)
-      --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
-      --globalHelp       View all available global flags
-      --no-header        hide table header from output
-      --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
-      --sort=<value>     property to sort by (prepend '-' for descending)
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List live governance proposals (queued and ongoing)
@@ -214,13 +282,21 @@ Prepare a governance hotfix for execution in the current epoch
 
 ```
 USAGE
-  $ celocli governance:preparehotfix --from <value> --hash <value> [--globalHelp]
+  $ celocli governance:preparehotfix --from <value> --hash <value> [--gasCurrency <value>]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Preparer's address
-  --globalHelp                                       View all available global flags
-  --hash=<value>                                     (required) Hash of hotfix
-                                                     transactions
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Preparer's
+                                                            address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --hash=<value>                                            (required) Hash of hotfix
+                                                            transactions
 
 DESCRIPTION
   Prepare a governance hotfix for execution in the current epoch
@@ -238,26 +314,35 @@ Submit a governance proposal
 ```
 USAGE
   $ celocli governance:propose --jsonTransactions <value> --deposit <value> --from
-    <value> --descriptionURL <value> [--globalHelp] [--force] [--noInfo]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+    <value> --descriptionURL <value> [--gasCurrency <value>] [--globalHelp] [--force]
+    [--noInfo] [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --afterExecutingID=<value>                         Governance proposal identifier
-                                                     which will be executed prior to
-                                                     proposal
-  --afterExecutingProposal=<value>                   Path to proposal which will be
-                                                     executed prior to proposal
-  --deposit=<value>                                  (required) Amount of Celo to attach
-                                                     to proposal
-  --descriptionURL=<value>                           (required) A URL where further
-                                                     information about the proposal can
-                                                     be viewed
-  --force                                            Skip execution check
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Proposer's address
-  --globalHelp                                       View all available global flags
-  --jsonTransactions=<value>                         (required) Path to json
-                                                     transactions
-  --noInfo                                           Skip printing the proposal info
+  --afterExecutingID=<value>                                Governance proposal
+                                                            identifier which will be
+                                                            executed prior to proposal
+  --afterExecutingProposal=<value>                          Path to proposal which will
+                                                            be executed prior to
+                                                            proposal
+  --deposit=<value>                                         (required) Amount of Celo to
+                                                            attach to proposal
+  --descriptionURL=<value>                                  (required) A URL where
+                                                            further information about
+                                                            the proposal can be viewed
+  --force                                                   Skip execution check
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Proposer's
+                                                            address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --jsonTransactions=<value>                                (required) Path to json
+                                                            transactions
+  --noInfo                                                  Skip printing the proposal
+                                                            info
 
 DESCRIPTION
   Submit a governance proposal
@@ -274,11 +359,18 @@ Revoke upvotes for queued governance proposals
 
 ```
 USAGE
-  $ celocli governance:revokeupvote --from <value> [--globalHelp]
+  $ celocli governance:revokeupvote --from <value> [--gasCurrency <value>]
+  [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Upvoter's address
-  --globalHelp                                       View all available global flags
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Upvoter's address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Revoke upvotes for queued governance proposals
@@ -295,28 +387,41 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:show [--globalHelp] [--raw] [--jsonTransactions <value>]
-    [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID <value> |
-    --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+  $ celocli governance:show [--gasCurrency <value>] [--globalHelp] [--raw]
+    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
+    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
+    [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --account=<value>                 Address of account or voter
-  --afterExecutingID=<value>        Governance proposal identifier which will be
-                                    executed prior to proposal
-  --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
-                                    proposal
-  --globalHelp                      View all available global flags
-  --hotfix=<value>                  Hash of hotfix proposal
-  --jsonTransactions=<value>        Output proposal JSON to provided file
-  --nonwhitelisters                 If set, displays validators that have not
-                                    whitelisted the hotfix.
-  --notwhitelisted                  List validators who have not whitelisted the
-                                    specified hotfix
-  --proposalID=<value>              UUID of proposal to view
-  --raw                             Display proposal in raw bytes format
-  --whitelisters                    If set, displays validators that have whitelisted
-                                    the hotfix.
+  --account=<value>                                         Address of account or voter
+  --afterExecutingID=<value>                                Governance proposal
+                                                            identifier which will be
+                                                            executed prior to proposal
+  --afterExecutingProposal=<value>                          Path to proposal which will
+                                                            be executed prior to
+                                                            proposal
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --hotfix=<value>                                          Hash of hotfix proposal
+  --jsonTransactions=<value>                                Output proposal JSON to
+                                                            provided file
+  --nonwhitelisters                                         If set, displays validators
+                                                            that have not whitelisted
+                                                            the hotfix.
+  --notwhitelisted                                          List validators who have not
+                                                            whitelisted the specified
+                                                            hotfix
+  --proposalID=<value>                                      UUID of proposal to view
+  --raw                                                     Display proposal in raw
+                                                            bytes format
+  --whitelisters                                            If set, displays validators
+                                                            that have whitelisted the
+                                                            hotfix.
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -351,28 +456,41 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:showaccount [--globalHelp] [--raw] [--jsonTransactions <value>]
-    [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID <value> |
-    --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+  $ celocli governance:showaccount [--gasCurrency <value>] [--globalHelp] [--raw]
+    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
+    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
+    [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --account=<value>                 Address of account or voter
-  --afterExecutingID=<value>        Governance proposal identifier which will be
-                                    executed prior to proposal
-  --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
-                                    proposal
-  --globalHelp                      View all available global flags
-  --hotfix=<value>                  Hash of hotfix proposal
-  --jsonTransactions=<value>        Output proposal JSON to provided file
-  --nonwhitelisters                 If set, displays validators that have not
-                                    whitelisted the hotfix.
-  --notwhitelisted                  List validators who have not whitelisted the
-                                    specified hotfix
-  --proposalID=<value>              UUID of proposal to view
-  --raw                             Display proposal in raw bytes format
-  --whitelisters                    If set, displays validators that have whitelisted
-                                    the hotfix.
+  --account=<value>                                         Address of account or voter
+  --afterExecutingID=<value>                                Governance proposal
+                                                            identifier which will be
+                                                            executed prior to proposal
+  --afterExecutingProposal=<value>                          Path to proposal which will
+                                                            be executed prior to
+                                                            proposal
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --hotfix=<value>                                          Hash of hotfix proposal
+  --jsonTransactions=<value>                                Output proposal JSON to
+                                                            provided file
+  --nonwhitelisters                                         If set, displays validators
+                                                            that have not whitelisted
+                                                            the hotfix.
+  --notwhitelisted                                          List validators who have not
+                                                            whitelisted the specified
+                                                            hotfix
+  --proposalID=<value>                                      UUID of proposal to view
+  --raw                                                     Display proposal in raw
+                                                            bytes format
+  --whitelisters                                            If set, displays validators
+                                                            that have whitelisted the
+                                                            hotfix.
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -405,28 +523,41 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:showhotfix [--globalHelp] [--raw] [--jsonTransactions <value>]
-    [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID <value> |
-    --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+  $ celocli governance:showhotfix [--gasCurrency <value>] [--globalHelp] [--raw]
+    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
+    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
+    [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --account=<value>                 Address of account or voter
-  --afterExecutingID=<value>        Governance proposal identifier which will be
-                                    executed prior to proposal
-  --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
-                                    proposal
-  --globalHelp                      View all available global flags
-  --hotfix=<value>                  Hash of hotfix proposal
-  --jsonTransactions=<value>        Output proposal JSON to provided file
-  --nonwhitelisters                 If set, displays validators that have not
-                                    whitelisted the hotfix.
-  --notwhitelisted                  List validators who have not whitelisted the
-                                    specified hotfix
-  --proposalID=<value>              UUID of proposal to view
-  --raw                             Display proposal in raw bytes format
-  --whitelisters                    If set, displays validators that have whitelisted
-                                    the hotfix.
+  --account=<value>                                         Address of account or voter
+  --afterExecutingID=<value>                                Governance proposal
+                                                            identifier which will be
+                                                            executed prior to proposal
+  --afterExecutingProposal=<value>                          Path to proposal which will
+                                                            be executed prior to
+                                                            proposal
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --hotfix=<value>                                          Hash of hotfix proposal
+  --jsonTransactions=<value>                                Output proposal JSON to
+                                                            provided file
+  --nonwhitelisters                                         If set, displays validators
+                                                            that have not whitelisted
+                                                            the hotfix.
+  --notwhitelisted                                          List validators who have not
+                                                            whitelisted the specified
+                                                            hotfix
+  --proposalID=<value>                                      UUID of proposal to view
+  --raw                                                     Display proposal in raw
+                                                            bytes format
+  --whitelisters                                            If set, displays validators
+                                                            that have whitelisted the
+                                                            hotfix.
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -459,13 +590,20 @@ Upvote a queued governance proposal
 
 ```
 USAGE
-  $ celocli governance:upvote --proposalID <value> --from <value> [--globalHelp]
+  $ celocli governance:upvote --proposalID <value> --from <value> [--gasCurrency
+    <value>] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Upvoter's address
-  --globalHelp                                       View all available global flags
-  --proposalID=<value>                               (required) UUID of proposal to
-                                                     upvote
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Upvoter's address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --proposalID=<value>                                      (required) UUID of proposal
+                                                            to upvote
 
 DESCRIPTION
   Upvote a queued governance proposal
@@ -482,28 +620,41 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:view [--globalHelp] [--raw] [--jsonTransactions <value>]
-    [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID <value> |
-    --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+  $ celocli governance:view [--gasCurrency <value>] [--globalHelp] [--raw]
+    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
+    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
+    [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --account=<value>                 Address of account or voter
-  --afterExecutingID=<value>        Governance proposal identifier which will be
-                                    executed prior to proposal
-  --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
-                                    proposal
-  --globalHelp                      View all available global flags
-  --hotfix=<value>                  Hash of hotfix proposal
-  --jsonTransactions=<value>        Output proposal JSON to provided file
-  --nonwhitelisters                 If set, displays validators that have not
-                                    whitelisted the hotfix.
-  --notwhitelisted                  List validators who have not whitelisted the
-                                    specified hotfix
-  --proposalID=<value>              UUID of proposal to view
-  --raw                             Display proposal in raw bytes format
-  --whitelisters                    If set, displays validators that have whitelisted
-                                    the hotfix.
+  --account=<value>                                         Address of account or voter
+  --afterExecutingID=<value>                                Governance proposal
+                                                            identifier which will be
+                                                            executed prior to proposal
+  --afterExecutingProposal=<value>                          Path to proposal which will
+                                                            be executed prior to
+                                                            proposal
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --hotfix=<value>                                          Hash of hotfix proposal
+  --jsonTransactions=<value>                                Output proposal JSON to
+                                                            provided file
+  --nonwhitelisters                                         If set, displays validators
+                                                            that have not whitelisted
+                                                            the hotfix.
+  --notwhitelisted                                          List validators who have not
+                                                            whitelisted the specified
+                                                            hotfix
+  --proposalID=<value>                                      UUID of proposal to view
+  --raw                                                     Display proposal in raw
+                                                            bytes format
+  --whitelisters                                            If set, displays validators
+                                                            that have whitelisted the
+                                                            hotfix.
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -536,28 +687,41 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:viewaccount [--globalHelp] [--raw] [--jsonTransactions <value>]
-    [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID <value> |
-    --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+  $ celocli governance:viewaccount [--gasCurrency <value>] [--globalHelp] [--raw]
+    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
+    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
+    [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --account=<value>                 Address of account or voter
-  --afterExecutingID=<value>        Governance proposal identifier which will be
-                                    executed prior to proposal
-  --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
-                                    proposal
-  --globalHelp                      View all available global flags
-  --hotfix=<value>                  Hash of hotfix proposal
-  --jsonTransactions=<value>        Output proposal JSON to provided file
-  --nonwhitelisters                 If set, displays validators that have not
-                                    whitelisted the hotfix.
-  --notwhitelisted                  List validators who have not whitelisted the
-                                    specified hotfix
-  --proposalID=<value>              UUID of proposal to view
-  --raw                             Display proposal in raw bytes format
-  --whitelisters                    If set, displays validators that have whitelisted
-                                    the hotfix.
+  --account=<value>                                         Address of account or voter
+  --afterExecutingID=<value>                                Governance proposal
+                                                            identifier which will be
+                                                            executed prior to proposal
+  --afterExecutingProposal=<value>                          Path to proposal which will
+                                                            be executed prior to
+                                                            proposal
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --hotfix=<value>                                          Hash of hotfix proposal
+  --jsonTransactions=<value>                                Output proposal JSON to
+                                                            provided file
+  --nonwhitelisters                                         If set, displays validators
+                                                            that have not whitelisted
+                                                            the hotfix.
+  --notwhitelisted                                          List validators who have not
+                                                            whitelisted the specified
+                                                            hotfix
+  --proposalID=<value>                                      UUID of proposal to view
+  --raw                                                     Display proposal in raw
+                                                            bytes format
+  --whitelisters                                            If set, displays validators
+                                                            that have whitelisted the
+                                                            hotfix.
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -590,28 +754,41 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:viewhotfix [--globalHelp] [--raw] [--jsonTransactions <value>]
-    [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID <value> |
-    --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+  $ celocli governance:viewhotfix [--gasCurrency <value>] [--globalHelp] [--raw]
+    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
+    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
+    [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --account=<value>                 Address of account or voter
-  --afterExecutingID=<value>        Governance proposal identifier which will be
-                                    executed prior to proposal
-  --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
-                                    proposal
-  --globalHelp                      View all available global flags
-  --hotfix=<value>                  Hash of hotfix proposal
-  --jsonTransactions=<value>        Output proposal JSON to provided file
-  --nonwhitelisters                 If set, displays validators that have not
-                                    whitelisted the hotfix.
-  --notwhitelisted                  List validators who have not whitelisted the
-                                    specified hotfix
-  --proposalID=<value>              UUID of proposal to view
-  --raw                             Display proposal in raw bytes format
-  --whitelisters                    If set, displays validators that have whitelisted
-                                    the hotfix.
+  --account=<value>                                         Address of account or voter
+  --afterExecutingID=<value>                                Governance proposal
+                                                            identifier which will be
+                                                            executed prior to proposal
+  --afterExecutingProposal=<value>                          Path to proposal which will
+                                                            be executed prior to
+                                                            proposal
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --hotfix=<value>                                          Hash of hotfix proposal
+  --jsonTransactions=<value>                                Output proposal JSON to
+                                                            provided file
+  --nonwhitelisters                                         If set, displays validators
+                                                            that have not whitelisted
+                                                            the hotfix.
+  --notwhitelisted                                          List validators who have not
+                                                            whitelisted the specified
+                                                            hotfix
+  --proposalID=<value>                                      UUID of proposal to view
+  --raw                                                     Display proposal in raw
+                                                            bytes format
+  --whitelisters                                            If set, displays validators
+                                                            that have whitelisted the
+                                                            hotfix.
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -645,15 +822,21 @@ Vote on an approved governance proposal
 ```
 USAGE
   $ celocli governance:vote --proposalID <value> --value Abstain|No|Yes --from
-    <value> [--globalHelp]
+    <value> [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Voter's address
-  --globalHelp                                       View all available global flags
-  --proposalID=<value>                               (required) UUID of proposal to vote
-                                                     on
-  --value=<option>                                   (required) Vote
-                                                     <options: Abstain|No|Yes>
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Voter's address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --proposalID=<value>                                      (required) UUID of proposal
+                                                            to vote on
+  --value=<option>                                          (required) Vote
+                                                            <options: Abstain|No|Yes>
 
 DESCRIPTION
   Vote on an approved governance proposal
@@ -670,17 +853,23 @@ Vote partially on an approved governance proposal
 
 ```
 USAGE
-  $ celocli governance:votePartially --proposalID <value> --from <value> [--globalHelp] [--yes
-    <value>] [--no <value>] [--abstain <value>]
+  $ celocli governance:votePartially --proposalID <value> --from <value> [--gasCurrency
+    <value>] [--globalHelp] [--yes <value>] [--no <value>] [--abstain <value>]
 
 FLAGS
-  --abstain=<value>                                  Abstain votes
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Voter's address
-  --globalHelp                                       View all available global flags
-  --no=<value>                                       No votes
-  --proposalID=<value>                               (required) UUID of proposal to vote
-                                                     on
-  --yes=<value>                                      Yes votes
+  --abstain=<value>                                         Abstain votes
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Voter's address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --no=<value>                                              No votes
+  --proposalID=<value>                                      (required) UUID of proposal
+                                                            to vote on
+  --yes=<value>                                             Yes votes
 
 DESCRIPTION
   Vote partially on an approved governance proposal
@@ -697,13 +886,21 @@ Whitelist a governance hotfix
 
 ```
 USAGE
-  $ celocli governance:whitelisthotfix --from <value> --hash <value> [--globalHelp]
+  $ celocli governance:whitelisthotfix --from <value> --hash <value> [--gasCurrency <value>]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Whitelister's address
-  --globalHelp                                       View all available global flags
-  --hash=<value>                                     (required) Hash of hotfix
-                                                     transactions
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Whitelister's
+                                                            address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --hash=<value>                                            (required) Hash of hotfix
+                                                            transactions
 
 DESCRIPTION
   Whitelist a governance hotfix
@@ -720,11 +917,18 @@ Withdraw refunded governance proposal deposits.
 
 ```
 USAGE
-  $ celocli governance:withdraw --from <value> [--globalHelp]
+  $ celocli governance:withdraw --from <value> [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Proposer's address
-  --globalHelp                                       View all available global flags
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Proposer's
+                                                            address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Withdraw refunded governance proposal deposits.

--- a/packages/docs/command-line-interface/grandamento.md
+++ b/packages/docs/command-line-interface/grandamento.md
@@ -1,0 +1,172 @@
+`celocli grandamento`
+=====================
+
+Cancels a Granda Mento exchange proposal
+
+* [`celocli grandamento:cancel`](#celocli-grandamentocancel)
+* [`celocli grandamento:execute`](#celocli-grandamentoexecute)
+* [`celocli grandamento:get-buy-amount`](#celocli-grandamentoget-buy-amount)
+* [`celocli grandamento:list`](#celocli-grandamentolist)
+* [`celocli grandamento:propose`](#celocli-grandamentopropose)
+* [`celocli grandamento:show`](#celocli-grandamentoshow)
+
+## `celocli grandamento:cancel`
+
+Cancels a Granda Mento exchange proposal
+
+```
+USAGE
+  $ celocli grandamento:cancel --from <value> (--proposalID <value> |  | )
+    [--gasCurrency <value>] [--globalHelp]
+
+FLAGS
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address
+                                                            allowed to cancel the
+                                                            proposal
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --proposalID=<value>                                      (required) UUID of proposal
+                                                            to view
+
+DESCRIPTION
+  Cancels a Granda Mento exchange proposal
+```
+
+## `celocli grandamento:execute`
+
+Executes a Granda Mento exchange proposal
+
+```
+USAGE
+  $ celocli grandamento:execute --from <value> --proposalID <value> [--gasCurrency
+    <value>] [--globalHelp]
+
+FLAGS
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address to
+                                                            execute the exchange
+                                                            proposal
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --proposalID=<value>                                      (required) UUID of proposal
+                                                            to view
+
+DESCRIPTION
+  Executes a Granda Mento exchange proposal
+```
+
+## `celocli grandamento:get-buy-amount`
+
+Gets the buy amount for a prospective Granda Mento exchange
+
+```
+USAGE
+  $ celocli grandamento:get-buy-amount --value <value> --stableToken
+    cUSD|cusd|cEUR|ceur|cREAL|creal --sellCelo [--gasCurrency <value>] [--globalHelp]
+
+FLAGS
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --sellCelo                                                (required) Sell or buy CELO
+  --stableToken=<option>                                    (required) [default: cusd]
+                                                            Name of the stable to
+                                                            receive or send
+                                                            <options: cUSD|cusd|cEUR|ceu
+                                                            r|cREAL|creal>
+  --value=10000000000000000000000                           (required) The value of the
+                                                            tokens to exchange
+
+DESCRIPTION
+  Gets the buy amount for a prospective Granda Mento exchange
+```
+
+## `celocli grandamento:list`
+
+List current active Granda Mento exchange proposals
+
+```
+USAGE
+  $ celocli grandamento:list [--gasCurrency <value>] [--globalHelp]
+
+FLAGS
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+
+DESCRIPTION
+  List current active Granda Mento exchange proposals
+```
+
+## `celocli grandamento:propose`
+
+Proposes a Granda Mento exchange
+
+```
+USAGE
+  $ celocli grandamento:propose --from <value> --value <value> --stableToken
+    cUSD|cusd|cEUR|ceur|cREAL|creal --sellCelo [--gasCurrency <value>] [--globalHelp]
+
+FLAGS
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
+                                                            tokens to exchange
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --sellCelo                                                (required) Sell or buy CELO
+  --stableToken=<option>                                    (required) [default: cusd]
+                                                            Name of the stable to
+                                                            receive or send
+                                                            <options: cUSD|cusd|cEUR|ceu
+                                                            r|cREAL|creal>
+  --value=10000000000000000000000                           (required) The value of the
+                                                            tokens to exchange
+
+DESCRIPTION
+  Proposes a Granda Mento exchange
+```
+
+## `celocli grandamento:show`
+
+Shows details of a Granda Mento exchange proposal
+
+```
+USAGE
+  $ celocli grandamento:show --proposalID <value> [--gasCurrency <value>]
+    [--globalHelp]
+
+FLAGS
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --proposalID=<value>                                      (required) UUID of proposal
+                                                            to view
+
+DESCRIPTION
+  Shows details of a Granda Mento exchange proposal
+```

--- a/packages/docs/command-line-interface/identity.md
+++ b/packages/docs/command-line-interface/identity.md
@@ -13,17 +13,28 @@ Looks up attestations associated with the provided phone number. If a pepper is 
 
 ```
 USAGE
-  $ celocli identity:get-attestations [--globalHelp] [--phoneNumber <value>] [--from <value>]
-    [--pepper <value>] [--identifier <value>] [--network <value>]
+  $ celocli identity:get-attestations [--gasCurrency <value>] [--globalHelp] [--phoneNumber
+    <value>] [--from <value>] [--pepper <value>] [--identifier <value>] [--network
+    <value>]
 
 FLAGS
-  --from=<value>         Account whose balance to use for querying ODIS for the pepper
-                         lookup
-  --globalHelp           View all available global flags
-  --identifier=<value>   On-chain identifier
-  --network=<value>      The ODIS service to hit: mainnet, alfajores, alfajoresstaging
-  --pepper=<value>       ODIS phone number pepper
-  --phoneNumber=<value>  Phone number to check attestations for
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         Account whose balance to use
+                                                            for querying ODIS for the
+                                                            pepper lookup
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --identifier=<value>                                      On-chain identifier
+  --network=<value>                                         The ODIS service to hit:
+                                                            mainnet, alfajores,
+                                                            alfajoresstaging
+  --pepper=<value>                                          ODIS phone number pepper
+  --phoneNumber=<value>                                     Phone number to check
+                                                            attestations for
 
 DESCRIPTION
   Looks up attestations associated with the provided phone number. If a pepper is not
@@ -45,19 +56,27 @@ Queries ODIS for the on-chain identifier and pepper corresponding to a given pho
 
 ```
 USAGE
-  $ celocli identity:identifier --from <value> --phoneNumber <value> [--globalHelp]
-    [--context <value>]
+  $ celocli identity:identifier --from <value> --phoneNumber <value> [--gasCurrency
+    <value>] [--globalHelp] [--context <value>]
 
 FLAGS
-  --context=<value>                                  mainnet (default), alfajores, or
-                                                     alfajoresstaging
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) The address from which
-                                                     to perform the query
-  --globalHelp                                       View all available global flags
-  --phoneNumber=+14152223333                         (required) The phone number for
-                                                     which to query the identifier.
-                                                     Should be in e164 format with
-                                                     country code.
+  --context=<value>                                         mainnet (default),
+                                                            alfajores, or
+                                                            alfajoresstaging
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address from
+                                                            which to perform the query
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --phoneNumber=+14152223333                                (required) The phone number
+                                                            for which to query the
+                                                            identifier. Should be in
+                                                            e164 format with country
+                                                            code.
 
 DESCRIPTION
   Queries ODIS for the on-chain identifier and pepper corresponding to a given phone
@@ -75,20 +94,23 @@ Withdraw accumulated attestation rewards for a given currency
 
 ```
 USAGE
-  $ celocli identity:withdraw-attestation-rewards --from <value> [--globalHelp]
-  [--tokenAddress <value>]
+  $ celocli identity:withdraw-attestation-rewards --from <value> [--gasCurrency <value>] [--globalHelp]
+    [--tokenAddress <value>]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d          (required) Address to
-                                                             withdraw from. Can be the
-                                                             attestation signer address
-                                                             or the underlying account
-                                                             address
-  --globalHelp                                               View all available global
-                                                             flags
-  --tokenAddress=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  The address of the token
-                                                             that will be withdrawn.
-                                                             Defaults to cUSD
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address to withdraw from. Can be the attestation signer address or the
+      underlying account address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --tokenAddress=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      The address of the token that will be withdrawn. Defaults to cUSD
 
 DESCRIPTION
   Withdraw accumulated attestation rewards for a given currency

--- a/packages/docs/command-line-interface/lockedgold.md
+++ b/packages/docs/command-line-interface/lockedgold.md
@@ -20,13 +20,20 @@ Delegate locked celo.
 ```
 USAGE
   $ celocli lockedgold:delegate --from <value> --to <value> --percent <value>
-    [--globalHelp]
+    [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --from=<value>     (required)
-  --globalHelp       View all available global flags
-  --percent=<value>  (required) 1-100% of locked celo to be delegated
-  --to=<value>       (required)
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --percent=<value>                                         (required) 1-100% of locked
+                                                            celo to be delegated
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Account Address
 
 DESCRIPTION
   Delegate locked celo.
@@ -43,11 +50,18 @@ Delegate info about account.
 
 ```
 USAGE
-  $ celocli lockedgold:delegate-info --account <value> [--globalHelp]
+  $ celocli lockedgold:delegate-info --account <value> [--gasCurrency <value>]
+  [--globalHelp]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-  --globalHelp                                          View all available global flags
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Account Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Delegate info about account.
@@ -64,12 +78,20 @@ Locks CELO to be used in governance and validator elections.
 
 ```
 USAGE
-  $ celocli lockedgold:lock --from <value> --value <value> [--globalHelp]
+  $ celocli lockedgold:lock --from <value> --value <value> [--gasCurrency <value>]
+    [--globalHelp]
 
 FLAGS
-  --from=<value>   (required)
-  --globalHelp     View all available global flags
-  --value=<value>  (required) The unit amount of CELO
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --value=<value>                                           (required) The unit amount
+                                                            of CELO
 
 DESCRIPTION
   Locks CELO to be used in governance and validator elections.
@@ -86,10 +108,16 @@ Returns the maximum number of delegates allowed per account.
 
 ```
 USAGE
-  $ celocli lockedgold:max-delegatees-count [--globalHelp]
+  $ celocli lockedgold:max-delegatees-count [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Returns the maximum number of delegates allowed per account.
@@ -107,14 +135,21 @@ Revoke delegated locked celo.
 ```
 USAGE
   $ celocli lockedgold:revoke-delegate --from <value> --to <value> --percent <value>
-    [--globalHelp]
+    [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --from=<value>     (required)
-  --globalHelp       View all available global flags
-  --percent=<value>  (required) 1-100% of locked celo to be revoked from currently
-                     delegated amount
-  --to=<value>       (required)
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --percent=<value>                                         (required) 1-100% of locked
+                                                            celo to be revoked from
+                                                            currently delegated amount
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Account Address
 
 DESCRIPTION
   Revoke delegated locked celo.
@@ -131,10 +166,16 @@ Show Locked Gold information for a given account. This includes the total amount
 
 ```
 USAGE
-  $ celocli lockedgold:show ARG1 [--globalHelp]
+  $ celocli lockedgold:show ARG1 [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Show Locked Gold information for a given account. This includes the total amount of
@@ -155,12 +196,20 @@ Unlocks CELO, which can be withdrawn after the unlocking period. Unlocked celo w
 
 ```
 USAGE
-  $ celocli lockedgold:unlock --from <value> --value <value> [--globalHelp]
+  $ celocli lockedgold:unlock --from <value> --value <value> [--gasCurrency <value>]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-  --globalHelp                                       View all available global flags
-  --value=<value>                                    (required) The unit amount of CELO
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --value=<value>                                           (required) The unit amount
+                                                            of CELO
 
 DESCRIPTION
   Unlocks CELO, which can be withdrawn after the unlocking period. Unlocked celo will
@@ -179,13 +228,19 @@ Updates the amount of delegated locked celo. There might be discrepancy between 
 
 ```
 USAGE
-  $ celocli lockedgold:update-delegated-amount --from <value> --to <value>
-  [--globalHelp]
+  $ celocli lockedgold:update-delegated-amount --from <value> --to <value> [--gasCurrency <value>]
+    [--globalHelp]
 
 FLAGS
-  --from=<value>  (required)
-  --globalHelp    View all available global flags
-  --to=<value>    (required)
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Account Address
 
 DESCRIPTION
   Updates the amount of delegated locked celo. There might be discrepancy between the
@@ -204,11 +259,17 @@ Withdraw any pending withdrawals created via "lockedgold:unlock" that have becom
 
 ```
 USAGE
-  $ celocli lockedgold:withdraw --from <value> [--globalHelp]
+  $ celocli lockedgold:withdraw --from <value> [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-  --globalHelp                                       View all available global flags
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Withdraw any pending withdrawals created via "lockedgold:unlock" that have become

--- a/packages/docs/command-line-interface/multisig.md
+++ b/packages/docs/command-line-interface/multisig.md
@@ -13,15 +13,23 @@ Approves an existing transaction on a multi-sig contract
 
 ```
 USAGE
-  $ celocli multisig:approve --from <value> --for <value> --tx <value> [--globalHelp]
+  $ celocli multisig:approve --from <value> --for <value> --tx <value> [--gasCurrency
+    <value>] [--globalHelp]
 
 FLAGS
-  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d   (required) Address of the multi-sig
-                                                     contract
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account approving the
-                                                     multi-sig transaction
-  --globalHelp                                       View all available global flags
-  --tx=<value>                                       (required) Transaction to approve
+  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d          (required) Address of the
+                                                            multi-sig contract
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account approving
+                                                            the multi-sig transaction
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --tx=<value>                                              (required) Transaction to
+                                                            approve
 
 DESCRIPTION
   Approves an existing transaction on a multi-sig contract
@@ -38,13 +46,22 @@ Shows information about multi-sig contract
 
 ```
 USAGE
-  $ celocli multisig:show ARG1 [--globalHelp] [--tx <value>] [--all] [--raw]
+  $ celocli multisig:show ARG1 [--gasCurrency <value>] [--globalHelp] [--tx
+    <value>] [--all] [--raw]
 
 FLAGS
-  --all         Show info about all transactions
-  --globalHelp  View all available global flags
-  --raw         Do not attempt to parse transactions
-  --tx=<value>  Show info for a transaction
+  --all                                                     Show info about all
+                                                            transactions
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --raw                                                     Do not attempt to parse
+                                                            transactions
+  --tx=<value>                                              Show info for a transaction
 
 DESCRIPTION
   Shows information about multi-sig contract
@@ -66,19 +83,28 @@ Ability to approve CELO transfers to and from multisig. Submit transaction or ap
 ```
 USAGE
   $ celocli multisig:transfer ARG1 --to <value> --amount <value> --from <value>
-    [--globalHelp] [--transferFrom] [--sender <value>]
+    [--gasCurrency <value>] [--globalHelp] [--transferFrom] [--sender <value>]
 
 FLAGS
-  --amount=<value>                                     (required) Amount to transfer,
-                                                       e.g. 10e18
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Account transferring
-                                                       value to the recipient
-  --globalHelp                                         View all available global flags
-  --sender=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Identify sender if performing
-                                                       transferFrom
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Recipient of transfer
-  --transferFrom                                       Perform transferFrom instead of
-                                                       transfer in the ERC-20 interface
+  --amount=<value>                                          (required) Amount to
+                                                            transfer, e.g. 10e18
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account
+                                                            transferring value to the
+                                                            recipient
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --sender=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       Identify sender if
+                                                            performing transferFrom
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Recipient of
+                                                            transfer
+  --transferFrom                                            Perform transferFrom instead
+                                                            of transfer in the ERC-20
+                                                            interface
 
 DESCRIPTION
   Ability to approve CELO transfers to and from multisig. Submit transaction or approve

--- a/packages/docs/command-line-interface/network.md
+++ b/packages/docs/command-line-interface/network.md
@@ -6,6 +6,7 @@ View details about the network, like contracts and parameters
 * [`celocli network:contracts`](#celocli-networkcontracts)
 * [`celocli network:info`](#celocli-networkinfo)
 * [`celocli network:parameters`](#celocli-networkparameters)
+* [`celocli network:whitelist`](#celocli-networkwhitelist)
 
 ## `celocli network:contracts`
 
@@ -13,21 +14,42 @@ Lists Celo core contracts and their addesses.
 
 ```
 USAGE
-  $ celocli network:contracts [--globalHelp] [--columns <value> | -x] [--filter
-    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
-    [--sort <value>]
+  $ celocli network:contracts [--gasCurrency <value>] [--globalHelp] [--columns <value>
+    | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
+    csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -x, --extended         show extra columns
-      --columns=<value>  only show provided columns (comma-separated)
-      --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
-      --globalHelp       View all available global flags
-      --no-header        hide table header from output
-      --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
-      --sort=<value>     property to sort by (prepend '-' for descending)
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Lists Celo core contracts and their addesses.
@@ -41,11 +63,18 @@ View general network information such as the current block number
 
 ```
 USAGE
-  $ celocli network:info [--globalHelp] [-n <value>]
+  $ celocli network:info [--gasCurrency <value>] [--globalHelp] [-n <value>]
 
 FLAGS
-  -n, --lastN=<value>  [default: 1] Fetch info about the last n epochs
-      --globalHelp     View all available global flags
+  -n, --lastN=<value>
+      [default: 1] Fetch info about the last n epochs
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
 
 DESCRIPTION
   View general network information such as the current block number
@@ -59,11 +88,18 @@ View parameters of the network, including but not limited to configuration for t
 
 ```
 USAGE
-  $ celocli network:parameters [--globalHelp] [--raw]
+  $ celocli network:parameters [--gasCurrency <value>] [--globalHelp] [--raw]
 
 FLAGS
-  --globalHelp  View all available global flags
-  --raw         Display raw numerical configuration
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --raw                                                     Display raw numerical
+                                                            configuration
 
 DESCRIPTION
   View parameters of the network, including but not limited to configuration for the
@@ -71,3 +107,29 @@ DESCRIPTION
 ```
 
 _See code: [src/commands/network/parameters.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/network/parameters.ts)_
+
+## `celocli network:whitelist`
+
+List the whitelisted fee currencies
+
+```
+USAGE
+  $ celocli network:whitelist [--gasCurrency <value>] [--globalHelp]
+
+FLAGS
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+
+DESCRIPTION
+  List the whitelisted fee currencies
+
+EXAMPLES
+  whitelist
+```
+
+_See code: [src/commands/network/whitelist.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/network/whitelist.ts)_

--- a/packages/docs/command-line-interface/node.md
+++ b/packages/docs/command-line-interface/node.md
@@ -12,10 +12,16 @@ List the addresses that this node has the private keys for.
 
 ```
 USAGE
-  $ celocli node:accounts [--globalHelp]
+  $ celocli node:accounts [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   List the addresses that this node has the private keys for.
@@ -29,11 +35,18 @@ Check if the node is synced
 
 ```
 USAGE
-  $ celocli node:synced [--globalHelp] [--verbose]
+  $ celocli node:synced [--gasCurrency <value>] [--globalHelp] [--verbose]
 
 FLAGS
-  --globalHelp  View all available global flags
-  --verbose     output the full status if syncing
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --verbose                                                 output the full status if
+                                                            syncing
 
 DESCRIPTION
   Check if the node is synced

--- a/packages/docs/command-line-interface/oracle.md
+++ b/packages/docs/command-line-interface/oracle.md
@@ -14,13 +14,19 @@ List oracle addresses for a given token
 
 ```
 USAGE
-  $ celocli oracle:list ARG1 [--globalHelp]
+  $ celocli oracle:list ARG1 [--gasCurrency <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to list the oracles for
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   List oracle addresses for a given token
@@ -41,15 +47,23 @@ Remove expired oracle reports for a specified token
 
 ```
 USAGE
-  $ celocli oracle:remove-expired-reports ARG1 --from <value> [--globalHelp]
+  $ celocli oracle:remove-expired-reports ARG1 --from <value> [--gasCurrency <value>]
+  [--globalHelp]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to remove expired reports for
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the account
-                                                     removing oracle reports
-  --globalHelp                                       View all available global flags
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            account removing oracle
+                                                            reports
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Remove expired oracle reports for a specified token
@@ -70,17 +84,25 @@ Report the price of CELO in a specified token
 
 ```
 USAGE
-  $ celocli oracle:report ARG1 --from <value> --value <value> [--globalHelp]
+  $ celocli oracle:report ARG1 --from <value> --value <value> [--gasCurrency
+    <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to report on
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the oracle
-                                                     account
-  --globalHelp                                       View all available global flags
-  --value=<value>                                    (required) Amount of the specified
-                                                     token equal to 1 CELO
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            oracle account
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --value=<value>                                           (required) Amount of the
+                                                            specified token equal to 1
+                                                            CELO
 
 DESCRIPTION
   Report the price of CELO in a specified token
@@ -101,24 +123,45 @@ List oracle reports for a given token
 
 ```
 USAGE
-  $ celocli oracle:reports ARG1 [--globalHelp] [--columns <value> | -x] [--filter
-    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
-    [--sort <value>]
+  $ celocli oracle:reports ARG1 [--gasCurrency <value>] [--globalHelp] [--columns
+    <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
+    csv|json|yaml |  | ] [--sort <value>]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to list the reports for
 
 FLAGS
-  -x, --extended         show extra columns
-      --columns=<value>  only show provided columns (comma-separated)
-      --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
-      --globalHelp       View all available global flags
-      --no-header        hide table header from output
-      --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
-      --sort=<value>     property to sort by (prepend '-' for descending)
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List oracle reports for a given token

--- a/packages/docs/command-line-interface/releasecelo.md
+++ b/packages/docs/command-line-interface/releasecelo.md
@@ -26,31 +26,38 @@ Authorize an alternative key to be used for a given action (Vote, Validate, Atte
 ```
 USAGE
   $ celocli releasecelo:authorize --contract <value> --role vote|validator|attestation
-    --signer <value> --signature <value> [--globalHelp] [--blsKey <value> --blsPop
-    <value>]
+    --signer <value> --signature <value> [--gasCurrency <value>] [--globalHelp]
+    [--blsKey <value> --blsPop <value>]
 
 FLAGS
-  --blsKey=0x                                            The BLS public key that the
-                                                         validator is using for
-                                                         consensus, should pass proof of
-                                                         possession. 96 bytes.
-  --blsPop=0x                                            The BLS public key
-                                                         proof-of-possession, which
-                                                         consists of a signature on the
-                                                         account address. 48 bytes.
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                         ReleaseGold Contract
-  --globalHelp                                           View all available global flags
-  --role=<option>                                        (required)
-                                                         <options:
-                                                         vote|validator|attestation>
-  --signature=0x                                         (required) Signature (a.k.a.
-                                                         proof-of-possession) of the
-                                                         signer key
-  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) The signer key that
-                                                         is to be used for voting
-                                                         through the ReleaseGold
-                                                         instance
+  --blsKey=0x                                               The BLS public key that the
+                                                            validator is using for
+                                                            consensus, should pass proof
+                                                            of possession. 96 bytes.
+  --blsPop=0x                                               The BLS public key
+                                                            proof-of-possession, which
+                                                            consists of a signature on
+                                                            the account address. 48
+                                                            bytes.
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
+                                                            ReleaseGold Contract
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --role=<option>                                           (required)
+                                                            <options:
+                                                            vote|validator|attestation>
+  --signature=0x                                            (required) Signature (a.k.a.
+                                                            proof-of-possession) of the
+                                                            signer key
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) The signer key
+                                                            that is to be used for
+                                                            voting through the
+                                                            ReleaseGold instance
 
 DESCRIPTION
   Authorize an alternative key to be used for a given action (Vote, Validate, Attest) on
@@ -72,12 +79,19 @@ Creates a new account for the ReleaseGold instance
 
 ```
 USAGE
-  $ celocli releasecelo:create-account --contract <value> [--globalHelp]
+  $ celocli releasecelo:create-account --contract <value> [--gasCurrency <value>]
+  [--globalHelp]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                         ReleaseGold Contract
-  --globalHelp                                           View all available global flags
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
+                                                            ReleaseGold Contract
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Creates a new account for the ReleaseGold instance
@@ -95,20 +109,28 @@ Perform actions [lock, unlock, withdraw] on CELO that has been locked via the pr
 ```
 USAGE
   $ celocli releasecelo:locked-gold --contract <value> -a lock|unlock|withdraw --value
-    <value> [--globalHelp] [--yes]
+    <value> [--gasCurrency <value>] [--globalHelp] [--yes]
 
 FLAGS
-  -a, --action=<option>                                      (required) Action to
-                                                             perform on contract's celo
-                                                             <options:
-                                                             lock|unlock|withdraw>
-      --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                             ReleaseGold Contract
-      --globalHelp                                           View all available global
-                                                             flags
-      --value=10000000000000000000000                        (required) Amount of celo
-                                                             to perform `action` with
-      --yes                                                  Answer yes to prompt
+  -a, --action=<option>
+      (required) Action to perform on contract's celo
+      <options: lock|unlock|withdraw>
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --value=10000000000000000000000
+      (required) Amount of celo to perform `action` with
+
+  --yes
+      Answer yes to prompt
 
 DESCRIPTION
   Perform actions [lock, unlock, withdraw] on CELO that has been locked via the provided
@@ -130,12 +152,19 @@ Refund the given contract's balance to the appopriate parties and destroy the co
 
 ```
 USAGE
-  $ celocli releasecelo:refund-and-finalize --contract <value> [--globalHelp]
+  $ celocli releasecelo:refund-and-finalize --contract <value> [--gasCurrency <value>]
+  [--globalHelp]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                         ReleaseGold Contract
-  --globalHelp                                           View all available global flags
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
+                                                            ReleaseGold Contract
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Refund the given contract's balance to the appopriate parties and destroy the contact.
@@ -153,14 +182,21 @@ Revoke the given contract instance. Once revoked, any Locked Gold can be unlocke
 
 ```
 USAGE
-  $ celocli releasecelo:revoke --contract <value> [--globalHelp] [--yesreally]
+  $ celocli releasecelo:revoke --contract <value> [--gasCurrency <value>] [--globalHelp]
+    [--yesreally]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                         ReleaseGold Contract
-  --globalHelp                                           View all available global flags
-  --yesreally                                            Override prompt to set
-                                                         liquidity (be careful!)
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
+                                                            ReleaseGold Contract
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --yesreally                                               Override prompt to set
+                                                            liquidity (be careful!)
 
 DESCRIPTION
   Revoke the given contract instance. Once revoked, any Locked Gold can be unlocked by
@@ -180,19 +216,26 @@ Revokes `votes` for the given contract's account from the given group's account
 
 ```
 USAGE
-  $ celocli releasecelo:revoke-votes --contract <value> [--globalHelp] [--group <value> |
-    --allGroups] [--votes <value> | --allVotes | ]
+  $ celocli releasecelo:revoke-votes --contract <value> [--gasCurrency <value>] [--globalHelp]
+    [--group <value> | --allGroups] [--votes <value> | --allVotes | ]
 
 FLAGS
-  --allGroups                                            Revoke all votes from all
-                                                         groups
-  --allVotes                                             Revoke all votes
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                         ReleaseGold Contract
-  --globalHelp                                           View all available global flags
-  --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     Address of the group to revoke
-                                                         votes from
-  --votes=<value>                                        The number of votes to revoke
+  --allGroups                                               Revoke all votes from all
+                                                            groups
+  --allVotes                                                Revoke all votes
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
+                                                            ReleaseGold Contract
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d        Address of the group to
+                                                            revoke votes from
+  --votes=<value>                                           The number of votes to
+                                                            revoke
 
 DESCRIPTION
   Revokes `votes` for the given contract's account from the given group's account
@@ -212,19 +255,25 @@ Set account properties of the ReleaseGold instance account such as name, data en
 ```
 USAGE
   $ celocli releasecelo:set-account --contract <value> -p name|dataEncryptionKey|metaURL -v
-    <value> [--globalHelp]
+    <value> [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  -p, --property=<option>                                    (required) Property type to
-                                                             set
-                                                             <options: name|dataEncrypti
-                                                             onKey|metaURL>
-  -v, --value=<value>                                        (required) Property value
-                                                             to set
-      --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                             ReleaseGold Contract
-      --globalHelp                                           View all available global
-                                                             flags
+  -p, --property=<option>
+      (required) Property type to set
+      <options: name|dataEncryptionKey|metaURL>
+
+  -v, --value=<value>
+      (required) Property value to set
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
 
 DESCRIPTION
   Set account properties of the ReleaseGold instance account such as name, data
@@ -235,7 +284,7 @@ EXAMPLES
 
   set-account --contract 0x5719118266779B58D0f9519383A4A27aA7b829E5 --property dataEncryptionKey --value 0x041bb96e35f9f4b71ca8de561fff55a249ddf9d13ab582bdd09a09e75da68ae4cd0ab7038030f41b237498b4d76387ae878dc8d98fd6f6db2c15362d1a3bf11216
 
-  set-account --contract 0x5719118266779B58D0f9519383A4A27aA7b829E5 --property metaURL --value www.test.com
+  set-account --contract 0x5719118266779B58D0f9519383A4A27aA7b829E5 --property metaURL --value www.example.com
 ```
 
 _See code: [src/commands/releasecelo/set-account.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/set-account.ts)_
@@ -246,12 +295,16 @@ Set the ReleaseGold contract account's wallet address
 
 ```
 USAGE
-  $ celocli releasecelo:set-account-wallet-address --contract <value> --walletAddress <value> [--globalHelp]
-    [--pop <value>]
+  $ celocli releasecelo:set-account-wallet-address --contract <value> --walletAddress <value> [--gasCurrency
+    <value>] [--globalHelp] [--pop <value>]
 
 FLAGS
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
 
   --globalHelp
       View all available global flags
@@ -279,7 +332,7 @@ Set the beneficiary of the ReleaseGold contract. This command is gated via a mul
 ```
 USAGE
   $ celocli releasecelo:set-beneficiary --contract <value> --from <value> --beneficiary <value>
-    [--globalHelp] [--yesreally]
+    [--gasCurrency <value>] [--globalHelp] [--yesreally]
 
 FLAGS
   --beneficiary=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
@@ -289,6 +342,11 @@ FLAGS
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address to submit
                                                             multisig transaction from
                                                             (one of the owners)
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
   --globalHelp                                              View all available global
                                                             flags
   --yesreally                                               Override prompt to set new
@@ -313,17 +371,24 @@ Set the canExpire flag for the given ReleaseGold contract
 ```
 USAGE
   $ celocli releasecelo:set-can-expire --contract <value> --value true|false|True|False
-    [--globalHelp] [--yesreally]
+    [--gasCurrency <value>] [--globalHelp] [--yesreally]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                         ReleaseGold Contract
-  --globalHelp                                           View all available global flags
-  --value=<option>                                       (required) canExpire value
-                                                         <options:
-                                                         true|false|True|False>
-  --yesreally                                            Override prompt to set
-                                                         expiration flag (be careful!)
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
+                                                            ReleaseGold Contract
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --value=<option>                                          (required) canExpire value
+                                                            <options:
+                                                            true|false|True|False>
+  --yesreally                                               Override prompt to set
+                                                            expiration flag (be
+                                                            careful!)
 
 DESCRIPTION
   Set the canExpire flag for the given ReleaseGold contract
@@ -340,15 +405,21 @@ Set the liquidity provision to true, allowing the beneficiary to withdraw releas
 
 ```
 USAGE
-  $ celocli releasecelo:set-liquidity-provision --contract <value> [--globalHelp]
-  [--yesreally]
+  $ celocli releasecelo:set-liquidity-provision --contract <value> [--gasCurrency <value>] [--globalHelp]
+    [--yesreally]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                         ReleaseGold Contract
-  --globalHelp                                           View all available global flags
-  --yesreally                                            Override prompt to set
-                                                         liquidity (be careful!)
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
+                                                            ReleaseGold Contract
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --yesreally                                               Override prompt to set
+                                                            liquidity (be careful!)
 
 DESCRIPTION
   Set the liquidity provision to true, allowing the beneficiary to withdraw released
@@ -367,19 +438,26 @@ Set the maximum distribution of celo for the given contract
 ```
 USAGE
   $ celocli releasecelo:set-max-distribution --contract <value> --distributionRatio <value>
-    [--globalHelp] [--yesreally]
+    [--gasCurrency <value>] [--globalHelp] [--yesreally]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                         ReleaseGold Contract
-  --distributionRatio=<value>                            (required) Amount in range [0,
-                                                         1000] (3 significant figures)
-                                                         indicating % of total balance
-                                                         available for distribution.
-  --globalHelp                                           View all available global flags
-  --yesreally                                            Override prompt to set new
-                                                         maximum distribution (be
-                                                         careful!)
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
+                                                            ReleaseGold Contract
+  --distributionRatio=<value>                               (required) Amount in range
+                                                            [0, 1000] (3 significant
+                                                            figures) indicating % of
+                                                            total balance available for
+                                                            distribution.
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --yesreally                                               Override prompt to set new
+                                                            maximum distribution (be
+                                                            careful!)
 
 DESCRIPTION
   Set the maximum distribution of celo for the given contract
@@ -396,12 +474,18 @@ Show info on a ReleaseGold instance contract.
 
 ```
 USAGE
-  $ celocli releasecelo:show --contract <value> [--globalHelp]
+  $ celocli releasecelo:show --contract <value> [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                         ReleaseGold Contract
-  --globalHelp                                           View all available global flags
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
+                                                            ReleaseGold Contract
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Show info on a ReleaseGold instance contract.
@@ -419,17 +503,23 @@ Transfer Celo Dollars from the given contract address. Dollars may be accrued to
 ```
 USAGE
   $ celocli releasecelo:transfer-dollars --contract <value> --to <value> --value <value>
-    [--globalHelp]
+    [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                         ReleaseGold Contract
-  --globalHelp                                           View all available global flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d        (required) Address of the
-                                                         recipient of Celo Dollars
-                                                         transfer
-  --value=10000000000000000000000                        (required) Value (in Wei) of
-                                                         Celo Dollars to transfer
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
+                                                            ReleaseGold Contract
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
+                                                            recipient of Celo Dollars
+                                                            transfer
+  --value=10000000000000000000000                           (required) Value (in Wei) of
+                                                            Celo Dollars to transfer
 
 DESCRIPTION
   Transfer Celo Dollars from the given contract address. Dollars may be accrued to the
@@ -447,14 +537,22 @@ Withdraws `value` released celo to the beneficiary address. Fails if `value` wor
 
 ```
 USAGE
-  $ celocli releasecelo:withdraw --contract <value> --value <value> [--globalHelp]
+  $ celocli releasecelo:withdraw --contract <value> --value <value> [--gasCurrency
+    <value>] [--globalHelp]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                         ReleaseGold Contract
-  --globalHelp                                           View all available global flags
-  --value=10000000000000000000000                        (required) Amount of released
-                                                         celo (in wei) to withdraw
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
+                                                            ReleaseGold Contract
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --value=10000000000000000000000                           (required) Amount of
+                                                            released celo (in wei) to
+                                                            withdraw
 
 DESCRIPTION
   Withdraws `value` released celo to the beneficiary address. Fails if `value` worth of

--- a/packages/docs/command-line-interface/reserve.md
+++ b/packages/docs/command-line-interface/reserve.md
@@ -12,10 +12,16 @@ Shows information about reserve
 
 ```
 USAGE
-  $ celocli reserve:status [--globalHelp]
+  $ celocli reserve:status [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Shows information about reserve
@@ -33,15 +39,22 @@ Transfers reserve celo to other reserve address
 ```
 USAGE
   $ celocli reserve:transfergold --value <value> --to <value> --from <value>
-    [--globalHelp] [--useMultiSig]
+    [--gasCurrency <value>] [--globalHelp] [--useMultiSig]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Spender's address
-  --globalHelp                                       View all available global flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Receiving address
-  --useMultiSig                                      True means the request will be sent
-                                                     through multisig.
-  --value=<value>                                    (required) The unit amount of CELO
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Spender's address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Receiving address
+  --useMultiSig                                             True means the request will
+                                                            be sent through multisig.
+  --value=<value>                                           (required) The unit amount
+                                                            of CELO
 
 DESCRIPTION
   Transfers reserve celo to other reserve address

--- a/packages/docs/command-line-interface/rewards.md
+++ b/packages/docs/command-line-interface/rewards.md
@@ -11,42 +11,61 @@ Show rewards information about a voter, registered Validator, or Validator Group
 
 ```
 USAGE
-  $ celocli rewards:show [--globalHelp] [--estimate] [--voter <value>]
-    [--validator <value>] [--group <value>] [--slashing] [--epochs <value>] [--columns
-    <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ celocli rewards:show [--gasCurrency <value>] [--globalHelp] [--estimate]
+    [--voter <value>] [--validator <value>] [--group <value>] [--slashing] [--epochs
+    <value>] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
+    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -x, --extended                                              show extra columns
-      --columns=<value>                                       only show provided columns
-                                                              (comma-separated)
-      --csv                                                   output is csv format
-                                                              [alias: --output=csv]
-      --epochs=<value>                                        [default: 1] Show results
-                                                              for the last N epochs
-      --estimate                                              Estimate voter rewards
-                                                              from current votes
-      --filter=<value>                                        filter property by partial
-                                                              string matching, ex:
-                                                              name=foo
-      --globalHelp                                            View all available global
-                                                              flags
-      --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Validator Group to show
-                                                              rewards for
-      --no-header                                             hide table header from
-                                                              output
-      --no-truncate                                           do not truncate output to
-                                                              fit screen
-      --output=<option>                                       output in a more machine
-                                                              friendly format
-                                                              <options: csv|json|yaml>
-      --slashing                                              Show rewards for slashing
-      --sort=<value>                                          property to sort by
-                                                              (prepend '-' for
-                                                              descending)
-      --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Validator to show rewards
-                                                              for
-      --voter=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Voter to show rewards for
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --epochs=<value>
+      [default: 1] Show results for the last N epochs
+
+  --estimate
+      Estimate voter rewards from current votes
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Validator Group to show rewards for
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --slashing
+      Show rewards for slashing
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
+
+  --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Validator to show rewards for
+
+  --voter=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Voter to show rewards for
 
 DESCRIPTION
   Show rewards information about a voter, registered Validator, or Validator Group

--- a/packages/docs/command-line-interface/transfer.md
+++ b/packages/docs/command-line-interface/transfer.md
@@ -18,15 +18,23 @@ Transfer CELO to a specified address. (Note: this is the equivalent of the old t
 ```
 USAGE
   $ celocli transfer:celo --from <value> --to <value> --value <value>
-    [--globalHelp] [--comment <value>]
+    [--gasCurrency <value>] [--globalHelp] [--comment <value>]
 
 FLAGS
-  --comment=<value>                                  Transfer comment
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
-  --globalHelp                                       View all available global flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Address of the receiver
-  --value=<value>                                    (required) Amount to transfer (in
-                                                     wei)
+  --comment=<value>                                         Transfer comment
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            sender
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
+                                                            receiver
+  --value=<value>                                           (required) Amount to
+                                                            transfer (in wei)
 
 DESCRIPTION
   Transfer CELO to a specified address. (Note: this is the equivalent of the old
@@ -45,15 +53,23 @@ Transfer Celo Dollars (cUSD) to a specified address.
 ```
 USAGE
   $ celocli transfer:dollars --from <value> --to <value> --value <value>
-    [--globalHelp] [--comment <value>]
+    [--gasCurrency <value>] [--globalHelp] [--comment <value>]
 
 FLAGS
-  --comment=<value>                                  Transfer comment
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
-  --globalHelp                                       View all available global flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Address of the receiver
-  --value=<value>                                    (required) Amount to transfer (in
-                                                     wei)
+  --comment=<value>                                         Transfer comment
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            sender
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
+                                                            receiver
+  --value=<value>                                           (required) Amount to
+                                                            transfer (in wei)
 
 DESCRIPTION
   Transfer Celo Dollars (cUSD) to a specified address.
@@ -71,19 +87,27 @@ Transfer ERC20 to a specified address
 ```
 USAGE
   $ celocli transfer:erc20 --erc20Address <value> --from <value> --to <value>
-    --value <value> [--globalHelp]
+    --value <value> [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --erc20Address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Custom erc20 to
-                                                             check it's balance too
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d          (required) Address of the
-                                                             sender
-  --globalHelp                                               View all available global
-                                                             flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d            (required) Address of the
-                                                             receiver
-  --value=<value>                                            (required) Amount to
-                                                             transfer (in wei)
+  --erc20Address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Custom erc20 to check it's balance too
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the sender
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the receiver
+
+  --value=<value>
+      (required) Amount to transfer (in wei)
 
 DESCRIPTION
   Transfer ERC20 to a specified address
@@ -101,15 +125,23 @@ Transfer Celo Euros (cEUR) to a specified address.
 ```
 USAGE
   $ celocli transfer:euros --from <value> --to <value> --value <value>
-    [--globalHelp] [--comment <value>]
+    [--gasCurrency <value>] [--globalHelp] [--comment <value>]
 
 FLAGS
-  --comment=<value>                                  Transfer comment
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
-  --globalHelp                                       View all available global flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Address of the receiver
-  --value=<value>                                    (required) Amount to transfer (in
-                                                     wei)
+  --comment=<value>                                         Transfer comment
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            sender
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
+                                                            receiver
+  --value=<value>                                           (required) Amount to
+                                                            transfer (in wei)
 
 DESCRIPTION
   Transfer Celo Euros (cEUR) to a specified address.
@@ -127,15 +159,23 @@ Transfer CELO to a specified address. *DEPRECATION WARNING* Use the "transfer:ce
 ```
 USAGE
   $ celocli transfer:gold --from <value> --to <value> --value <value>
-    [--globalHelp] [--comment <value>]
+    [--gasCurrency <value>] [--globalHelp] [--comment <value>]
 
 FLAGS
-  --comment=<value>                                  Transfer comment
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
-  --globalHelp                                       View all available global flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Address of the receiver
-  --value=<value>                                    (required) Amount to transfer (in
-                                                     wei)
+  --comment=<value>                                         Transfer comment
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            sender
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
+                                                            receiver
+  --value=<value>                                           (required) Amount to
+                                                            transfer (in wei)
 
 DESCRIPTION
   Transfer CELO to a specified address. *DEPRECATION WARNING* Use the "transfer:celo"
@@ -154,15 +194,23 @@ Transfer Celo Brazilian Real (cREAL) to a specified address.
 ```
 USAGE
   $ celocli transfer:reals --from <value> --to <value> --value <value>
-    [--globalHelp] [--comment <value>]
+    [--gasCurrency <value>] [--globalHelp] [--comment <value>]
 
 FLAGS
-  --comment=<value>                                  Transfer comment
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
-  --globalHelp                                       View all available global flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Address of the receiver
-  --value=<value>                                    (required) Amount to transfer (in
-                                                     wei)
+  --comment=<value>                                         Transfer comment
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            sender
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
+                                                            receiver
+  --value=<value>                                           (required) Amount to
+                                                            transfer (in wei)
 
 DESCRIPTION
   Transfer Celo Brazilian Real (cREAL) to a specified address.
@@ -180,18 +228,28 @@ Transfer a stable token to a specified address.
 ```
 USAGE
   $ celocli transfer:stable --from <value> --to <value> --value <value>
-    [--globalHelp] [--comment <value>] [--stableToken cUSD|cusd|cEUR|ceur|cREAL|creal]
+    [--gasCurrency <value>] [--globalHelp] [--comment <value>] [--stableToken
+    cUSD|cusd|cEUR|ceur|cREAL|creal]
 
 FLAGS
-  --comment=<value>                                  Transfer comment
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the sender
-  --globalHelp                                       View all available global flags
-  --stableToken=<option>                             Name of the stable to be transfered
-                                                     <options:
-                                                     cUSD|cusd|cEUR|ceur|cREAL|creal>
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Address of the receiver
-  --value=<value>                                    (required) Amount to transfer (in
-                                                     wei)
+  --comment=<value>                                         Transfer comment
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
+                                                            sender
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --stableToken=<option>                                    Name of the stable to be
+                                                            transfered
+                                                            <options: cUSD|cusd|cEUR|ceu
+                                                            r|cREAL|creal>
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
+                                                            receiver
+  --value=<value>                                           (required) Amount to
+                                                            transfer (in wei)
 
 DESCRIPTION
   Transfer a stable token to a specified address.

--- a/packages/docs/command-line-interface/utils.md
+++ b/packages/docs/command-line-interface/utils.md
@@ -1,0 +1,30 @@
+`celocli utils`
+===============
+
+List the whitelisted fee currencies
+
+* [`celocli utils:whitelist`](#celocli-utilswhitelist)
+
+## `celocli utils:whitelist`
+
+List the whitelisted fee currencies
+
+```
+USAGE
+  $ celocli utils:whitelist [--gasCurrency <value>] [--globalHelp]
+
+FLAGS
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+
+DESCRIPTION
+  List the whitelisted fee currencies
+
+EXAMPLES
+  whitelist
+```

--- a/packages/docs/command-line-interface/validator.md
+++ b/packages/docs/command-line-interface/validator.md
@@ -23,16 +23,23 @@ Affiliate a Validator with a Validator Group. This allows the Validator Group to
 
 ```
 USAGE
-  $ celocli validator:affiliate ARG1 --from <value> [--globalHelp] [--yes]
+  $ celocli validator:affiliate ARG1 --from <value> [--gasCurrency <value>]
+    [--globalHelp] [--yes]
 
 ARGUMENTS
   ARG1  ValidatorGroup's address
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Signer or Validator's
-                                                     address
-  --globalHelp                                       View all available global flags
-  --yes                                              Answer yes to prompt
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Signer or
+                                                            Validator's address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --yes                                                     Answer yes to prompt
 
 DESCRIPTION
   Affiliate a Validator with a Validator Group. This allows the Validator Group to add
@@ -52,12 +59,18 @@ Deaffiliate a Validator from a Validator Group, and remove it from the Group if 
 
 ```
 USAGE
-  $ celocli validator:deaffiliate --from <value> [--globalHelp]
+  $ celocli validator:deaffiliate --from <value> [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Signer or Validator's
-                                                     address
-  --globalHelp                                       View all available global flags
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Signer or
+                                                            Validator's address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Deaffiliate a Validator from a Validator Group, and remove it from the Group if it is
@@ -75,12 +88,18 @@ Deregister a Validator. Approximately 60 days after the validator is no longer p
 
 ```
 USAGE
-  $ celocli validator:deregister --from <value> [--globalHelp]
+  $ celocli validator:deregister --from <value> [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Signer or Validator's
-                                                     address
-  --globalHelp                                       View all available global flags
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Signer or
+                                                            Validator's address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Deregister a Validator. Approximately 60 days after the validator is no longer part of
@@ -101,8 +120,9 @@ Downtime slash a validator
 
 ```
 USAGE
-  $ celocli validator:downtime-slash --from <value> [--globalHelp] [--validator <value> |
-    --validators <value>] [--intervals <value> | --beforeBlock <value>]
+  $ celocli validator:downtime-slash --from <value> [--gasCurrency <value>] [--globalHelp]
+    [--validator <value> | --validators <value>] [--intervals <value> | --beforeBlock
+    <value>]
 
 FLAGS
   --beforeBlock=<value>
@@ -110,6 +130,10 @@ FLAGS
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) From address to perform the slash (reward recipient)
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
 
   --globalHelp
       View all available global flags
@@ -141,14 +165,20 @@ Force deaffiliate a Validator from a Validator Group, and remove it from the Gro
 
 ```
 USAGE
-  $ celocli validator:force-deaffiliate --from <value> --validator <value>
-  [--globalHelp]
+  $ celocli validator:force-deaffiliate --from <value> --validator <value> [--gasCurrency
+    <value>] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Initiator
-  --globalHelp                                            View all available global
-                                                          flags
-  --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Validator's address
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Initiator
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d    (required) Validator's
+                                                            address
 
 DESCRIPTION
   Force deaffiliate a Validator from a Validator Group, and remove it from the Group if
@@ -169,21 +199,42 @@ List registered Validators, their name (if provided), affiliation, uptime score,
 
 ```
 USAGE
-  $ celocli validator:list [--globalHelp] [--columns <value> | -x] [--filter
-    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
-    [--sort <value>]
+  $ celocli validator:list [--gasCurrency <value>] [--globalHelp] [--columns <value>
+    | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
+    csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -x, --extended         show extra columns
-      --columns=<value>  only show provided columns (comma-separated)
-      --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
-      --globalHelp       View all available global flags
-      --no-header        hide table header from output
-      --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
-      --sort=<value>     property to sort by (prepend '-' for descending)
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List registered Validators, their name (if provided), affiliation, uptime score, and
@@ -202,16 +253,23 @@ Register a new Validator
 ```
 USAGE
   $ celocli validator:register --from <value> --ecdsaKey <value> --blsKey <value>
-    --blsSignature <value> [--globalHelp] [--yes]
+    --blsSignature <value> [--gasCurrency <value>] [--globalHelp] [--yes]
 
 FLAGS
-  --blsKey=0x                                        (required) BLS Public Key
-  --blsSignature=0x                                  (required) BLS Proof-of-Possession
-  --ecdsaKey=0x                                      (required) ECDSA Public Key
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address for the
-                                                     Validator
-  --globalHelp                                       View all available global flags
-  --yes                                              Answer yes to prompt
+  --blsKey=0x                                               (required) BLS Public Key
+  --blsSignature=0x                                         (required) BLS
+                                                            Proof-of-Possession
+  --ecdsaKey=0x                                             (required) ECDSA Public Key
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address for the
+                                                            Validator
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --yes                                                     Answer yes to prompt
 
 DESCRIPTION
   Register a new Validator
@@ -228,10 +286,16 @@ List the Locked Gold requirements for registering a Validator. This consists of 
 
 ```
 USAGE
-  $ celocli validator:requirements [--globalHelp]
+  $ celocli validator:requirements [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   List the Locked Gold requirements for registering a Validator. This consists of a
@@ -251,21 +315,28 @@ Set validator signature bitmaps for provided intervals
 
 ```
 USAGE
-  $ celocli validator:set-bitmaps --from <value> [--globalHelp]
+  $ celocli validator:set-bitmaps --from <value> [--gasCurrency <value>] [--globalHelp]
     [--slashableDowntimeBeforeBlock <value> | --intervals <value> |
     --slashableDowntimeBeforeLatest]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) From address to sign set
-                                                     bitmap transactions
-  --globalHelp                                       View all available global flags
-  --intervals='[0:1], [1:2]'                         Array of intervals, ordered by min
-                                                     start to max end
-  --slashableDowntimeBeforeBlock=<value>             Set all bitmaps for slashable
-                                                     downtime window before provided
-                                                     block
-  --slashableDowntimeBeforeLatest                    Set all bitmaps for slashable
-                                                     downtime window before latest block
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) From address to
+                                                            sign set bitmap transactions
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --intervals='[0:1], [1:2]'                                Array of intervals, ordered
+                                                            by min start to max end
+  --slashableDowntimeBeforeBlock=<value>                    Set all bitmaps for
+                                                            slashable downtime window
+                                                            before provided block
+  --slashableDowntimeBeforeLatest                           Set all bitmaps for
+                                                            slashable downtime window
+                                                            before latest block
 
 DESCRIPTION
   Set validator signature bitmaps for provided intervals
@@ -284,13 +355,19 @@ Show information about a registered Validator.
 
 ```
 USAGE
-  $ celocli validator:show ARG1 [--globalHelp]
+  $ celocli validator:show ARG1 [--gasCurrency <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  Validator's address
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Show information about a registered Validator.
@@ -307,13 +384,17 @@ Display a graph of blocks and whether the given signer's signature is included i
 
 ```
 USAGE
-  $ celocli validator:signed-blocks [--globalHelp] [--signer <value> | --signers <value>]
-    [--wasDownWhileElected] [--at-block <value> | ] [--slashableDowntimeLookback |
-    [--lookback <value> | ]] [--width <value>]
+  $ celocli validator:signed-blocks [--gasCurrency <value>] [--globalHelp] [--signer <value>
+    | --signers <value>] [--wasDownWhileElected] [--at-block <value> | ]
+    [--slashableDowntimeLookback | [--lookback <value> | ]] [--width <value>]
 
 FLAGS
   --at-block=<value>
       latest block to examine for signer activity
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
 
   --globalHelp
       View all available global flags
@@ -363,49 +444,60 @@ Shows the consensus status of a validator. This command will show whether a vali
 
 ```
 USAGE
-  $ celocli validator:status [--globalHelp] [--validator <value> | --all | --signer
-    <value>] [--start <value>] [--end <value>] [--columns <value> | -x] [--filter
-    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
-    [--sort <value>]
+  $ celocli validator:status [--gasCurrency <value>] [--globalHelp] [--validator
+    <value> | --all | --signer <value>] [--start <value>] [--end <value>] [--columns
+    <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
+    csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -x, --extended                                              show extra columns
-      --all                                                   get the status of all
-                                                              registered validators
-      --columns=<value>                                       only show provided columns
-                                                              (comma-separated)
-      --csv                                                   output is csv format
-                                                              [alias: --output=csv]
-      --end=<value>                                           [default: -1] what block
-                                                              to end at when looking at
-                                                              signer activity. defaults
-                                                              to the latest block
-      --filter=<value>                                        filter property by partial
-                                                              string matching, ex:
-                                                              name=foo
-      --globalHelp                                            View all available global
-                                                              flags
-      --no-header                                             hide table header from
-                                                              output
-      --no-truncate                                           do not truncate output to
-                                                              fit screen
-      --output=<option>                                       output in a more machine
-                                                              friendly format
-                                                              <options: csv|json|yaml>
-      --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     address of the signer to
-                                                              check if elected and
-                                                              validating
-      --sort=<value>                                          property to sort by
-                                                              (prepend '-' for
-                                                              descending)
-      --start=<value>                                         [default: -1] what block
-                                                              to start at when looking
-                                                              at signer activity.
-                                                              defaults to the last 100
-                                                              blocks
-      --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  address of the validator
-                                                              to check if elected and
-                                                              validating
+  -x, --extended
+      show extra columns
+
+  --all
+      get the status of all registered validators
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --end=<value>
+      [default: -1] what block to end at when looking at signer activity. defaults to the
+      latest block
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      address of the signer to check if elected and validating
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
+
+  --start=<value>
+      [default: -1] what block to start at when looking at signer activity. defaults to
+      the last 100 blocks
+
+  --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      address of the validator to check if elected and validating
 
 DESCRIPTION
   Shows the consensus status of a validator. This command will show whether a validator
@@ -430,13 +522,21 @@ Update the BLS public key for a Validator to be used in consensus.
 ```
 USAGE
   $ celocli validator:update-bls-public-key --from <value> --blsKey <value> --blsPop <value>
-    [--globalHelp]
+    [--gasCurrency <value>] [--globalHelp]
 
 FLAGS
-  --blsKey=0x                                        (required) BLS Public Key
-  --blsPop=0x                                        (required) BLS Proof-of-Possession
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Validator's address
-  --globalHelp                                       View all available global flags
+  --blsKey=0x                                               (required) BLS Public Key
+  --blsPop=0x                                               (required) BLS
+                                                            Proof-of-Possession
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Validator's
+                                                            address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Update the BLS public key for a Validator to be used in consensus.

--- a/packages/docs/command-line-interface/validatorgroup.md
+++ b/packages/docs/command-line-interface/validatorgroup.md
@@ -17,20 +17,27 @@ Manage the commission for a registered Validator Group. This represents the shar
 
 ```
 USAGE
-  $ celocli validatorgroup:commission --from <value> [--globalHelp] [--apply | --queue-update
-    <value>]
+  $ celocli validatorgroup:commission --from <value> [--gasCurrency <value>] [--globalHelp]
+    [--apply | --queue-update <value>]
 
 FLAGS
-  --apply                                            Applies a previously queued update.
-                                                     Should be called after the update
-                                                     delay.
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address for the
-                                                     Validator Group or Validator Group
-                                                     validator signer
-  --globalHelp                                       View all available global flags
-  --queue-update=<value>                             Queues an update to the commission,
-                                                     which can be applied after the
-                                                     update delay.
+  --apply                                                   Applies a previously queued
+                                                            update. Should be called
+                                                            after the update delay.
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address for the
+                                                            Validator Group or Validator
+                                                            Group validator signer
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --queue-update=<value>                                    Queues an update to the
+                                                            commission, which can be
+                                                            applied after the update
+                                                            delay.
 
 DESCRIPTION
   Manage the commission for a registered Validator Group. This represents the share of
@@ -54,12 +61,19 @@ Deregister a Validator Group. Approximately 180 days after the validator group i
 
 ```
 USAGE
-  $ celocli validatorgroup:deregister --from <value> [--globalHelp]
+  $ celocli validatorgroup:deregister --from <value> [--gasCurrency <value>]
+  [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Signer or
-                                                     ValidatorGroup's address
-  --globalHelp                                       View all available global flags
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Signer or
+                                                            ValidatorGroup's address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Deregister a Validator Group. Approximately 180 days after the validator group is
@@ -79,21 +93,42 @@ List registered Validator Groups, their names (if provided), commission, and mem
 
 ```
 USAGE
-  $ celocli validatorgroup:list [--globalHelp] [--columns <value> | -x] [--filter
-    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
-    [--sort <value>]
+  $ celocli validatorgroup:list [--gasCurrency <value>] [--globalHelp] [--columns <value>
+    | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
+    csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -x, --extended         show extra columns
-      --columns=<value>  only show provided columns (comma-separated)
-      --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
-      --globalHelp       View all available global flags
-      --no-header        hide table header from output
-      --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
-      --sort=<value>     property to sort by (prepend '-' for descending)
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List registered Validator Groups, their names (if provided), commission, and members.
@@ -110,23 +145,31 @@ Add or remove members from a Validator Group
 
 ```
 USAGE
-  $ celocli validatorgroup:member ARG1 --from <value> [--globalHelp] [--yes] [--accept |
-    --remove | --reorder <value>]
+  $ celocli validatorgroup:member ARG1 --from <value> [--gasCurrency <value>]
+    [--globalHelp] [--yes] [--accept | --remove | --reorder <value>]
 
 ARGUMENTS
   ARG1  Validator's address
 
 FLAGS
-  --accept                                           Accept a validator whose
-                                                     affiliation is already set to the
-                                                     group
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) ValidatorGroup's address
-  --globalHelp                                       View all available global flags
-  --remove                                           Remove a validator from the members
-                                                     list
-  --reorder=<value>                                  Reorder a validator within the
-                                                     members list. Indices are 0 based
-  --yes                                              Answer yes to prompt
+  --accept                                                  Accept a validator whose
+                                                            affiliation is already set
+                                                            to the group
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) ValidatorGroup's
+                                                            address
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --remove                                                  Remove a validator from the
+                                                            members list
+  --reorder=<value>                                         Reorder a validator within
+                                                            the members list. Indices
+                                                            are 0 based
+  --yes                                                     Answer yes to prompt
 
 DESCRIPTION
   Add or remove members from a Validator Group
@@ -147,17 +190,24 @@ Register a new Validator Group
 
 ```
 USAGE
-  $ celocli validatorgroup:register --from <value> --commission <value> [--globalHelp]
-  [--yes]
+  $ celocli validatorgroup:register --from <value> --commission <value> [--gasCurrency
+    <value>] [--globalHelp] [--yes]
 
 FLAGS
-  --commission=<value>                               (required) The share of the epoch
-                                                     rewards given to elected Validators
-                                                     that goes to the group.
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address for the
-                                                     Validator Group
-  --globalHelp                                       View all available global flags
-  --yes                                              Answer yes to prompt
+  --commission=<value>                                      (required) The share of the
+                                                            epoch rewards given to
+                                                            elected Validators that goes
+                                                            to the group.
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address for the
+                                                            Validator Group
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --yes                                                     Answer yes to prompt
 
 DESCRIPTION
   Register a new Validator Group
@@ -174,13 +224,20 @@ Reset validator group slashing multiplier.
 
 ```
 USAGE
-  $ celocli validatorgroup:reset-slashing-multiplier ARG1 [--globalHelp]
+  $ celocli validatorgroup:reset-slashing-multiplier ARG1 [--gasCurrency <value>]
+  [--globalHelp]
 
 ARGUMENTS
   ARG1  ValidatorGroup's address
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Reset validator group slashing multiplier.
@@ -197,13 +254,19 @@ Show information about an existing Validator Group
 
 ```
 USAGE
-  $ celocli validatorgroup:show ARG1 [--globalHelp]
+  $ celocli validatorgroup:show ARG1 [--gasCurrency <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  ValidatorGroup's address
 
 FLAGS
-  --globalHelp  View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
 
 DESCRIPTION
   Show information about an existing Validator Group

--- a/packages/sdk/wallets/wallet-base/src/signing-utils.ts
+++ b/packages/sdk/wallets/wallet-base/src/signing-utils.ts
@@ -17,9 +17,9 @@ import {
   inputCeloTxFormatter,
   parseAccessList,
 } from '@celo/connect/lib/utils/formatter'
+import { publicKeyToAddress } from '@celo/utils/lib/address'
 import { EIP712TypedData, generateTypedDataHash } from '@celo/utils/lib/sign-typed-data-utils'
 import { parseSignatureWithoutPrefix } from '@celo/utils/lib/signatureUtils'
-import { publicKeyToAddress } from '@celo/utils/src/address'
 import * as RLP from '@ethereumjs/rlp'
 import * as ethUtil from '@ethereumjs/util'
 import { secp256k1 } from '@noble/curves/secp256k1'


### PR DESCRIPTION
This PR has the following fixes:

- [CI] uses a `cp` command rather than the postinstall hook of the target repository (docs) because it includes more logic (such as `git submodules update` which defeated the docs gh action)
- [CLI docs] fixes the entrypoint to not use `await import` but good ol' `require` so oclif can generate the docs