### PR TITLE
Add FeeCurrencyDirectoryWrapper config to network:parameters command

### DIFF
--- a/.changeset/spotty-bats-visit.md
+++ b/.changeset/spotty-bats-visit.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Changes network:parameters to include FeeCurrencyDirectory data

--- a/.changeset/strong-kiwis-jam.md
+++ b/.changeset/strong-kiwis-jam.md
@@ -1,0 +1,5 @@
+---
+'@celo/contractkit': minor
+---
+
+Introduces getConfig for FeeCurrencyDirectoryWrapper

--- a/docs/sdk/contractkit/classes/kit.ContractKit.md
+++ b/docs/sdk/contractkit/classes/kit.ContractKit.md
@@ -63,7 +63,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:106](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L106)
+[packages/sdk/contractkit/src/kit.ts:113](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L113)
 
 ## Properties
 
@@ -75,7 +75,7 @@ factory for core contract's native web3 wrappers
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:97](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L97)
+[packages/sdk/contractkit/src/kit.ts:104](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L104)
 
 ___
 
@@ -87,7 +87,7 @@ helper for interacting with CELO & stable tokens
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:101](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L101)
+[packages/sdk/contractkit/src/kit.ts:108](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L108)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:106](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L106)
+[packages/sdk/contractkit/src/kit.ts:113](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L113)
 
 ___
 
@@ -109,7 +109,7 @@ factory for core contract's kit wrappers
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:99](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L99)
+[packages/sdk/contractkit/src/kit.ts:106](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L106)
 
 ___
 
@@ -123,7 +123,7 @@ no longer needed since gasPrice is available on node rpc
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:104](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L104)
+[packages/sdk/contractkit/src/kit.ts:111](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L111)
 
 ___
 
@@ -135,7 +135,7 @@ core contract's address registry
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:95](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L95)
+[packages/sdk/contractkit/src/kit.ts:102](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L102)
 
 ## Accessors
 
@@ -149,7 +149,7 @@ core contract's address registry
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:226](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L226)
+[packages/sdk/contractkit/src/kit.ts:237](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L237)
 
 • `set` **defaultAccount**(`address`): `void`
 
@@ -165,7 +165,7 @@ core contract's address registry
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:222](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L222)
+[packages/sdk/contractkit/src/kit.ts:233](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L233)
 
 ___
 
@@ -179,7 +179,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:242](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L242)
+[packages/sdk/contractkit/src/kit.ts:253](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L253)
 
 • `set` **defaultFeeCurrency**(`address`): `void`
 
@@ -195,7 +195,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:238](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L238)
+[packages/sdk/contractkit/src/kit.ts:249](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L249)
 
 ___
 
@@ -209,7 +209,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:234](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L234)
+[packages/sdk/contractkit/src/kit.ts:245](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L245)
 
 • `set` **gasInflationFactor**(`factor`): `void`
 
@@ -225,7 +225,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:230](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L230)
+[packages/sdk/contractkit/src/kit.ts:241](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L241)
 
 ___
 
@@ -239,7 +239,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:273](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L273)
+[packages/sdk/contractkit/src/kit.ts:284](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L284)
 
 ## Methods
 
@@ -259,7 +259,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:218](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L218)
+[packages/sdk/contractkit/src/kit.ts:229](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L229)
 
 ___
 
@@ -279,7 +279,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:209](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L209)
+[packages/sdk/contractkit/src/kit.ts:220](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L220)
 
 ___
 
@@ -293,7 +293,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:194](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L194)
+[packages/sdk/contractkit/src/kit.ts:205](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L205)
 
 ___
 
@@ -313,7 +313,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:199](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L199)
+[packages/sdk/contractkit/src/kit.ts:210](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L210)
 
 ___
 
@@ -327,7 +327,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:180](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L180)
+[packages/sdk/contractkit/src/kit.ts:191](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L191)
 
 ___
 
@@ -347,7 +347,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:204](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L204)
+[packages/sdk/contractkit/src/kit.ts:215](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L215)
 
 ___
 
