### PR TITLE
Fix renovate to always update package.json

### DIFF
--- a/dt-renovate-base.json
+++ b/dt-renovate-base.json
@@ -6,14 +6,9 @@
   "prCreation": "approval",
   "prConcurrentLimit": 2,
   "minimumReleaseAge": "5 days",
+  "rangeStrategy": "bump",
   "major": {
     "minimumReleaseAge": "14 days"
-  },
-  "minor": {
-    "rangeStrategy": "bump"
-  },
-  "patch": {
-    "rangeStrategy": "bump"
   },
   "packageRules": [
     {


### PR DESCRIPTION
### Description

For direct dependencies package.json should always be updated

i tried this before but it looks like it has to be top level config


### Other changes

I wish there was an easier way to test renovate config changes

### Tested

no
### Related issues

