### PR TITLE
CLI network commands anvil / L2 

### DIFF
--- a/.changeset/gentle-suits-deliver.md
+++ b/.changeset/gentle-suits-deliver.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+network:info will not show epoch info when ran on an L2 context

--- a/.changeset/poor-moles-help.md
+++ b/.changeset/poor-moles-help.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+network:contracts no longer shows balance each contract holds of mento tokens

--- a/packages/cli/src/commands/network/__snapshots__/contracts-l2.test.ts.snap
+++ b/packages/cli/src/commands/network/__snapshots__/contracts-l2.test.ts.snap
@@ -1,0 +1,167 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`network:contracts runs 1`] = `
+[
+  [
+    "[
+  {
+    "contract": "Accounts",
+    "proxy": "0x8f24d37a4697e49AECd08d2b197E6968D2f007d3",
+    "implementation": "0xCCf2141AC0F9a8bfD248d5b176d3a0FE6e92256C",
+    "version": "1.1.5.0"
+  },
+  {
+    "contract": "BlockchainParameters",
+    "proxy": "0xFEB14C5787fd63a417612bF8Bc2232e169A7034F",
+    "implementation": "0x1FCd4C3382702553316d810ea338E5eCCF176105",
+    "version": "1.3.1.0"
+  },
+  {
+    "contract": "DoubleSigningSlasher",
+    "proxy": "0xA920a6fF4249f9A4CDdE3D67ff6275EdA6A1D89f",
+    "implementation": "0xC5F6cEC0742589fD2bD88A5391A4376d70bc272E",
+    "version": "1.1.2.0"
+  },
+  {
+    "contract": "DowntimeSlasher",
+    "proxy": "0xAADB35CAD2f922180106F50BF7ead66C5AD0f101",
+    "implementation": "0x469E41Da18317E32C5BE85cDA387c6F5003Bc3Ab",
+    "version": "2.0.1.0"
+  },
+  {
+    "contract": "Election",
+    "proxy": "0x5E386A280030a076528aD192BA94D7e31090F461",
+    "implementation": "0x8a48Bcfe922e13F03958434a54Fe9D9956Ce0Aee",
+    "version": "1.1.4.0"
+  },
+  {
+    "contract": "EpochRewards",
+    "proxy": "0xfff723D9B8f466Cd9e11BF4aaca171550aCF18Fc",
+    "implementation": "0xB81c5ab7205c329A287c9123a83f55329BCEB8e9",
+    "version": "1.1.2.0"
+  },
+  {
+    "contract": "Escrow",
+    "proxy": "0xd773882801F417427aE5C7A032296D93Fcf11DA9",
+    "implementation": "0xAA1Ed790Ab56E34d04E2746C9DDBe9ea1E38825f",
+    "version": "1.2.0.0"
+  },
+  {
+    "contract": "FederatedAttestations",
+    "proxy": "0x93f2E9307e3003a0a10A5171478CE18796aA2333",
+    "implementation": "0x2C60D99fbb3D937865c129334aB2203aeDED69A9",
+    "version": "1.1.0.0"
+  },
+  {
+    "contract": "FeeCurrencyWhitelist",
+    "proxy": "0x99f389e8a9903aF72ba481e8f000e8E229e529dA",
+    "implementation": "0x84E366f7a6d4b8F9C00c86EB22de9f1Cbfff4327",
+    "version": "NONE"
+  },
+  {
+    "contract": "FeeHandler",
+    "proxy": "0x04dE09026097347E2D540b6fbD9dC4aae3Ab0A90",
+    "implementation": "0x8495b38627e5878ab84d1729df964F319caC7EEc",
+    "version": "1.1.0.0"
+  },
+  {
+    "contract": "Freezer",
+    "proxy": "0x91dfD4C1B1262fad0f75A38D955B42b4bC586Bc1",
+    "implementation": "0x871840D455493BA55F04056D557a92AB92c5901a",
+    "version": "NONE"
+  },
+  {
+    "contract": "GasPriceMinimum",
+    "proxy": "0xb6b29b75e5616839eFc5883341042DAF72402966",
+    "implementation": "0x1d1e8F4AA7B9d263830d68BBc8C82e5Fbf30Df7E",
+    "version": "1.2.1.0"
+  },
+  {
+    "contract": "GoldToken",
+    "proxy": "0xfE8CbC1cFA1b3b8256f310bdfd40E60597083448",
+    "implementation": "0x7E25F97124321c81EE39e80241fD2eDFAbe94999",
+    "version": "1.1.2.0"
+  },
+  {
+    "contract": "Governance",
+    "proxy": "0xcF636ab1f15d3FB684A82cB1c69977DAfDFc6a0d",
+    "implementation": "0x5889dd256a2bc829dDb44C4Fb1A140967854EB05",
+    "version": "1.4.1.1"
+  },
+  {
+    "contract": "LockedGold",
+    "proxy": "0xc7F0E00681356896c06d5c810F0333ab30fBB8D1",
+    "implementation": "0x017EfF77Eea3E83f50972FaCB6A585b46495f946",
+    "version": "1.1.5.0"
+  },
+  {
+    "contract": "MentoFeeHandlerSeller",
+    "proxy": "0x677e4E735a36A7Ed935D424fCCe57a33831BF0Dc",
+    "implementation": "0x944D551Ada142aa88388d6861b3c37fc99aB08dA",
+    "version": "1.1.0.0"
+  },
+  {
+    "contract": "OdisPayments",
+    "proxy": "0xf7EfD92E61aB144483738B5F0f9cd46E6E9190BC",
+    "implementation": "0x57B99AeE2b49D4D25f071c107bEcf20862B62b08",
+    "version": "1.1.0.0"
+  },
+  {
+    "contract": "Random",
+    "proxy": "0x8982140ccFb38d7Dc439f953b37829f019A3e6e5",
+    "implementation": "0xD2C3de3802a8130F4F171a7c1eebBb812B12Cf62",
+    "version": "1.1.2.0"
+  },
+  {
+    "contract": "Registry",
+    "proxy": "0x000000000000000000000000000000000000ce10",
+    "implementation": "0xF09E8DCA7ca021a11CC5927fC8fDD3b701Acf87e",
+    "version": "NONE"
+  },
+  {
+    "contract": "Reserve",
+    "proxy": "0xe130B448fed06f3D5A2B196fAd4eE5b67f2E0805",
+    "implementation": "0x4731729cA2F9BCAF57232BF2289b6BD59ea5F085",
+    "version": "1.1.2.2"
+  },
+  {
+    "contract": "SortedOracles",
+    "proxy": "0xa2204011717369e044106e3bC93599E02538d65b",
+    "implementation": "0xfDdDF67406A5E27a03bd3c78bF468f3D28D43f05",
+    "version": "1.1.4.0"
+  },
+  {
+    "contract": "StableToken",
+    "proxy": "0xe6774BE4E5f97dB10cAFB4c00C74cFbdCDc434D9",
+    "implementation": "0x8ccF94BE2763890dcf19e3c9B6c18558da565b22",
+    "version": "NONE"
+  },
+  {
+    "contract": "StableTokenBRL",
+    "proxy": "0x2A3733dBc31980f02b12135C809b5da33BF3a1e9",
+    "implementation": "0xAd798B7e15e484D01530a6413F15d26A368cD7CC",
+    "version": "NONE"
+  },
+  {
+    "contract": "StableTokenEUR",
+    "proxy": "0xb7a33b4ad2B1f6b0a944232F5c71798d27Ad9272",
+    "implementation": "0x589f510020b7fD6c7Ec94BDD352Cb6E8EB353c8A",
+    "version": "NONE"
+  },
+  {
+    "contract": "UniswapFeeHandlerSeller",
+    "proxy": "0x27D282cBE154FD738de3242F80005cc2ca183981",
+    "implementation": "0x88C21C7772521069611777747B5E140063A03B73",
+    "version": "1.1.0.0"
+  },
+  {
+    "contract": "Validators",
+    "proxy": "0xA6aaDC309AA8E134d4a150eb4b58254801353FDc",
+    "implementation": "0xD77fFbAd6F1aEc0F62AE4e46cc9156aB2EF1b1B1",
+    "version": "1.3.0.0"
+  }
+]
+",
+  ],
+]
+`;