@@ -367,7 +367,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:134](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L134)
+[packages/sdk/contractkit/src/kit.ts:141](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L141)
 
 ___
 
@@ -387,7 +387,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:117](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L117)
+[packages/sdk/contractkit/src/kit.ts:124](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L124)
 
 ___
 
@@ -401,7 +401,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:113](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L113)
+[packages/sdk/contractkit/src/kit.ts:120](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L120)
 
 ___
 
@@ -415,7 +415,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:246](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L246)
+[packages/sdk/contractkit/src/kit.ts:257](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L257)
 
 ___
 
@@ -429,7 +429,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:250](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L250)
+[packages/sdk/contractkit/src/kit.ts:261](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L261)
 
 ___
 
@@ -449,7 +449,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:254](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L254)
+[packages/sdk/contractkit/src/kit.ts:265](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L265)
 
 ___
 
@@ -470,7 +470,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:258](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L258)
+[packages/sdk/contractkit/src/kit.ts:269](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L269)
 
 ___
 
@@ -496,7 +496,7 @@ Throws if supplied address is not a valid hexadecimal address
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:187](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L187)
+[packages/sdk/contractkit/src/kit.ts:198](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L198)
 
 ___
 
@@ -517,7 +517,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:265](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L265)
+[packages/sdk/contractkit/src/kit.ts:276](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L276)
 
 ___
 
@@ -531,4 +531,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:269](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L269)
+[packages/sdk/contractkit/src/kit.ts:280](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L280)

--- a/docs/sdk/contractkit/classes/wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryWrapper.md
@@ -34,6 +34,7 @@ FeeCurrencyDirectory contract listing available currencies usable to pay fees
 ### Methods
 
 - [getAddresses](wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryWrapper.md#getaddresses)
+- [getConfig](wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryWrapper.md#getconfig)
 - [getFeeCurrencyInformation](wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryWrapper.md#getfeecurrencyinformation)
 - [getPastEvents](wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryWrapper.md#getpastevents)
 - [version](wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryWrapper.md#version)
@@ -120,7 +121,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts:11](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts#L11)
+[packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts:17](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts#L17)
 
 ___
 
@@ -144,7 +145,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts:32](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts#L32)
+[packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts:38](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts#L38)
 
 ___
 
@@ -168,7 +169,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts:21](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts#L21)
+[packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts:27](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts#L27)
 
 ___
 
@@ -220,7 +221,23 @@ AbstractFeeCurrencyWrapper.address
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts:17](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts#L17)
+[packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts:23](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts#L23)
+
+___
+
+### getConfig
+
+▸ **getConfig**(): `Promise`\<[`FeeCurrencyDirectoryConfig`](../interfaces/wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryConfig.md)\>
+
+Returns current configuration parameters.
+
+#### Returns
+
+`Promise`\<[`FeeCurrencyDirectoryConfig`](../interfaces/wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryConfig.md)\>
+
+#### Defined in
+
+[packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts:52](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts#L52)
 
 ___
 

--- a/docs/sdk/contractkit/interfaces/kit.NetworkConfig.md
+++ b/docs/sdk/contractkit/interfaces/kit.NetworkConfig.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:66](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L66)
+[packages/sdk/contractkit/src/kit.ts:73](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L73)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:74](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L74)
+[packages/sdk/contractkit/src/kit.ts:81](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L81)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:73](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L73)
+[packages/sdk/contractkit/src/kit.ts:80](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L80)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:65](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L65)
+[packages/sdk/contractkit/src/kit.ts:72](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L72)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:70](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L70)
+[packages/sdk/contractkit/src/kit.ts:77](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L77)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:67](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L67)
+[packages/sdk/contractkit/src/kit.ts:74](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L74)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:68](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L68)
+[packages/sdk/contractkit/src/kit.ts:75](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L75)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:71](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L71)
+[packages/sdk/contractkit/src/kit.ts:78](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L78)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:69](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L69)
+[packages/sdk/contractkit/src/kit.ts:76](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L76)
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:64](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L64)
+[packages/sdk/contractkit/src/kit.ts:71](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L71)
 
 ___
 
