### PR TITLE
docs: fixes small typo in URLs of various READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/docs/sdk/connect/README.md
+++ b/docs/sdk/connect/README.md
@@ -13,7 +13,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/docs/sdk/contractkit/README.md
+++ b/docs/sdk/contractkit/README.md
@@ -30,7 +30,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/docs/sdk/cryptographic-utils/README.md
+++ b/docs/sdk/cryptographic-utils/README.md
@@ -17,7 +17,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/docs/sdk/phone-utils/README.md
+++ b/docs/sdk/phone-utils/README.md
@@ -17,7 +17,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,7 +23,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/base/README.MD
+++ b/packages/sdk/base/README.MD
@@ -12,7 +12,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/connect/README.md
+++ b/packages/sdk/connect/README.md
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/contractkit/README.md
+++ b/packages/sdk/contractkit/README.md
@@ -28,7 +28,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/cryptographic-utils/README.md
+++ b/packages/sdk/cryptographic-utils/README.md
@@ -15,7 +15,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/explorer/README.md
+++ b/packages/sdk/explorer/README.md
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/governance/README.md
+++ b/packages/sdk/governance/README.md
@@ -15,7 +15,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/keystores/README.md
+++ b/packages/sdk/keystores/README.md
@@ -9,7 +9,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/network-utils/README.md
+++ b/packages/sdk/network-utils/README.md
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/phone-utils/README.md
+++ b/packages/sdk/phone-utils/README.md
@@ -15,7 +15,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/transactions-uri/README.md
+++ b/packages/sdk/transactions-uri/README.md
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/utils/README.md
+++ b/packages/sdk/utils/README.md
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/wallets/wallet-base/Readme.md
+++ b/packages/sdk/wallets/wallet-base/Readme.md
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/wallets/wallet-hsm-aws/README.MD
+++ b/packages/sdk/wallets/wallet-hsm-aws/README.MD
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/wallets/wallet-hsm-azure/README.md
+++ b/packages/sdk/wallets/wallet-hsm-azure/README.md
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/wallets/wallet-hsm-gcp/README.md
+++ b/packages/sdk/wallets/wallet-hsm-gcp/README.md
@@ -9,7 +9,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/wallets/wallet-hsm/README.md
+++ b/packages/sdk/wallets/wallet-hsm/README.md
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/wallets/wallet-ledger/README.MD
+++ b/packages/sdk/wallets/wallet-ledger/README.MD
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/wallets/wallet-local/Readme.MD
+++ b/packages/sdk/wallets/wallet-local/Readme.MD
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/wallets/wallet-remote/README.md
+++ b/packages/sdk/wallets/wallet-remote/README.md
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 

--- a/packages/sdk/wallets/wallet-rpc/README.md
+++ b/packages/sdk/wallets/wallet-rpc/README.md
@@ -11,7 +11,7 @@ Please use GitHub to:
 
 💬 [Ask a question](https://github.com/celo-org/developer-tooling/discussions)
 
-✨ [Suggest a feature](httpsi//github.com/celo-org/developer-tooling/issues/new/choose)
+✨ [Suggest a feature](https://github.com/celo-org/developer-tooling/issues/new/choose)
 
 🧑‍💻 [Contribute!](/CONTRIBUTING.md)
 


### PR DESCRIPTION
### Description

Fixes small typo in the URL of multiple `README` files. The typo is the same in all files, because it's a paragraph that I copy/pasted into all READMEs in the past.

### Other changes

None

### Tested

No.

### Related issues

None

### Backwards compatibility

Yes.

### Documentation

Yes

<!-- start pr-codex -->

---

## PR-Codex overview
This PR corrects a typo in a URL link in the README.md file and adds a missing newline at the end of the file.

### Detailed summary
- Fixed a typo in the "Suggest a feature" URL link
- Added a newline at the end of the file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->