--- a/packages/cli/src/commands/network/__snapshots__/contracts-l2.test.ts.snap
+++ b/packages/cli/src/commands/network/__snapshots__/contracts-l2.test.ts.snap
@@ -53,6 +53,12 @@ exports[`network:contracts runs 1`] = `
     "version": "1.1.0.0"
   },
   {
+    "contract": "FeeCurrencyDirectory",
+    "proxy": "0x42Fe5a2A61ed9705eb2F08a04A58CEB606D22f6a",
+    "implementation": "0x63837e6E68C9070DF4f1CD70DCdcce4644b42b0E",
+    "version": "1.1.0.0"
+  },
+  {
     "contract": "FeeCurrencyWhitelist",
     "proxy": "0x99f389e8a9903aF72ba481e8f000e8E229e529dA",
     "implementation": "0x84E366f7a6d4b8F9C00c86EB22de9f1Cbfff4327",

--- a/packages/cli/src/commands/network/__snapshots__/contracts.test.ts.snap
+++ b/packages/cli/src/commands/network/__snapshots__/contracts.test.ts.snap
@@ -8,271 +8,163 @@ exports[`network:contracts runs 1`] = `
     "contract": "Accounts",
     "proxy": "0xa9a65D631f8c8577f543B64B35909030C84676A2",
     "implementation": "0x038C860fd0d598B3DF5577B466c8b0a074867f56",