@@ -128,4 +128,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:72](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L72)
+[packages/sdk/contractkit/src/kit.ts:79](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L79)

--- a/docs/sdk/contractkit/interfaces/wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryConfig.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryConfig.md
@@ -1,0 +1,25 @@
+[@celo/contractkit](../README.md) / [Exports](../modules.md) / [wrappers/FeeCurrencyDirectoryWrapper](../modules/wrappers_FeeCurrencyDirectoryWrapper.md) / FeeCurrencyDirectoryConfig
+
+# Interface: FeeCurrencyDirectoryConfig
+
+[wrappers/FeeCurrencyDirectoryWrapper](../modules/wrappers_FeeCurrencyDirectoryWrapper.md).FeeCurrencyDirectoryConfig
+
+## Table of contents
+
+### Properties
+
+- [intrinsicGasForAlternativeFeeCurrency](wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryConfig.md#intrinsicgasforalternativefeecurrency)
+
+## Properties
+
+### intrinsicGasForAlternativeFeeCurrency
+
+• **intrinsicGasForAlternativeFeeCurrency**: `Object`
+
+#### Index signature
+
+▪ [feeCurrencyAddress: `StrongAddress`]: `BigNumber`
+
+#### Defined in
+
+[packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts:8](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts#L8)

--- a/docs/sdk/contractkit/modules/kit.md
+++ b/docs/sdk/contractkit/modules/kit.md
@@ -65,7 +65,7 @@ options to pass to the Web3 HttpProvider constructor
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:39](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L39)
+[packages/sdk/contractkit/src/kit.ts:46](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L46)
 
 ___
 
@@ -88,7 +88,7 @@ Creates a new instance of the `ContractKit` with a web3 instance
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:59](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L59)
+[packages/sdk/contractkit/src/kit.ts:66](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L66)
 
 ___
 
