### PR TITLE
Anvil Migrate: Fed Attestate

### DIFF
--- a/.changeset/dry-plants-happen.md
+++ b/.changeset/dry-plants-happen.md
@@ -1,0 +1,5 @@
+---
+'@celo/connect': patch
+---
+
+signTypedData now defaults to eth_signTypedDataV4 pass null for the previous behavior. this is due to v4 being the recommended way to use signTypedData and the only version supported by anvil.

--- a/docs/sdk/connect/classes/connection.Connection.md
+++ b/docs/sdk/connect/classes/connection.Connection.md
@@ -802,11 +802,11 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `signer` | `string` |
-| `typedData` | `EIP712TypedData` |
-| `version?` | ``1`` \| ``3`` \| ``4`` \| ``5`` |
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `signer` | `string` | `undefined` |
+| `typedData` | `EIP712TypedData` | `undefined` |
+| `version` | ``null`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` | `4` |
 
 #### Returns
 

--- a/packages/sdk/connect/src/connection.ts
+++ b/packages/sdk/connect/src/connection.ts
@@ -266,7 +266,7 @@ export class Connection {
   signTypedData = async (
     signer: string,
     typedData: EIP712TypedData,
-    version?: 1 | 3 | 4 | 5
+    version: 1 | 3 | 4 | 5 | null = 4
   ): Promise<Signature> => {
     // stringify data for v3 & v4 based on https://github.com/MetaMask/metamask-extension/blob/c72199a1a6e4151c40c22f79d0f3b6ed7a2d59a7/app/scripts/lib/typed-message-manager.js#L185
     const shouldStringify = version === 3 || version === 4

--- a/packages/sdk/contractkit/src/wrappers/FederatedAttestations.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/FederatedAttestations.test.ts
@@ -1,9 +1,9 @@
 import { StrongAddress } from '@celo/base'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import { newKitFromWeb3 } from '../kit'
 import { FederatedAttestationsWrapper } from './FederatedAttestations'
 
-testWithGanache('FederatedAttestations Wrapper', (web3) => {
+testWithAnvil('FederatedAttestations Wrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
   const TIME_STAMP = 1665080820
   let accounts: StrongAddress[] = []
@@ -50,11 +50,6 @@ testWithGanache('FederatedAttestations Wrapper', (web3) => {
 
     const accountInstance = await kit.contracts.getAccounts()
     await accountInstance.createAccount().sendAndWaitForReceipt({ from: issuer })
-
-    // Ganache returns 1 in chainId assembly code
-    // @ts-ignore
-    jest.spyOn<any, any>(kit.connection, 'chainId').mockReturnValue(1)
-
     const celoTransactionObject = await federatedAttestations.registerAttestation(
       testIdentifierBytes32,
       issuer,


### PR DESCRIPTION
### Description

migrates FederatedAttestationsWrapper tests to run against anvil

### Other changes

testing revealed that anvil only supports sign_typed_data_V4 so ive made that the default. 

### Tested

100%
### Related issues

- Fixes 

### Backwards compatibility

is it? the behavior changed but the api is the same. 
### Documentation

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `signTypedData` function to default to `eth_signTypedDataV4` and adds support for `null` version. It also replaces Ganache with Anvil for testing `FederatedAttestations`.

### Detailed summary
- `signTypedData` now defaults to `eth_signTypedDataV4` with support for `null` version
- Updated default values in `Connection` class documentation
- Replaced Ganache with Anvil for testing `FederatedAttestations`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->