-    "version": "1.1.4.1",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.4.1"
   },
   {
     "contract": "Attestations",
     "proxy": "0x54a582397Ace3F9a6F5A28cE6Dc50473E4A9d375",
     "implementation": "0xc650825Ca03EeB83d0d075c2737022cBb01F5799",
-    "version": "1.2.0.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.2.0.0"
   },
   {
     "contract": "BlockchainParameters",
     "proxy": "0xd418d14C9b8aA740E8D18C6dfda3af6f023A27A5",
     "implementation": "0x4CF20BEf2FBe159601939bE49B760457B11C1d52",
-    "version": "1.3.0.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.3.0.0"
   },
   {
     "contract": "DoubleSigningSlasher",
     "proxy": "0x175Ac784563DE645647C6350F0CFc577Dcc7eE5b",
     "implementation": "0xA47aA5fCecBfb374E79144F05fDf91D0F50fA351",
-    "version": "1.1.1.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.1.0"
   },
   {
     "contract": "DowntimeSlasher",
     "proxy": "0x0C5173a51e26b29d6126C686756FB9FBEf71f762",
     "implementation": "0x33a89cA59bc3A9221456ffE461de17C8deF24684",
-    "version": "2.0.0.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "2.0.0.0"
   },
   {
     "contract": "Election",
     "proxy": "0xcBAe15A320F56Fc9ad6c8319D55Be1FeF0750070",
     "implementation": "0x51815ebd3C922B215b0d0B9b41a4Daa0dB70b841",
-    "version": "1.1.3.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.3.0"
   },
   {
     "contract": "EpochRewards",
     "proxy": "0x537732b0bAC4F2A1a97b1a60cEa0df5C3f0DEF16",
     "implementation": "0x1E28a5fB7B112291F088bBB8ab693D2214DB7895",
-    "version": "1.1.1.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.1.0"
   },
   {
     "contract": "Escrow",
     "proxy": "0xE8593eFb73423D86e5F337A46B3450eEec1027c6",
     "implementation": "0xc51B43db0Cea40E36207993F0aB1883E7A865417",
-    "version": "1.2.0.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.2.0.0"
   },
   {
     "contract": "FederatedAttestations",
     "proxy": "0x8C3d218745c360A399285c0176714530Ce0af3B1",
     "implementation": "0x9d0e84A58Bb5B9b94F5c34fD4f310ed3F41A2D69",
-    "version": "1.1.0.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.0.0"
   },
   {
     "contract": "FeeCurrencyWhitelist",
     "proxy": "0xE86bB98fcF9BFf3512C74589B78Fb168200CC546",
     "implementation": "0xDc688D29394a3f1E6f1E5100862776691afAf3d2",
-    "version": "NONE",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "NONE"
   },
   {
     "contract": "FeeHandler",
     "proxy": "0x176097114008844bCb75Ea58998B7f8303b4C2d4",
     "implementation": "0x123d0530A2a37FA4d4efA3999e79203BAf5bE517",
-    "version": "1.1.0.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.0.0"
   },
   {
     "contract": "Freezer",
     "proxy": "0xcFC18CEc799fBD1793B5C43E773C98D4d61Cc2dB",
     "implementation": "0xF22469F31527adc53284441bae1665A7b9214DBA",
-    "version": "NONE",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "NONE"
   },
   {
     "contract": "GasPriceMinimum",
     "proxy": "0x038F9B392Fb9A9676DbAddF78EA5fdbf6C7d9710",
     "implementation": "0x371b13d97f4bF77d724E78c16B7dC74099f40e84",
-    "version": "1.2.0.1",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.2.0.1"
   },
   {
     "contract": "GoldToken",
     "proxy": "0x04B5dAdd2c0D6a261bfafBc964E0cAc48585dEF3",
     "implementation": "0x8726C7414ac023D23348326B47AF3205185Fd035",
-    "version": "1.1.2.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.2.0"
   },
   {
     "contract": "Governance",
     "proxy": "0x82E9A894F6b752E5c1058ea69898Ff5D3EBA3939",
     "implementation": "0xc98E260cBF7041cc2C42D7e055fb4350DF22dd68",
-    "version": "1.4.1.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.4.1.0"
   },
   {
     "contract": "LockedGold",
     "proxy": "0x4A86aD5f263260f24483Df2B1B3a23ea4788B6AB",
     "implementation": "0x0221652D4306F6b3CB7B23E43C3e25D8F9a142Ca",
-    "version": "1.1.4.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.4.0"
   },
   {
     "contract": "MentoFeeHandlerSeller",
     "proxy": "0x98942DE2B8eaC1c264e41cA981b82032762d72a4",
     "implementation": "0x8501835ac2B234147F766bB6e6423D6Ef50A9247",
-    "version": "1.1.0.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.0.0"
   },
   {
     "contract": "OdisPayments",
     "proxy": "0x347BfD5F56F04210603c9cC7c6c1f88E9E5c9676",
     "implementation": "0x05E0c172eB6244A564B0D9e59Ce63074584a1e7A",
-    "version": "1.1.0.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.0.0"
   },
   {
     "contract": "Random",
     "proxy": "0xd2dBF3250a764eaaa94fa0C84ED87C0Edc8eD04E",
     "implementation": "0x39c3Fc9F4D8430af2713306CE80C584752d9e1C7",
-    "version": "1.1.1.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.1.0"
   },
   {
     "contract": "Registry",
     "proxy": "0x000000000000000000000000000000000000ce10",
     "implementation": "0x07f96Aa816C1F244CbC6ef114bB2b023Ba54a2EB",
-    "version": "NONE",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "NONE"
   },
   {
     "contract": "Reserve",
     "proxy": "0xCA9717a4A6e8009B3518648C9f3E7676255471A1",
     "implementation": "0x4586649629F699f9A4B61D0e962DC3c9025Fe488",
-    "version": "1.1.2.2",
-    "CELO": "1.000e+26",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.2.2"
   },
   {
     "contract": "SortedOracles",
     "proxy": "0x4D3d5c850Dd5bD9D6F4AdDA3DD039a3C8054CA29",
     "implementation": "0xA31E64EA55B9B6Bbb9d6A676738e9A5b23149f84",
-    "version": "1.1.3.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.3.0"
   },
   {
     "contract": "StableToken",
     "proxy": "0x5315e44798395d4a952530d131249fE00f554565",
     "implementation": "0xDFF540fE764855D3175DcfAe9d91AE8aEE5C6D6F",
-    "version": "NONE",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "NONE"
   },
   {
     "contract": "StableTokenBRL",
     "proxy": "0x965D352283a3C8A016b9BBbC9bf6306665d495E7",
     "implementation": "0x9a1df498af690a7EB43E10A28AB51345a3A33F75",
-    "version": "NONE",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "NONE"
   },
   {
     "contract": "StableTokenEUR",
     "proxy": "0xdD66C23e07b4D6925b6089b5Fe6fc9E62941aFE8",
     "implementation": "0x4609e0ED27A8BAAc57b753D36a5D2971915588f9",
-    "version": "NONE",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "NONE"
   },
   {
     "contract": "UniswapFeeHandlerSeller",
     "proxy": "0x9EF3dACB3367d7741099b5607A7a93E99a119F7b",
     "implementation": "0x0F3723fB2a7C147357868702164f9beEf54E1E85",
-    "version": "1.1.0.0",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.1.0.0"
   },
   {
     "contract": "Validators",
     "proxy": "0x6AC7189BD267c81c55d7d7d0321f9B23639cB9db",
     "implementation": "0x3E809c563c15a295E832e37053798DdC8d6C8dab",
-    "version": "1.2.0.5",
-    "CELO": "0",
-    "cUSD": "0",
-    "cEUR": "0",
-    "cREAL": "0"
+    "version": "1.2.0.5"
   }
 ]
 ",

