### PR TITLE
Migrate governance tests to anvil

### DIFF
--- a/packages/cli/src/commands/governance/approve.test.ts
+++ b/packages/cli/src/commands/governance/approve.test.ts
@@ -1,19 +1,25 @@
 import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
-import { NetworkConfig, testWithGanache, timeTravel } from '@celo/dev-utils/lib/ganache-test'
+import {
+  impersonateAccount,
+  stopImpersonatingAccount,
+  testWithAnvil,
+} from '@celo/dev-utils/lib/anvil-test'
+import { NetworkConfig, timeTravel } from '@celo/dev-utils/lib/ganache-test'
+import { ux } from '@oclif/core'
 import Web3 from 'web3'
-import { testLocally } from '../../test-utils/cliUtils'
+import { stripAnsiCodes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Approve from './approve'
 
 process.env.NO_SYNCCHECK = 'true'
 
 const expConfig = NetworkConfig.governance
 
-testWithGanache('governance:approve cmd', (web3: Web3) => {
-  const minDeposit = web3.utils.toWei(expConfig.minDeposit.toString(), 'ether')
+testWithAnvil('governance:approve cmd', (web3: Web3) => {
   const kit = newKitFromWeb3(web3)
   const proposalID = '1'
+  let minDeposit: string
 
   let accounts: StrongAddress[] = []
   let governance: GovernanceWrapper
@@ -22,18 +28,119 @@ testWithGanache('governance:approve cmd', (web3: Web3) => {
     accounts = (await web3.eth.getAccounts()) as StrongAddress[]
     kit.defaultAccount = accounts[0]
     governance = await kit.contracts.getGovernance()
+    minDeposit = (await governance.minDeposit()).toFixed()
+
     await governance
       .propose([], 'URL')
       .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
     await timeTravel(expConfig.dequeueFrequency, web3)
   })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   test('approve fails if approver not passed in', async () => {
     await expect(
-      testLocally(Approve, ['--from', accounts[0], '--proposalID', proposalID])
+      testLocallyWithWeb3Node(Approve, ['--from', accounts[0], '--proposalID', proposalID], web3)
     ).rejects.toThrow("Some checks didn't pass!")
   })
+
+  test('fails when account is not multisig owner', async () => {
+    const writeMock = jest.spyOn(ux.write, 'stdout')
+    const logMock = jest.spyOn(console, 'log')
+
+    await expect(
+      testLocallyWithWeb3Node(
+        Approve,
+        ['--from', accounts[0], '--proposalID', proposalID, '--useMultiSig'],
+        web3
+      )
+    ).rejects.toThrow("Some checks didn't pass!")
+
+    expect(await governance.isApproved(proposalID)).toEqual(false)
+    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      [
+        [
+          "Running Checks:",
+        ],
+        [
+          "   ✔  0x1288C356E8d9F2811F10B8E92dBADbf3bCEC12F8 is approver address ",
+        ],
+        [
+          "   ✘  0x5409ED021D9299bf6814279A6A1411A7e866A631 is multisig signatory ",
+        ],
+        [
+          "   ✔  1 is an existing proposal ",
+        ],
+        [
+          "   ✔  1 is in stage Referendum ",
+        ],
+        [
+          "   ✔  1 not already approved ",
+        ],
+      ]
+    `)
+    expect(writeMock.mock.calls).toMatchInlineSnapshot(`[]`)
+  })
+
   test('can approve with multisig option', async () => {
-    await testLocally(Approve, ['--from', accounts[0], '--proposalID', proposalID, '--useMultiSig'])
-    expect(await governance.isApproved(proposalID)).toBeTruthy()
+    // replace the original owner in the devchain, so we can act as the multisig owner
+    // the transaction needs to be sent by the multisig itself and it needs some funds first
+    // TODO possibly create a helper function if needed in more tests
+    const multisig = await governance.getApproverMultisig()
+    await kit.sendTransaction({
+      from: accounts[0],
+      to: multisig.address,
+      value: web3.utils.toWei('1', 'ether'),
+    })
+    await impersonateAccount(web3, multisig.address)
+    await multisig
+      .replaceOwner('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', accounts[0])
+      .sendAndWaitForReceipt({ from: multisig.address })
+    await stopImpersonatingAccount(web3, multisig.address)
+
+    const writeMock = jest.spyOn(ux.write, 'stdout')
+    const logMock = jest.spyOn(console, 'log')
+
+    await testLocallyWithWeb3Node(
+      Approve,
+      ['--from', accounts[0], '--proposalID', proposalID, '--useMultiSig'],
+      web3
+    )
+
+    expect(await governance.isApproved(proposalID)).toEqual(true)
+    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      [
+        [
+          "Running Checks:",
+        ],
+        [
+          "   ✔  0x1288C356E8d9F2811F10B8E92dBADbf3bCEC12F8 is approver address ",
+        ],
+        [
+          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is multisig signatory ",
+        ],
+        [
+          "   ✔  1 is an existing proposal ",
+        ],
+        [
+          "   ✔  1 is in stage Referendum ",
+        ],
+        [
+          "   ✔  1 not already approved ",
+        ],
+        [
+          "All checks passed",
+        ],
+        [
+          "SendTransaction: approveTx",
+        ],
+        [
+          "txHash: 0x10ee79a4404b04c5312fe146f49f1f84dd0ee451f5bebbe5dc2b78b2c0f37520",
+        ],
+      ]
+    `)
+    expect(writeMock.mock.calls).toMatchInlineSnapshot(`[]`)
   })
 })

--- a/packages/cli/src/commands/governance/approve.test.ts
+++ b/packages/cli/src/commands/governance/approve.test.ts
@@ -1,14 +1,11 @@
 import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
-import {
-  impersonateAccount,
-  stopImpersonatingAccount,
-  testWithAnvil,
-} from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import { NetworkConfig, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import { ux } from '@oclif/core'
 import Web3 from 'web3'
+import { changeMultiSigOwner } from '../../test-utils/chain-setup'
 import { stripAnsiCodes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Approve from './approve'
 
@@ -85,20 +82,7 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
   })
 
   test('can approve with multisig option', async () => {
-    // replace the original owner in the devchain, so we can act as the multisig owner
-    // the transaction needs to be sent by the multisig itself and it needs some funds first
-    // TODO possibly create a helper function if needed in more tests
-    const multisig = await governance.getApproverMultisig()
-    await kit.sendTransaction({
-      from: accounts[0],
-      to: multisig.address,
-      value: web3.utils.toWei('1', 'ether'),
-    })
-    await impersonateAccount(web3, multisig.address)
-    await multisig
-      .replaceOwner('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', accounts[0])
-      .sendAndWaitForReceipt({ from: multisig.address })
-    await stopImpersonatingAccount(web3, multisig.address)
+    await changeMultiSigOwner(kit, accounts[0])
 
     const writeMock = jest.spyOn(ux.write, 'stdout')
     const logMock = jest.spyOn(console, 'log')

--- a/packages/cli/src/commands/governance/propose.test.ts
+++ b/packages/cli/src/commands/governance/propose.test.ts
@@ -2,11 +2,11 @@ import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GoldTokenWrapper } from '@celo/contractkit/lib/wrappers/GoldTokenWrapper'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
-import { NetworkConfig, testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import * as fs from 'fs'
 import Web3 from 'web3'
-import { EXTRA_LONG_TIMEOUT_MS, testLocally } from '../../test-utils/cliUtils'
+import { EXTRA_LONG_TIMEOUT_MS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import Approve from '../multisig/approve'
 import Propose from './propose'
@@ -137,13 +137,11 @@ const structAbiDefinition = {
   type: 'function',
 }
 
-testWithGanache('governance:propose cmd', (web3: Web3) => {
+testWithAnvil('governance:propose cmd', (web3: Web3) => {
   let governance: GovernanceWrapper
   let goldToken: GoldTokenWrapper
+  let minDeposit: string
 
-  const expConfig = NetworkConfig.governance
-
-  const minDeposit = web3.utils.toWei(expConfig.minDeposit.toString(), 'ether')
   const kit = newKitFromWeb3(web3)
 
   let accounts: StrongAddress[] = []
@@ -153,6 +151,7 @@ testWithGanache('governance:propose cmd', (web3: Web3) => {
     kit.defaultAccount = accounts[0]
     governance = await kit.contracts.getGovernance()
     goldToken = await kit.contracts.getGoldToken()
+    minDeposit = (await governance.minDeposit()).toFixed()
   })
 
   test(
@@ -172,16 +171,20 @@ testWithGanache('governance:propose cmd', (web3: Web3) => {
       const proposalBefore = await governance.getProposal(1)
       expect(proposalBefore).toEqual([])
 
-      await testLocally(Propose, [
-        '--jsonTransactions',
-        'transactions.json',
-        '--deposit',
-        '1000000000000000000',
-        '--from',
-        accounts[0],
-        '--descriptionURL',
-        'https://dummyurl.com',
-      ])
+      await testLocallyWithWeb3Node(
+        Propose,
+        [
+          '--jsonTransactions',
+          'transactions.json',
+          '--deposit',
+          minDeposit,
+          '--from',
+          accounts[0],
+          '--descriptionURL',
+          'https://example.com',
+        ],
+        web3
+      )
 
       const proposal = await governance.getProposal(1)
       expect(proposal.length).toEqual(transactions.length)
@@ -229,19 +232,23 @@ testWithGanache('governance:propose cmd', (web3: Web3) => {
       const proposalBefore = await governance.getProposal(1)
       expect(proposalBefore).toEqual([])
 
-      await testLocally(Propose, [
-        '--jsonTransactions',
-        'transactions.json',
-        '--deposit',
-        '10000e18',
-        '--from',
-        accounts[0],
-        '--useMultiSig',
-        '--for',
-        multisigWithOneSigner,
-        '--descriptionURL',
-        'https://dummyurl.com',
-      ])
+      await testLocallyWithWeb3Node(
+        Propose,
+        [
+          '--jsonTransactions',
+          'transactions.json',
+          '--deposit',
+          '10000e18',
+          '--from',
+          accounts[0],
+          '--useMultiSig',
+          '--for',
+          multisigWithOneSigner,
+          '--descriptionURL',
+          'https://dummyurl.com',
+        ],
+        web3
+      )
 
       const proposal = await governance.getProposal(1)
       expect(proposal.length).toEqual(transactions.length)
@@ -290,32 +297,33 @@ testWithGanache('governance:propose cmd', (web3: Web3) => {
       expect(proposalBefore).toEqual([])
 
       // Submit proposal from signer A
-      await testLocally(Propose, [
-        '--jsonTransactions',
-        'transactions.json',
-        '--deposit',
-        '10000e18',
-        '--from',
-        accounts[0],
-        '--useMultiSig',
-        '--for',
-        multisigWithTwoSigners,
-        '--descriptionURL',
-        'https://dummyurl.com',
-      ])
+      await testLocallyWithWeb3Node(
+        Propose,
+        [
+          '--jsonTransactions',
+          'transactions.json',
+          '--deposit',
+          '10000e18',
+          '--from',
+          accounts[0],
+          '--useMultiSig',
+          '--for',
+          multisigWithTwoSigners,
+          '--descriptionURL',
+          'https://dummyurl.com',
+        ],
+        web3
+      )
 
       const proposalBetween = await governance.getProposal(1)
       expect(proposalBetween).toEqual([])
 
       // Approve proposal from signer B
-      await testLocally(Approve, [
-        '--from',
-        accounts[1],
-        '--for',
-        multisigWithTwoSigners,
-        '--tx',
-        '0',
-      ])
+      await testLocallyWithWeb3Node(
+        Approve,
+        ['--from', accounts[1], '--for', multisigWithTwoSigners, '--tx', '0'],
+        web3
+      )
 
       const proposal = await governance.getProposal(1)
       expect(proposal.length).toEqual(transactions.length)
@@ -347,18 +355,22 @@ testWithGanache('governance:propose cmd', (web3: Web3) => {
       const proposalBefore = await governance.getProposal(1)
       expect(proposalBefore).toEqual([])
 
-      await testLocally(Propose, [
-        '--jsonTransactions',
-        'transactions.json',
-        '--deposit',
-        '1000000000000000000',
-        '--from',
-        accounts[0],
-        '--descriptionURL',
-        'https://dummyurl.com',
-        '--force',
-        '--noInfo',
-      ])
+      await testLocallyWithWeb3Node(
+        Propose,
+        [
+          '--jsonTransactions',
+          'transactions.json',
+          '--deposit',
+          minDeposit,
+          '--from',
+          accounts[0],
+          '--descriptionURL',
+          'https://dummyurl.com',
+          '--force',
+          '--noInfo',
+        ],
+        web3
+      )
 
       const proposal = await governance.getProposal(1)
       expect(proposal.length).toEqual(transactions.length)
@@ -390,18 +402,22 @@ testWithGanache('governance:propose cmd', (web3: Web3) => {
       const proposalBefore = await governance.getProposal(1)
       expect(proposalBefore).toEqual([])
 
-      await testLocally(Propose, [
-        '--jsonTransactions',
-        'transactions.json',
-        '--deposit',
-        '1000000000000000000',
-        '--from',
-        accounts[0],
-        '--descriptionURL',
-        'https://dummyurl.com',
-        '--force',
-        '--noInfo',
-      ])
+      await testLocallyWithWeb3Node(
+        Propose,
+        [
+          '--jsonTransactions',
+          'transactions.json',
+          '--deposit',
+          minDeposit,
+          '--from',
+          accounts[0],
+          '--descriptionURL',
+          'https://dummyurl.com',
+          '--force',
+          '--noInfo',
+        ],
+        web3
+      )
 
       const proposal = await governance.getProposal(1)
       expect(proposal.length).toEqual(transactions.length)
@@ -421,14 +437,11 @@ testWithGanache('governance:propose cmd', (web3: Web3) => {
     'fails when descriptionURl is missing',
     async () => {
       await expect(
-        testLocally(Propose, [
-          '--from',
-          accounts[0],
-          '--deposit',
-          '0',
-          '--jsonTransactions',
-          './exampleProposal.json',
-        ])
+        testLocallyWithWeb3Node(
+          Propose,
+          ['--from', accounts[0], '--deposit', '0', '--jsonTransactions', './exampleProposal.json'],
+          web3
+        )
       ).rejects.toThrow('Missing required flag descriptionURL')
     },
     EXTRA_LONG_TIMEOUT_MS
@@ -437,16 +450,20 @@ testWithGanache('governance:propose cmd', (web3: Web3) => {
   test(
     'can submit empty proposal',
     async () => {
-      await testLocally(Propose, [
-        '--from',
-        accounts[0],
-        '--deposit',
-        minDeposit,
-        '--jsonTransactions',
-        './exampleProposal.json',
-        '--descriptionURL',
-        'https://example.com',
-      ])
+      await testLocallyWithWeb3Node(
+        Propose,
+        [
+          '--from',
+          accounts[0],
+          '--deposit',
+          minDeposit,
+          '--jsonTransactions',
+          './exampleProposal.json',
+          '--descriptionURL',
+          'https://example.com',
+        ],
+        web3
+      )
     },
     EXTRA_LONG_TIMEOUT_MS
   )
@@ -456,16 +473,20 @@ testWithGanache('governance:propose cmd', (web3: Web3) => {
     async () => {
       const spyStart = jest.spyOn(ux.action, 'start')
       const spyStop = jest.spyOn(ux.action, 'stop')
-      await testLocally(Propose, [
-        '--from',
-        accounts[0],
-        '--deposit',
-        '10000e18',
-        '--jsonTransactions',
-        './exampleProposal.json',
-        '--descriptionURL',
-        'https://example.com',
-      ])
+      await testLocallyWithWeb3Node(
+        Propose,
+        [
+          '--from',
+          accounts[0],
+          '--deposit',
+          '10000e18',
+          '--jsonTransactions',
+          './exampleProposal.json',
+          '--descriptionURL',
+          'https://example.com',
+        ],
+        web3
+      )
       expect(spyStart).toHaveBeenCalledWith('Sending Transaction: proposeTx')
       expect(spyStop).toHaveBeenCalled()
     },
@@ -478,16 +499,20 @@ testWithGanache('governance:propose cmd', (web3: Web3) => {
       const spyStart = jest.spyOn(ux.action, 'start')
       const spyStop = jest.spyOn(ux.action, 'stop')
 
-      await testLocally(Propose, [
-        '--from',
-        accounts[0],
-        '--deposit',
-        '10000000000000000000000',
-        '--jsonTransactions',
-        './exampleProposal.json',
-        '--descriptionURL',
-        'https://example.com',
-      ])
+      await testLocallyWithWeb3Node(
+        Propose,
+        [
+          '--from',
+          accounts[0],
+          '--deposit',
+          '10000000000000000000000',
+          '--jsonTransactions',
+          './exampleProposal.json',
+          '--descriptionURL',
+          'https://example.com',
+        ],
+        web3
+      )
       expect(spyStart).toHaveBeenCalledWith('Sending Transaction: proposeTx')
       expect(spyStop).toHaveBeenCalled()
     },

--- a/packages/cli/src/commands/governance/upvote.test.ts
+++ b/packages/cli/src/commands/governance/upvote.test.ts
@@ -1,10 +1,11 @@
 import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
-import { NetworkConfig, testWithGanache, timeTravel } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
-import { testLocally } from '../../test-utils/cliUtils'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from '../lockedgold/lock'
 import Dequeue from './dequeue'
@@ -12,18 +13,14 @@ import Upvote from './upvote'
 
 process.env.NO_SYNCCHECK = 'true'
 
-const expConfig = NetworkConfig.governance
-
-testWithGanache('governance:upvote cmd', (web3: Web3) => {
-  const minDeposit = web3.utils.toWei(expConfig.minDeposit.toString(), 'ether')
+testWithAnvil('governance:upvote cmd', (web3: Web3) => {
+  let minDeposit: string
   const kit = newKitFromWeb3(web3)
   const proposalID = new BigNumber(1)
   const proposalID2 = new BigNumber(2)
   const proposalID3 = new BigNumber(3)
   const proposalID4 = new BigNumber(4)
   const proposalID5 = new BigNumber(5)
-  const proposalID6 = new BigNumber(6)
-  const proposalID7 = new BigNumber(7)
 
   let accounts: StrongAddress[] = []
   let governance: GovernanceWrapper
@@ -32,14 +29,15 @@ testWithGanache('governance:upvote cmd', (web3: Web3) => {
     accounts = (await web3.eth.getAccounts()) as StrongAddress[]
     kit.defaultAccount = accounts[0]
     governance = await kit.contracts.getGovernance()
+    minDeposit = (await governance.minDeposit()).toFixed()
     const dequeueFrequency = (await governance.dequeueFrequency()).toNumber()
 
     await governance
       .propose([], 'URL')
       .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
     // this will reset lastDequeue to now
-    // there is 5 concurrent proposals possible to be dequeued
-    await testLocally(Dequeue, ['--from', accounts[0]])
+    // there is 3 concurrent proposals possible to be dequeued
+    await testLocallyWithWeb3Node(Dequeue, ['--from', accounts[0]], web3)
     await governance
       .propose([], 'URL2')
       .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
@@ -52,39 +50,34 @@ testWithGanache('governance:upvote cmd', (web3: Web3) => {
     await governance
       .propose([], 'URL5')
       .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
-    await governance
-      .propose([], 'URL6')
-      .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
-    await governance
-      .propose([], 'URL7')
-      .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
 
     await timeTravel(dequeueFrequency, web3)
-    await testLocally(Register, ['--from', accounts[0]])
-    await testLocally(Lock, ['--from', accounts[0], '--value', '100'])
+    await testLocallyWithWeb3Node(Register, ['--from', accounts[0]], web3)
+    await testLocallyWithWeb3Node(Lock, ['--from', accounts[0], '--value', '100'], web3)
   })
 
   test('will dequeue proposal if ready', async () => {
-    await testLocally(Upvote, ['--proposalID', proposalID2.toString(10), '--from', accounts[0]])
+    await testLocallyWithWeb3Node(
+      Upvote,
+      ['--proposalID', proposalID2.toString(10), '--from', accounts[0]],
+      web3
+    )
 
     const queue = await governance.getQueue()
-    expect(queue.map((k) => k.proposalID)).toEqual([proposalID7])
+    expect(queue.map((k) => k.proposalID)).toEqual([proposalID5])
 
     const dequeue = await governance.getDequeue()
-    expect(dequeue).toEqual([
-      proposalID,
-      proposalID2,
-      proposalID3,
-      proposalID4,
-      proposalID5,
-      proposalID6,
-    ])
+    expect(dequeue).toEqual([proposalID, proposalID2, proposalID3, proposalID4])
   })
 
   test('can upvote proposal which cannot be dequeued', async () => {
-    await testLocally(Upvote, ['--proposalID', proposalID7.toString(10), '--from', accounts[0]])
+    await testLocallyWithWeb3Node(
+      Upvote,
+      ['--proposalID', proposalID5.toString(10), '--from', accounts[0]],
+      web3
+    )
 
     const queue = await governance.getQueue()
-    expect(queue).toEqual([{ proposalID: proposalID7, upvotes: new BigNumber(100) }])
+    expect(queue).toEqual([{ proposalID: proposalID5, upvotes: new BigNumber(100) }])
   })
 })

--- a/packages/cli/src/commands/governance/vote.test.ts
+++ b/packages/cli/src/commands/governance/vote.test.ts
@@ -1,10 +1,12 @@
 import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
-import { NetworkConfig, testWithGanache, timeTravel } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { NetworkConfig, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
-import { testLocally } from '../../test-utils/cliUtils'
+import { changeMultiSigOwner } from '../../test-utils/chain-setup'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from '../lockedgold/lock'
 import Approve from './approve'
@@ -15,8 +17,8 @@ process.env.NO_SYNCCHECK = 'true'
 
 const expConfig = NetworkConfig.governance
 
-testWithGanache('governance:vote cmd', (web3: Web3) => {
-  const minDeposit = web3.utils.toWei(expConfig.minDeposit.toString(), 'ether')
+testWithAnvil('governance:vote cmd', (web3: Web3) => {
+  let minDeposit: string
   const kit = newKitFromWeb3(web3)
   const proposalID = new BigNumber(1)
 
@@ -27,31 +29,28 @@ testWithGanache('governance:vote cmd', (web3: Web3) => {
     accounts = (await web3.eth.getAccounts()) as StrongAddress[]
     kit.defaultAccount = accounts[0]
     governance = await kit.contracts.getGovernance()
+    minDeposit = (await governance.minDeposit()).toFixed()
     await governance
       .propose([], 'URL')
       .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
     await timeTravel(expConfig.dequeueFrequency, web3)
-    await testLocally(Dequeue, ['--from', accounts[0]])
-    await testLocally(Approve, [
-      '--from',
-      accounts[0],
-      '--proposalID',
-      proposalID.toString(10),
-      '--useMultiSig',
-    ])
-    await testLocally(Register, ['--from', accounts[0]])
-    await testLocally(Lock, ['--from', accounts[0], '--value', '100'])
+    await testLocallyWithWeb3Node(Dequeue, ['--from', accounts[0]], web3)
+    await changeMultiSigOwner(kit, accounts[0])
+    await testLocallyWithWeb3Node(
+      Approve,
+      ['--from', accounts[0], '--proposalID', proposalID.toString(10), '--useMultiSig'],
+      web3
+    )
+    await testLocallyWithWeb3Node(Register, ['--from', accounts[0]], web3)
+    await testLocallyWithWeb3Node(Lock, ['--from', accounts[0], '--value', '100'], web3)
   })
 
   test('can vote yes', async () => {
-    await testLocally(Vote, [
-      '--from',
-      accounts[0],
-      '--proposalID',
-      proposalID.toString(10),
-      '--value',
-      'Yes',
-    ])
+    await testLocallyWithWeb3Node(
+      Vote,
+      ['--from', accounts[0], '--proposalID', proposalID.toString(10), '--value', 'Yes'],
+      web3
+    )
     const votes = await governance.getVotes(proposalID)
     expect(votes.Yes.toNumber()).toEqual(100)
   })

--- a/packages/cli/src/commands/governance/votePartially.test.ts
+++ b/packages/cli/src/commands/governance/votePartially.test.ts
@@ -1,10 +1,12 @@
 import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
-import { NetworkConfig, testWithGanache, timeTravel } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { NetworkConfig, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
-import { testLocally } from '../../test-utils/cliUtils'
+import { changeMultiSigOwner } from '../../test-utils/chain-setup'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from '../lockedgold/lock'
 import Approve from './approve'
@@ -15,8 +17,8 @@ process.env.NO_SYNCCHECK = 'true'
 
 const expConfig = NetworkConfig.governance
 
-testWithGanache('governance:vote-partially cmd', (web3: Web3) => {
-  const minDeposit = web3.utils.toWei(expConfig.minDeposit.toString(), 'ether')
+testWithAnvil('governance:vote-partially cmd', (web3: Web3) => {
+  let minDeposit: string
   const kit = newKitFromWeb3(web3)
   const proposalID = new BigNumber(1)
 
@@ -27,35 +29,39 @@ testWithGanache('governance:vote-partially cmd', (web3: Web3) => {
     accounts = (await web3.eth.getAccounts()) as StrongAddress[]
     kit.defaultAccount = accounts[0]
     governance = await kit.contracts.getGovernance()
+    minDeposit = (await governance.minDeposit()).toFixed()
     await governance
       .propose([], 'URL')
       .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
     await timeTravel(expConfig.dequeueFrequency, web3)
-    await testLocally(Dequeue, ['--from', accounts[0]])
-    await testLocally(Approve, [
-      '--from',
-      accounts[0],
-      '--proposalID',
-      proposalID.toString(10),
-      '--useMultiSig',
-    ])
-    await testLocally(Register, ['--from', accounts[0]])
-    await testLocally(Lock, ['--from', accounts[0], '--value', '100'])
+    await testLocallyWithWeb3Node(Dequeue, ['--from', accounts[0]], web3)
+    await changeMultiSigOwner(kit, accounts[0])
+    await testLocallyWithWeb3Node(
+      Approve,
+      ['--from', accounts[0], '--proposalID', proposalID.toString(10), '--useMultiSig'],
+      web3
+    )
+    await testLocallyWithWeb3Node(Register, ['--from', accounts[0]], web3)
+    await testLocallyWithWeb3Node(Lock, ['--from', accounts[0], '--value', '100'], web3)
   })
 
   test('can vote partially yes and no', async () => {
-    await testLocally(VotePartially, [
-      '--from',
-      accounts[0],
-      '--proposalID',
-      proposalID.toString(10),
-      '--yes',
-      '10',
-      '--no',
-      '20',
-      '--abstain',
-      '0',
-    ])
+    await testLocallyWithWeb3Node(
+      VotePartially,
+      [
+        '--from',
+        accounts[0],
+        '--proposalID',
+        proposalID.toString(10),
+        '--yes',
+        '10',
+        '--no',
+        '20',
+        '--abstain',
+        '0',
+      ],
+      web3
+    )
     const votes = await governance.getVotes(proposalID)
     expect(votes.Yes.toNumber()).toEqual(10)
     expect(votes.No.toNumber()).toEqual(20)

--- a/packages/cli/src/commands/governance/withdraw.test.ts
+++ b/packages/cli/src/commands/governance/withdraw.test.ts
@@ -1,19 +1,20 @@
 import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GovernanceWrapper, Proposal } from '@celo/contractkit/lib/wrappers/Governance'
-import { NetworkConfig, testWithGanache, timeTravel } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { NetworkConfig, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import { ProposalBuilder } from '@celo/governance'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
-import { testLocally } from '../../test-utils/cliUtils'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Withdraw from './withdraw'
 
 process.env.NO_SYNCCHECK = 'true'
 
 const expConfig = NetworkConfig.governance
 
-testWithGanache('governance:withdraw', (web3: Web3) => {
-  const minDeposit = web3.utils.toWei(expConfig.minDeposit.toString(), 'ether')
+testWithAnvil('governance:withdraw', (web3: Web3) => {
+  let minDeposit: string
   const kit = newKitFromWeb3(web3)
 
   let accounts: StrongAddress[] = []
@@ -23,24 +24,34 @@ testWithGanache('governance:withdraw', (web3: Web3) => {
     accounts = (await web3.eth.getAccounts()) as StrongAddress[]
     kit.defaultAccount = accounts[0]
     governance = await kit.contracts.getGovernance()
-    console.log((await governance.lastDequeue()).toNumber())
+    minDeposit = (await governance.minDeposit()).toFixed()
     const proposal: Proposal = await new ProposalBuilder(kit).build()
     await governance
       .propose(proposal, 'URL')
       .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
-    console.log(await governance.getProposalMetadata(1))
     await timeTravel(expConfig.dequeueFrequency + 1, web3)
     await governance.dequeueProposalsIfReady().sendAndWaitForReceipt()
   })
 
   test('can withdraw', async () => {
-    console.log(await governance.getProposalMetadata(1))
-    console.log(await governance.getProposalStage(1))
     const balanceBefore = await kit.connection.getBalance(accounts[0])
-    console.log(accounts[0], await governance.getRefundedDeposits(accounts[0]))
-    console.log(await testLocally(Withdraw, ['--from', accounts[0]]))
+
+    await testLocallyWithWeb3Node(Withdraw, ['--from', accounts[0]], web3)
+
     const balanceAfter = await kit.connection.getBalance(accounts[0])
-    const difference = new BigNumber(balanceAfter).minus(balanceBefore)
+    const latestTransactionReceipt = await web3.eth.getTransactionReceipt(
+      (
+        await web3.eth.getBlock('latest')
+      ).transactions[0]
+    )
+
+    // Safety check if the latest transaction was originated by expected account
+    expect(latestTransactionReceipt.from.toLowerCase()).toEqual(accounts[0].toLowerCase())
+
+    const difference = new BigNumber(balanceAfter)
+      .minus(balanceBefore)
+      .plus(latestTransactionReceipt.effectiveGasPrice * latestTransactionReceipt.gasUsed)
+
     expect(difference.toFixed()).toEqual(minDeposit)
   })
 })

--- a/packages/dev-utils/src/anvil-test.ts
+++ b/packages/dev-utils/src/anvil-test.ts
@@ -15,6 +15,9 @@ const ANVIL_PORT = 8546
 
 export const STABLES_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
 
+// Introducing a different name for the same address to avoid confusion
+export const DEFAULT_OWNER_ADDRESS = STABLES_ADDRESS
+
 export function createInstance(): Anvil {
   // preparation for not needing to have --runInBand for anvil tests
   const port = ANVIL_PORT + (process.pid - process.ppid)


### PR DESCRIPTION
### Description

This PR migrates all existing `governance` tests to anvil.

### Other changes

Only related to test utils.

### Tested

Locally and on CI.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new constant `DEFAULT_OWNER_ADDRESS` to replace `STABLES_ADDRESS` for clarity. It also adds a function to change the multisig owner and updates test commands for governance operations using Anvil testing.

### Detailed summary
- Introduces `DEFAULT_OWNER_ADDRESS` constant to replace `STABLES_ADDRESS`
- Adds `changeMultiSigOwner` function for updating multisig owner
- Updates test commands for governance operations using Anvil testing

> The following files were skipped due to too many changes: `packages/cli/src/commands/governance/approve.test.ts`, `packages/cli/src/commands/governance/upvote.test.ts`, `packages/cli/src/commands/governance/propose.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->