### PR TITLE
Increase long timeout for tests

### DIFF
--- a/packages/cli/src/test-utils/cliUtils.ts
+++ b/packages/cli/src/test-utils/cliUtils.ts
@@ -52,4 +52,4 @@ export function stripAnsiCodesFromNestedArray(arrays: Array<string[]>) {
 }
 
 export const LONG_TIMEOUT_MS = 10 * 1000
-export const EXTRA_LONG_TIMEOUT_MS = 20 * 1000
+export const EXTRA_LONG_TIMEOUT_MS = 60 * 1000


### PR DESCRIPTION
### Description

This PR increases long timeout for some tests as they're currently timing out.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the value of `EXTRA_LONG_TIMEOUT_MS` from 20 seconds to 60 seconds in `cliUtils.ts`.

### Detailed summary
- Increased the value of `EXTRA_LONG_TIMEOUT_MS` from 20 * 1000 to 60 * 1000.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->