--- a/packages/cli/src/commands/network/contracts-l2.test.ts
+++ b/packages/cli/src/commands/network/contracts-l2.test.ts
@@ -1,0 +1,15 @@
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import write from '@oclif/core/lib/cli-ux/write'
+import { setupL2 } from '../../test-utils/chain-setup'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import Contracts from './contracts'
+process.env.NO_SYNCCHECK = 'true'
+
+testWithAnvil('network:contracts', (web3) => {
+  test('runs', async () => {
+    await setupL2(web3)
+    const spy = jest.spyOn(write, 'stdout')
+    await testLocallyWithWeb3Node(Contracts, ['--output', 'json'], web3)
+    expect(spy.mock.calls).toMatchSnapshot()
+  })
+})

--- a/packages/cli/src/commands/network/contracts.ts
+++ b/packages/cli/src/commands/network/contracts.ts
@@ -67,18 +67,6 @@ export default class Contracts extends BaseCommand {
       }
     )
 
-    const tokenBalanceColumns: ux.Table.table.Columns<(typeof contractInfo)[number]> = {}
-    await kit.celoTokens.forEachCeloToken(
-      (token) =>
-        (tokenBalanceColumns[token.symbol] = {
-          header: token.symbol,
-          get: (i) => {
-            const balance = i.balances[token.symbol]!
-            return balance.isZero() ? '0' : balance.toExponential(3)
-          },
-        })
-    )
-
     ux.table(
       contractInfo,
       {
@@ -88,7 +76,6 @@ export default class Contracts extends BaseCommand {
         version: {
           get: (i) => i.version,
         },
-        ...tokenBalanceColumns,
       },
       { sort: 'contract', ...res.flags }
     )

--- a/packages/cli/src/commands/network/info-l2.test.ts
+++ b/packages/cli/src/commands/network/info-l2.test.ts
@@ -1,0 +1,22 @@
+import { newKitFromWeb3 } from '@celo/contractkit'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { setupL2 } from '../../test-utils/chain-setup'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import Info from './info'
+process.env.NO_SYNCCHECK = 'true'
+
+testWithAnvil('network:info', (web3) => {
+  test('runs', async () => {
+    const kit = newKitFromWeb3(web3)
+    await setupL2(kit.web3)
+    const spy = jest.spyOn(console, 'log')
+    await testLocallyWithWeb3Node(Info, [], web3)
+    expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "blockNumber: 249",
+        ],
+      ]
+    `)
+  })
+})

--- a/packages/cli/src/commands/network/info.ts
+++ b/packages/cli/src/commands/network/info.ts
@@ -1,4 +1,5 @@
-import { Flags } from '@oclif/core'
+import { isCel2 } from '@celo/connect'
+import { Flags, ux } from '@oclif/core'
 import { BaseCommand } from '../../base'
 import { printValueMapRecursive } from '../../utils/cli'
 
@@ -18,8 +19,18 @@ export default class Info extends BaseCommand {
   async run() {
     const kit = await this.getKit()
     const res = await this.parse(Info)
+    const isL2 = await isCel2(kit.connection.web3)
 
     const blockNumber = await kit.connection.getBlockNumber()
+
+    if (isL2) {
+      ux.info('Celo no longer has epochs')
+      printValueMapRecursive({
+        blockNumber,
+      })
+      return
+    }
+
     const latestEpochNumber = await kit.getEpochNumberOfBlock(blockNumber)
     const epochSize = await kit.getEpochSize()
 

--- a/packages/cli/src/commands/network/parameters-l2.test.ts
+++ b/packages/cli/src/commands/network/parameters-l2.test.ts
@@ -1,0 +1,94 @@
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { setupL2 } from '../../test-utils/chain-setup'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import Parameters from './parameters'
+
+process.env.NO_SYNCCHECK = 'true'
+
+testWithAnvil('network:parameters', (web3) => {
+  test('runs', async () => {
+    await setupL2(web3)
+    const spy = jest.spyOn(console, 'log')
+    await testLocallyWithWeb3Node(Parameters, [], web3)
+    expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "Attestations: 
+      Failed to fetch config for contract Attestations: 
+      Error: Attestations not (yet) registered
+      BlockchainParameters: 
+        blockGasLimit: 13000000 (~1.300e+7)
+        intrinsicGasForAlternativeFeeCurrency: 50000 (~5.000e+4)
+      DowntimeSlasher: 
+        slashableDowntime: 5 minutes
+        slashingIncentives: 
+          penalty: 100000000000000000000 (~1.000e+20)
+          reward: 10000000000000000000 (~1.000e+19)
+      Election: 
+        currentThreshold: 0 
+        electabilityThreshold: 0.001 
+        electableValidators: 
+          max: 100 
+          min: 1 
+        maxNumGroupsVotedFor: 10 
+        totalVotes: 0 
+      EpochRewards: 
+        carbonOffsetting: 
+          factor: 0.001 
+          partner: 0x0000000000000000000000000000000000000000
+        communityReward: 0.25 
+        rewardsMultiplier: 
+          max: 0 
+          overspendAdjustment: 5 
+          underspendAdjustment: 0.5 
+        targetValidatorEpochPayment: 205479452054794520547 (~2.055e+20)
+        targetVotingYield: 
+          adjustment: 0 
+          max: 0.0005 
+          target: 0 
+      GasPriceMinimum: 
+        adjustmentSpeed: 0.5 
+        gasPriceMinimum: 100000000 (~1.000e+8)
+        targetDensity: 0.5 
+      Governance: 
+        concurrentProposals: 3 
+        dequeueFrequency: 4 hours
+        minDeposit: 100000000000000000000 (~1.000e+20)
+        participationParameters: 
+          baseline: 0.005 
+          baselineFloor: 0.01 
+          baselineQuorumFactor: 1 
+          baselineUpdateFactor: 0.2 
+        queueExpiry: 4 weeks
+        stageDurations: 
+          Execution: 1 week
+          Referendum: 1 day
+      LockedGold: 
+        totalLockedGold: 0 
+        unlockingPeriod: 6 hours
+      Reserve: 
+        frozenReserveGoldDays: 0 
+        frozenReserveGoldStartBalance: 0 
+        frozenReserveGoldStartDay: 19877 (~1.988e+4)
+        otherReserveAddresses: 
+
+        tobinTaxStalenessThreshold: 3153600000 (~3.154e+9)
+      SortedOracles: 
+        reportExpiry: 5 minutes
+      Validators: 
+        commissionUpdateDelay: 3 days
+        downtimeGracePeriod: 0 
+        groupLockedGoldRequirements: 
+          duration: 6 months
+          value: 10000000000000000000000 (~1.000e+22)
+        maxGroupSize: 5 
+        membershipHistoryLength: 60 
+        slashingMultiplierResetPeriod: 1 month
+        validatorLockedGoldRequirements: 
+          duration: 2 months
+          value: 10000000000000000000000 (~1.000e+22)",
+        ],
+      ]
+    `)
+  })
+})

--- a/packages/cli/src/commands/network/whitelist.ts
+++ b/packages/cli/src/commands/network/whitelist.ts
@@ -23,6 +23,7 @@ export default class Whitelist extends BaseCommand {
           adaptedToken ? ` (adapted token: ${adaptedToken})` : ''
         }`
     )
+    // if we use ux.table for this instead then people could pass --csv or --json to get the data how they need it
     console.log(`Available currencies:\n${pairs.join('\n')}`)
   }
 }


### PR DESCRIPTION
### Description

- [x] add anvil /l2 test for network commands
- [x] remove displaying balance of tokens
- [x] remove epoch info when in L2 context

### Other changes
 Leave a note about changing whitelist in future

### Tested

new tests. 
### Related issues

- Fixes [#265](https://github.com/celo-org/celo-blockchain-planning/issues/265)

### Backwards compatibility

some output has changed for commands

### Documentation

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `@celo/celocli` commands related to network information and contracts. It enhances data presentation and handles L2 context gracefully.

### Detailed summary
- Improved data display for network information and contracts
- Added handling for L2 context in commands
- Updated table rendering for contract balances

> The following files were skipped due to too many changes: `packages/cli/src/commands/network/__snapshots__/contracts.test.ts.snap`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->