### PR TITLE
Run celocli and contractkit tests always

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,13 +204,6 @@ jobs:
       id-token: write
       contents: read
     needs: [install-dependencies]
-    if: |
-
-      github.base_ref == 'master' ||  contains(github.base_ref, 'release') ||
-      contains(needs.install-dependencies.outputs.all_modified_files, 'packages/sdk') ||
-      contains(needs.install-dependencies.outputs.all_modified_files, ',package.json') ||
-      contains(needs.install-dependencies.outputs.all_modified_files, ',yarn.lock') ||
-      false
     steps:
       - uses: actions/checkout@v4
       - name: Sync workspace
@@ -233,15 +226,6 @@ jobs:
       id-token: write
       contents: read
     needs: [install-dependencies]
-    if: |
-
-      github.base_ref == 'master' || contains(github.base_ref, 'staging') || contains(github.base_ref, 'production') ||
-      contains(needs.install-dependencies.outputs.all_modified_files, 'packages/cli') ||
-      contains(needs.install-dependencies.outputs.all_modified_files, 'packages/sdk') ||
-      contains(needs.install-dependencies.outputs.all_modified_files, 'packages/typescript') ||
-      contains(needs.install-dependencies.outputs.all_modified_files, ',package.json') ||
-      contains(needs.install-dependencies.outputs.all_modified_files, ',yarn.lock') ||
-      false
     steps:
       - uses: actions/checkout@v4
       - name: Sync workspace


### PR DESCRIPTION
### Description

This PR removes conditions for running tests for CLI/contractkit in order to always have 4 reports uploaded to codecov. Otherwise the check fails when different amount of reports are uploaded due to difference in numbers.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the CI workflow conditions for `ci.yml` to streamline dependency checks and workspace syncing based on branch and modified files.

### Detailed summary
- Removed redundant conditions for base ref and modified files in CI workflow
- Simplified conditions for `id-token` job based on branch and modified files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->