### PR TITLE
Replace homepage for npm packages

### DIFF
--- a/packages/sdk/base/package.json
+++ b/packages/sdk/base/package.json
@@ -7,7 +7,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "sideEffects": false,
-  "homepage": "https://celo-sdk-docs.readthedocs.io/en/latest/base",
+  "homepage": "https://docs.celo.org/developer/tools#celo-sdk-reference-docs",
   "repository": "https://github.com/celo-org/developer-tooling/tree/master/packages/sdk/base",
   "scripts": {
     "prepublishOnly": "yarn build",

--- a/packages/sdk/connect/package.json
+++ b/packages/sdk/connect/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "author": "Celo",
   "license": "Apache-2.0",
-  "homepage": "https://celo-sdk-docs.readthedocs.io/en/latest/connect",
+  "homepage": "https://docs.celo.org/developer/tools",
   "repository": "https://github.com/celo-org/developer-tooling/tree/master/packages/sdk/connect",
   "keywords": [
     "celo",

--- a/packages/sdk/explorer/package.json
+++ b/packages/sdk/explorer/package.json
@@ -6,7 +6,7 @@
   "types": "./lib/index.d.ts",
   "author": "Celo",
   "license": "Apache-2.0",
-  "homepage": "https://celo-sdk-docs.readthedocs.io/en/latest/explorer",
+  "homepage": "https://docs.celo.org/developer/tools",
   "repository": "https://github.com/celo-org/developer-tooling/tree/master/packages/sdk/explorer",
   "keywords": [
     "celo",

--- a/packages/sdk/keystores/package.json
+++ b/packages/sdk/keystores/package.json
@@ -11,7 +11,7 @@
     "blockchain",
     "sdk"
   ],
-  "homepage": "https://celo-sdk-docs.readthedocs.io/en/latest/keystores",
+  "homepage": "https://docs.celo.org/developer/tools",
   "repository": "https://github.com/celo-org/developer-tooling/tree/master/packages/sdk/keystores",
   "scripts": {
     "build": "yarn run --top-level tsc -b .",

--- a/packages/sdk/network-utils/package.json
+++ b/packages/sdk/network-utils/package.json
@@ -6,7 +6,7 @@
   "types": "./lib/index.d.ts",
   "author": "Celo",
   "license": "Apache-2.0",
-  "homepage": "https://celo-sdk-docs.readthedocs.io/en/latest/network-utils",
+  "homepage": "https://docs.celo.org/developer/toolss",
   "repository": "https://github.com/celo-org/developer-tooling/tree/master/packages/sdk/network-utils",
   "keywords": [
     "celo",

--- a/packages/sdk/network-utils/package.json
+++ b/packages/sdk/network-utils/package.json
@@ -6,7 +6,7 @@
   "types": "./lib/index.d.ts",
   "author": "Celo",
   "license": "Apache-2.0",
-  "homepage": "https://docs.celo.org/developer/toolss",
+  "homepage": "https://docs.celo.org/developer/tools",
   "repository": "https://github.com/celo-org/developer-tooling/tree/master/packages/sdk/network-utils",
   "keywords": [
     "celo",

--- a/packages/sdk/phone-utils/package.json
+++ b/packages/sdk/phone-utils/package.json
@@ -7,7 +7,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "sideEffects": false,
-  "homepage": "https://celo-sdk-docs.readthedocs.io/en/latest/phone-utils",
+  "homepage": "https://docs.celo.org/developer/tools",
   "repository": "https://github.com/celo-org/developer-tooling/tree/master/packages/sdk/phone-utils",
   "scripts": {
     "prepublishOnly": "yarn build",

--- a/packages/sdk/transactions-uri/package.json
+++ b/packages/sdk/transactions-uri/package.json
@@ -6,7 +6,7 @@
   "types": "./lib/index.d.ts",
   "author": "Celo",
   "license": "Apache-2.0",
-  "homepage": "https://celo-sdk-docs.readthedocs.io/en/latest/transactions-uri",
+  "homepage": "https://docs.celo.org/developer/tools",
   "repository": "https://github.com/celo-org/developer-tooling/tree/master/packages/sdk/transactions-uri",
   "keywords": [
     "celo",

--- a/packages/sdk/utils/package.json
+++ b/packages/sdk/utils/package.json
@@ -7,7 +7,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "sideEffects": false,
-  "homepage": "https://celo-sdk-docs.readthedocs.io/en/latest/utils",
+  "homepage": "https://docs.celo.org/developer/tools",
   "repository": "https://github.com/celo-org/developer-tooling/tree/master/packages/sdk/utils",
   "scripts": {
     "prepublishOnly": "yarn build",


### PR DESCRIPTION
the old celo-sdks read the docs site no longer exists. so remove references to it.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the homepage URLs in multiple `package.json` files to point to the new documentation site.

### Detailed summary
- Updated homepage URLs to `https://docs.celo.org/developer/tools`
- Updated `base` package homepage with additional anchor link for reference docs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->