### PR TITLE
remove unused phone dependency from cli

### DIFF
--- a/.changeset/rich-glasses-lick.md
+++ b/.changeset/rich-glasses-lick.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+trim the @celo/phone-utils dependency

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,6 @@
     "@celo/explorer": "^5.0.10",
     "@celo/governance": "^5.1.1",
     "@celo/identity": "^5.1.2",
-    "@celo/phone-utils": "^6.0.2",
     "@celo/utils": "^6.0.1",
     "@celo/wallet-hsm-azure": "^5.2.0",
     "@celo/wallet-ledger": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1615,7 +1615,6 @@ __metadata:
     "@celo/explorer": "npm:^5.0.10"
     "@celo/governance": "npm:^5.1.1"
     "@celo/identity": "npm:^5.1.2"
-    "@celo/phone-utils": "npm:^6.0.2"
     "@celo/typescript": "workspace:^"
     "@celo/utils": "npm:^6.0.1"
     "@celo/wallet-hsm-azure": "npm:^5.2.0"
@@ -1916,7 +1915,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@celo/phone-utils@npm:^6.0.2, @celo/phone-utils@workspace:packages/sdk/phone-utils":
+"@celo/phone-utils@workspace:packages/sdk/phone-utils":
   version: 0.0.0-use.local
   resolution: "@celo/phone-utils@workspace:packages/sdk/phone-utils"
   dependencies:


### PR DESCRIPTION
### Description

phone-utils was never imported anywhere in the celocli but listed as a dependency. 

Did i just cut down the weight of celocli massively?  (phone utils depends on google-lib-phonenumber)

### Other changes

darling **this** is a drive by change

### Tested

it built and tests passed

### Related issues


### Backwards compatibility

yes

### Documentation

unneeded. 