### PR TITLE
Improve test setup for L2 / anvil

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,6 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: "nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9"
-      # NODE_OPTIONS="--experimental-vm-modules" is needed because @viem/anvil uses dynamic imports
       - name: Run tests
         run: |
           yarn workspace @celo/celocli test --coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
       # NODE_OPTIONS="--experimental-vm-modules" is needed because @viem/anvil uses dynamic imports
       - name: Run tests
         run: |
-          NODE_OPTIONS="--experimental-vm-modules" yarn workspace @celo/celocli test --coverage
+          yarn workspace @celo/celocli test --coverage
       - name: Verify that a new account can be created
         run: |
           yarn workspace @celo/celocli run celocli account:new

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "lint": "yarn run --top-level eslint -c .eslintrc.js ",
     "prepublish": "",
     "prepack": "yarn run build && oclif manifest && oclif readme",
-    "test": "TZ=UTC yarn jest --runInBand --forceExit"
+    "test": "TZ=UTC NODE_OPTIONS=--experimental-vm-modules yarn jest --runInBand --forceExit"
   },
   "dependencies": {
     "@celo/abis": "11.0.0",

--- a/packages/cli/src/test-utils/chain-setup.test.ts
+++ b/packages/cli/src/test-utils/chain-setup.test.ts
@@ -1,5 +1,4 @@
 import { isCel2 } from '@celo/connect'
-import { newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 import { setupL2 } from './chain-setup'
@@ -7,11 +6,9 @@ import { setupL2 } from './chain-setup'
 testWithAnvil('chain setup', (web3: Web3) => {
   describe('setupL2()', () => {
     it('sets up L2 context', async () => {
-      const kit = newKitFromWeb3(web3)
-
       expect(await isCel2(web3)).toEqual(false)
 
-      await setupL2(kit.web3)
+      await setupL2(web3)
 
       expect(await isCel2(web3)).toEqual(true)
     })

--- a/packages/cli/src/test-utils/chain-setup.test.ts
+++ b/packages/cli/src/test-utils/chain-setup.test.ts
@@ -11,7 +11,7 @@ testWithAnvil('chain setup', (web3: Web3) => {
 
       expect(await isCel2(web3)).toEqual(false)
 
-      await setupL2(kit)
+      await setupL2(kit.web3)
 
       expect(await isCel2(web3)).toEqual(true)
     })

--- a/packages/cli/src/test-utils/chain-setup.ts
+++ b/packages/cli/src/test-utils/chain-setup.ts
@@ -141,8 +141,8 @@ export const topUpWithToken = async (
 }
 
 // TODO remove this once no longer needed
-export const setupL2 = async (kit: ContractKit) => {
+export const setupL2 = async (web3: Web3) => {
   // Temporarily deploying any bytecode, so it's just there,
   // isCel2 should hence return true as it just checks for bytecode existence
-  await setCode(kit.web3, PROXY_ADMIN_ADDRESS, proxyBytecode)
+  await setCode(web3, PROXY_ADMIN_ADDRESS, proxyBytecode)
 }

--- a/packages/sdk/contractkit/package.json
+++ b/packages/sdk/contractkit/package.json
@@ -20,7 +20,7 @@
     "clean": "yarn run --top-level tsc -b . --clean",
     "prepublishOnly": "yarn build",
     "docs": "yarn run --top-level typedoc",
-    "test": "yarn run --top-level jest --runInBand --forceExit",
+    "test": "NODE_OPTIONS=--experimental-vm-modules yarn run --top-level jest --runInBand --forceExit",
     "lint": "yarn run --top-level eslint -c .eslintrc.js "
   },
   "dependencies": {


### PR DESCRIPTION
* experimental flag is always required so run it before tests always
* setupL2 only uses web3 so pass the smallest possible object, avoids creating kits we dont really need. less typing less griping.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update test configurations and dependencies in the `cli` and `contractkit` packages. 

### Detailed summary
- Updated test scripts to include `NODE_OPTIONS=--experimental-vm-modules`
- Refactored `setupL2` function parameter from `kit` to `web3`
- Removed unnecessary `NODE_OPTIONS` flag in CI workflow
- Updated test file to use `web3` directly in `setupL2` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->