@@ -116,4 +116,4 @@ wallet to reuse or add a wallet different than the default (example ledger-walle
 
 #### Defined in
 
-[packages/sdk/contractkit/src/kit.ts:50](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L50)
+[packages/sdk/contractkit/src/kit.ts:57](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/kit.ts#L57)

--- a/docs/sdk/contractkit/modules/wrappers_FeeCurrencyDirectoryWrapper.md
+++ b/docs/sdk/contractkit/modules/wrappers_FeeCurrencyDirectoryWrapper.md
@@ -7,3 +7,7 @@
 ### Classes
 
 - [FeeCurrencyDirectoryWrapper](../classes/wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryWrapper.md)
+
+### Interfaces
+
+- [FeeCurrencyDirectoryConfig](../interfaces/wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryConfig.md)

--- a/packages/cli/src/commands/network/parameters-l2.test.ts
+++ b/packages/cli/src/commands/network/parameters-l2.test.ts
@@ -46,6 +46,11 @@ testWithAnvil('network:parameters', (web3) => {
           adjustment: 0 
           max: 0.0005 
           target: 0 
+      FeeCurrencyDirectory: 
+        intrinsicGasForAlternativeFeeCurrency: 
+          0x2A3733dBc31980f02b12135C809b5da33BF3a1e9: 21000 (~2.100e+4)
+          0xb7a33b4ad2B1f6b0a944232F5c71798d27Ad9272: 21000 (~2.100e+4)
+          0xe6774BE4E5f97dB10cAFB4c00C74cFbdCDc434D9: 21000 (~2.100e+4)
       GasPriceMinimum: 
         adjustmentSpeed: 0.5 
         gasPriceMinimum: 100000000 (~1.000e+8)

--- a/packages/sdk/contractkit/src/kit.ts
+++ b/packages/sdk/contractkit/src/kit.ts
@@ -1,6 +1,13 @@
 // tslint:disable: ordered-imports
 import { StrongAddress } from '@celo/base'
-import { CeloTx, CeloTxObject, Connection, ReadOnlyWallet, TransactionResult } from '@celo/connect'
+import {
+  CeloTx,
+  CeloTxObject,
+  Connection,
+  ReadOnlyWallet,
+  TransactionResult,
+  isCel2,
+} from '@celo/connect'
 import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils'
 import { Signature } from '@celo/utils/lib/signatureUtils'
 import { LocalWallet } from '@celo/wallet-local'
@@ -147,6 +154,10 @@ export class ContractKit {
       CeloContract.BlockchainParameters,
       CeloContract.EpochRewards,
     ]
+
+    if (await isCel2(this.web3)) {
+      configContracts.push(CeloContract.FeeCurrencyDirectory)
+    }
 
     const configMethod = async (contract: ValidWrappers) => {
       try {

--- a/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.test.ts
@@ -52,4 +52,19 @@ testWithAnvil('FeeCurrencyDirectory', (web3) => {
       }
     `)
   })
+
+  it('fetches config', async () => {
+    const wrapper = await kit.contracts.getFeeCurrencyDirectory()
+    const config = await wrapper.getConfig()
+
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "intrinsicGasForAlternativeFeeCurrency": {
+          "0x2A3733dBc31980f02b12135C809b5da33BF3a1e9": "21000",
+          "0xb7a33b4ad2B1f6b0a944232F5c71798d27Ad9272": "21000",
+          "0xe6774BE4E5f97dB10cAFB4c00C74cFbdCDc434D9": "21000",
+        },
+      }
+    `)
+  })
 })

--- a/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts
+++ b/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.ts
@@ -4,6 +4,12 @@ import BigNumber from 'bignumber.js'
 import { AbstractFeeCurrencyWrapper } from './AbstractFeeCurrencyWrapper'
 import { proxyCall, valueToBigNumber } from './BaseWrapper'
 
+export interface FeeCurrencyDirectoryConfig {
+  intrinsicGasForAlternativeFeeCurrency: {
+    [feeCurrencyAddress: StrongAddress]: BigNumber
+  }
+}
+
 /**
  * FeeCurrencyDirectory contract listing available currencies usable to pay fees
  */
@@ -39,4 +45,20 @@ export class FeeCurrencyDirectoryWrapper extends AbstractFeeCurrencyWrapper<FeeC
       intrinsicGas: valueToBigNumber(res.intrinsicGas),
     })
   )
+
+  /**
+   * Returns current configuration parameters.
+   */
+  async getConfig(): Promise<FeeCurrencyDirectoryConfig> {
+    const addresses = await this.getAddresses()
+    let config: FeeCurrencyDirectoryConfig = { intrinsicGasForAlternativeFeeCurrency: {} }
+
+    for (const address of addresses) {
+      config.intrinsicGasForAlternativeFeeCurrency[address] = (
+        await this.getCurrencyConfig(address)
+      ).intrinsicGas
+    }
+
+    return config
+  }
 }


### PR DESCRIPTION
### Description

This PR adds displaying of `FeeCurrencyDirectoryWrapper` config to `network:parameters` command.

### Other changes

`network:parameters` snapshot for L2 had to be updated.

### Tested

Ran tests locally and executed `network:parameters` command for both L1 and L2 context.

### Backwards compatibility

It's backwards compatible.

### Documentation

None.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces `getConfig` for `FeeCurrencyDirectoryWrapper` and updates the `FeeCurrencyDirectoryConfig` interface.

### Detailed summary
- Added `getConfig` method to `FeeCurrencyDirectoryWrapper`
- Updated `FeeCurrencyDirectoryConfig` interface with `intrinsicGasForAlternativeFeeCurrency` property
- Updated network parameters in `network:parameters` to include FeeCurrencyDirectory data

> The following files were skipped due to too many changes: `docs/sdk/contractkit/interfaces/kit.NetworkConfig.md`, `docs/sdk/contractkit/classes/kit.ContractKit.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->