### PR TITLE
deprecate cip8 commands for offchain storage.

### DIFF
--- a/.changeset/slimy-cups-listen.md
+++ b/.changeset/slimy-cups-listen.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Add deprecation notice about future removal of account:offchain-read and account:offchain-write commands.These were created to showcase cip8 which has been abandond and they are presenting a high maintainence burden.

--- a/packages/cli/src/commands/account/offchain-read.ts
+++ b/packages/cli/src/commands/account/offchain-read.ts
@@ -1,9 +1,9 @@
 import { BasicDataWrapper } from '@celo/identity/lib/offchain-data-wrapper'
 import { PrivateNameAccessor, PublicNameAccessor } from '@celo/identity/lib/offchain/accessors/name'
-import { Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { BaseCommand } from '../../base'
 import { CustomArgs, CustomFlags } from '../../utils/command'
-import { OffchainDataCommand } from '../../utils/off-chain-data'
+import { DEPRECATION_NOTICE, OffchainDataCommand } from '../../utils/off-chain-data'
 
 export default class OffchainRead extends BaseCommand {
   static description = 'DEV: Reads the name from offchain storage'
@@ -23,6 +23,8 @@ export default class OffchainRead extends BaseCommand {
   static examples = ['offchain-read 0x...', 'offchain-read 0x... --from 0x... --privateKey 0x...']
 
   async run() {
+    ux.warn(DEPRECATION_NOTICE)
+
     const kit = await this.getKit()
     const {
       args: { arg1: address },

--- a/packages/cli/src/commands/account/offchain-write.ts
+++ b/packages/cli/src/commands/account/offchain-write.ts
@@ -1,8 +1,8 @@
 import { PrivateNameAccessor, PublicNameAccessor } from '@celo/identity/lib/offchain/accessors/name'
 import { privateKeyToAddress } from '@celo/utils/lib/address'
-import { Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { binaryPrompt } from '../../utils/cli'
-import { OffchainDataCommand } from '../../utils/off-chain-data'
+import { DEPRECATION_NOTICE, OffchainDataCommand } from '../../utils/off-chain-data'
 export default class OffchainWrite extends OffchainDataCommand {
   static description = 'DEV: Writes a name to offchain storage'
 
@@ -24,6 +24,8 @@ export default class OffchainWrite extends OffchainDataCommand {
   ]
 
   async run() {
+    ux.warn(DEPRECATION_NOTICE)
+
     const kit = await this.getKit()
     const {
       flags: { encryptTo, name, privateDEK, privateKey },

--- a/packages/cli/src/utils/off-chain-data.ts
+++ b/packages/cli/src/utils/off-chain-data.ts
@@ -60,4 +60,4 @@ export abstract class OffchainDataCommand extends BaseCommand {
 }
 
 export const DEPRECATION_NOTICE =
-  'offchain-read and offchain-write commands are deprecated as CIP8 was abandonded. They will be remove next major release.'
+  'offchain-read and offchain-write commands are deprecated as CIP8 was abandonded. They will be removed next major release.'

--- a/packages/cli/src/utils/off-chain-data.ts
+++ b/packages/cli/src/utils/off-chain-data.ts
@@ -58,3 +58,6 @@ export abstract class OffchainDataCommand extends BaseCommand {
         : new LocalStorageWriter(directory)
   }
 }
+
+export const DEPRECATION_NOTICE =
+  'offchain-read and offchain-write commands are deprecated as CIP8 was abandonded. They will be remove next major release.'


### PR DESCRIPTION
### Description

Shows a warning about the future removal of cip8 offchain commands. 

Removing these is part of a bigger initiative to remove celo/identity as a dependency of celocli as it has ben causing issues to have identity often include a different version of contractkit in its dependencies than celocli has. 

### Other changes

n/a

### Tested

n/a
### Related issues

- #222 

- https://github.com/celo-org/celo-monorepo/pull/4518|

- https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0008.md

### Backwards compatibility

yes... for now
### Documentation

