### PR TITLE
SUPPORT multiple ledger versions

### DIFF
--- a/.changeset/thin-yaks-lick.md
+++ b/.changeset/thin-yaks-lick.md
@@ -1,0 +1,5 @@
+---
+'@celo/wallet-ledger': patch
+---
+
+Temporarily support celo-legacy transactions / older celo-ledger apps.

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -1,5 +1,5 @@
 import { StrongAddress } from '@celo/base'
-import { ReadOnlyWallet } from '@celo/connect'
+import { ReadOnlyWallet, isCel2 } from '@celo/connect'
 import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
 import { AzureHSMWallet } from '@celo/wallet-hsm-azure'
 import { AddressValidation, newLedgerWalletWithSetup } from '@celo/wallet-ledger'
@@ -93,6 +93,8 @@ export abstract class BaseCommand extends Command {
   private _web3: Web3 | null = null
   private _kit: ContractKit | null = null
 
+  private cel2: boolean | null = null
+
   async getWeb3() {
     if (!this._web3) {
       const res = await this.parse()
@@ -170,7 +172,8 @@ export abstract class BaseCommand extends Command {
           transport,
           derivationPathIndexes,
           undefined,
-          ledgerConfirmation
+          ledgerConfirmation,
+          await this.isCel2()
         )
       } catch (err) {
         console.log('Check if the ledger is connected and logged.')
@@ -237,5 +240,13 @@ export abstract class BaseCommand extends Command {
     }
 
     return super.finally(arg)
+  }
+
+  protected async isCel2() {
+    if (this.cel2 === null) {
+      this.cel2 = await isCel2(await this.getWeb3())
+    }
+
+    return this.cel2
   }
 }

--- a/packages/sdk/wallets/wallet-base/src/signing-utils.test.ts
+++ b/packages/sdk/wallets/wallet-base/src/signing-utils.test.ts
@@ -6,6 +6,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 import { celo } from 'viem/chains'
 import Web3 from 'web3'
 import {
+  encode_deprecated_celo_legacy_type_only_for_temporary_ledger_compat,
   extractSignature,
   getSignerFromTxEIP2718TX,
   handleBigInt,
@@ -217,6 +218,44 @@ describe('rlpEncodedTx', () => {
       expect(parsedCK).toEqual(parsedViem)
       expect(serialized.rlpEncode).toEqual(viemSerialized)
     })
+  })
+})
+
+describe('encode_deprecated_celo_legacy_type_only_for_temporary_ledger_compat', () => {
+  test('serializes the deprecated tx type correctly', () => {
+    const legacyTransaction = {
+      feeCurrency: '0x5409ED021D9299bf6814279A6A1411A7e866A631',
+      from: ACCOUNT_ADDRESS1,
+      to: ACCOUNT_ADDRESS1,
+      chainId: 2,
+      value: Web3.utils.toWei('1000', 'ether'),
+      nonce: 1,
+      gas: '1500000000',
+      gasPrice: '9900000000',
+      data: '0xabcdef',
+    } as const
+
+    const result =
+      encode_deprecated_celo_legacy_type_only_for_temporary_ledger_compat(legacyTransaction)
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "rlpEncode": "0xf8490185024e1603008459682f00945409ed021d9299bf6814279a6a1411a7e866a6318080941be31a94361a391bbafb2a4ccd704f57dc04d4bb893635c9adc5dea0000083abcdef028080",
+        "transaction": {
+          "chainId": 2,
+          "data": "0xabcdef",
+          "feeCurrency": "0x5409ed021d9299bf6814279a6a1411a7e866a631",
+          "from": "0x1be31a94361a391bbafb2a4ccd704f57dc04d4bb",
+          "gas": "0x59682f00",
+          "gasPrice": "0x024e160300",
+          "gatewayFee": "0x",
+          "gatewayFeeRecipient": "0x",
+          "nonce": 1,
+          "to": "0x1be31a94361a391bbafb2a4ccd704f57dc04d4bb",
+          "value": "0x3635c9adc5dea00000",
+        },
+        "type": "celo-legacy",
+      }
+    `)
   })
 })
 

--- a/packages/sdk/wallets/wallet-base/src/signing-utils.ts
+++ b/packages/sdk/wallets/wallet-base/src/signing-utils.ts
@@ -232,8 +232,11 @@ export function encode_deprecated_celo_legacy_type_only_for_temporary_ledger_com
   // Celo Specific
   transaction.feeCurrency = ensureLeading0x((tx.feeCurrency || '0x').toLowerCase())
   // we arent supporting the full classic celo tx so we can zero out these fields.
-  const gatewayFeeRecipient = '0x'
-  const gatewayFee = '0x'
+
+  // @ts-expect-error
+  transaction.gatewayFeeRecipient = '0x'
+  // @ts-expect-error
+  transaction.gatewayFee = '0x'
   // Legacy
   transaction.gasPrice = stringNumberOrBNToHex(tx.gasPrice)
   // This order should match the order in Geth.
@@ -243,8 +246,10 @@ export function encode_deprecated_celo_legacy_type_only_for_temporary_ledger_com
     transaction.gasPrice,
     transaction.gas,
     transaction.feeCurrency,
-    gatewayFeeRecipient,
-    gatewayFee,
+    // @ts-expect-error
+    transaction.gatewayFeeRecipient,
+    // @ts-expect-error
+    transaction.gatewayFee,
     transaction.to,
     transaction.value,
     transaction.data,

--- a/packages/sdk/wallets/wallet-base/src/signing-utils.ts
+++ b/packages/sdk/wallets/wallet-base/src/signing-utils.ts
@@ -8,6 +8,7 @@ import {
   CeloTx,
   CeloTxWithSig,
   EncodedTransaction,
+  FormattedCeloTx,
   RLPEncodedTx,
   TransactionTypes,
   WithSig,
@@ -91,14 +92,14 @@ function makeEven(hex: string) {
 
 function signatureFormatter(
   signature: { v: number | bigint; r: Buffer; s: Buffer },
-  type: TransactionTypes
+  type: TransactionTypes | 'celo-legacy'
 ): {
   v: string
   r: string
   s: string
 } {
   let v = signature.v
-  if (type !== 'ethereum-legacy') {
+  if (type !== 'celo-legacy' && type !== 'ethereum-legacy') {
     v = signature.v === Y_PARITY_EIP_2098 ? 0 : 1
   }
   return {
@@ -211,9 +212,52 @@ enum TxTypeToPrefix {
   eip1559 = '0x02',
 }
 
+export interface LegacyEncodedTx {
+  type: 'celo-legacy'
+  rlpEncode: `0x${string}`
+  transaction: FormattedCeloTx
+}
+
+// dont use this its in snake case specifically to make you hesitate.
+export function encode_deprecated_celo_legacy_type_only_for_temporary_ledger_compat(
+  tx: CeloTx
+): LegacyEncodedTx {
+  const transaction = inputCeloTxFormatter(tx)
+  transaction.to = ensureLeading0x((tx.to || '0x').toLowerCase())
+  transaction.nonce = Number(((tx.nonce as any) !== '0x' ? tx.nonce : 0) || 0)
+  transaction.data = (tx.data || '0x').toLowerCase()
+  transaction.value = stringNumberOrBNToHex(tx.value)
+  transaction.gas = stringNumberOrBNToHex(tx.gas)
+  transaction.chainId = tx.chainId || 1
+  // Celo Specific
+  transaction.feeCurrency = ensureLeading0x((tx.feeCurrency || '0x').toLowerCase())
+  // we arent supporting the full classic celo tx so we can zero out these fields.
+  const gatewayFeeRecipient = '0x'
+  const gatewayFee = '0x'
+  // Legacy
+  transaction.gasPrice = stringNumberOrBNToHex(tx.gasPrice)
+  // This order should match the order in Geth.
+  // https://github.com/celo-org/celo-blockchain/blob/027dba2e4584936cc5a8e8993e4e27d28d5247b8/core/types/transaction.go#L65
+  const rlpEncode = rlpEncodeHex([
+    stringNumberToHex(transaction.nonce),
+    transaction.gasPrice,
+    transaction.gas,
+    transaction.feeCurrency,
+    gatewayFeeRecipient,
+    gatewayFee,
+    transaction.to,
+    transaction.value,
+    transaction.data,
+    stringNumberToHex(transaction.chainId),
+    '0x',
+    '0x',
+  ])
+  return { transaction, rlpEncode, type: 'celo-legacy' }
+}
+
 function concatTypePrefixHex(
   rawTransaction: string,
-  txType: EncodedTransaction['tx']['type']
+  txType: EncodedTransaction['tx']['type'] | 'celo-legacy'
 ): StrongAddress {
   const prefix = TxTypeToPrefix[txType]
   if (prefix) {
@@ -272,11 +316,11 @@ export function isPriceToLow(tx: CeloTx) {
   return isLow
 }
 
-function isEIP1559(tx: CeloTx): boolean {
+export function isEIP1559(tx: CeloTx): boolean {
   return isPresent(tx.maxFeePerGas) && isPresent(tx.maxPriorityFeePerGas)
 }
 
-function isCIP64(tx: CeloTx) {
+export function isCIP64(tx: CeloTx) {
   return isEIP1559(tx) && isPresent(tx.feeCurrency)
 }
 
@@ -298,7 +342,7 @@ function isLessThanZero(value: CeloTx['gasPrice']) {
 }
 
 export async function encodeTransaction(
-  rlpEncoded: RLPEncodedTx,
+  rlpEncoded: RLPEncodedTx | LegacyEncodedTx,
   signature: { v: number | bigint; r: Buffer; s: Buffer }
 ): Promise<EncodedTransaction> {
   const sanitizedSignature = signatureFormatter(signature, rlpEncoded.type)
@@ -307,7 +351,9 @@ export async function encodeTransaction(
   // for legacy tx we need to slice but for new ones we do not want to do that
   let decodedFields: typeof decodedTX
 
-  if (rlpEncoded.type == 'ethereum-legacy') {
+  if (rlpEncoded.type == 'celo-legacy') {
+    decodedFields = decodedTX.slice(0, 9)
+  } else if (rlpEncoded.type == 'ethereum-legacy') {
     decodedFields = decodedTX.slice(0, 6)
   } else {
     decodedFields = decodedTX
@@ -339,7 +385,7 @@ export async function encodeTransaction(
       accessList: parseAccessList(rlpEncoded.transaction.accessList || []),
     }
   }
-  if (rlpEncoded.type === 'cip64') {
+  if (rlpEncoded.type === 'cip64' || rlpEncoded.type === 'celo-legacy') {
     tx = {
       ...tx,
       // @ts-expect-error -- just a matter of how  this tx is built
@@ -354,7 +400,7 @@ export async function encodeTransaction(
     }
   }
 
-  const result: EncodedTransaction & { type: TransactionTypes } = {
+  const result: EncodedTransaction & { type: TransactionTypes | 'celo-legacy' } = {
     tx: tx as EncodedTransaction['tx'],
     raw: rawTransaction,
     type: rlpEncoded.type,

--- a/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.test.ts
+++ b/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.test.ts
@@ -374,9 +374,77 @@ describe('LedgerWallet class', () => {
             })
 
             test(
-              'succeeds',
+              'succeeds on cel2 (when ledger version is above minimum)',
               async () => {
                 await expect(wallet.signTransaction(celoTransaction)).resolves.not.toBeUndefined()
+              },
+              TEST_TIMEOUT_IN_MS
+            )
+            //
+            test(
+              'fails on cel2 (when ledger version is below minimum)',
+              async () => {
+                wallet = new LedgerWallet(
+                  undefined,
+                  undefined,
+                  undefined,
+                  AddressValidation.never,
+                  true
+                )
+                mockForceValidation = jest.fn((): void => {
+                  // do nothing
+                })
+                mockLedger(wallet, mockForceValidation, '1.0.0')
+                await wallet.init()
+
+                expect(
+                  wallet.signTransaction(celoTransaction)
+                ).rejects.toThrowErrorMatchingInlineSnapshot(
+                  `"celo ledger app version must be at least 1.2.0 to sign transactions supported on celo after the L2 upgrade"`
+                )
+              },
+              TEST_TIMEOUT_IN_MS
+            )
+            test(
+              'on cel1 with old ledger converts to legacy tx',
+              async () => {
+                wallet = new LedgerWallet(
+                  undefined,
+                  undefined,
+                  undefined,
+                  AddressValidation.never,
+                  false
+                )
+                mockForceValidation = jest.fn((): void => {
+                  // do nothing
+                })
+                mockLedger(wallet, mockForceValidation, '1.0.0')
+                await wallet.init()
+                const warnSpy = jest.spyOn(console, 'warn')
+                // setup complete
+
+                await expect(wallet.signTransaction(celoTransaction)).resolves
+                  .toMatchInlineSnapshot(`
+                  {
+                    "raw": "0xf86b80636380808094588e4b68193001e4d10928660ab4165b813717c0880de0b6b3a76400008083015e09a0dc9e278c10d4b3416f436ef1c3e7ab913391771fee82f7d7f5a810d01561ba34a07d9d09088d2cfe05345fede2fdfb837be7b5e2ae428e4dda94c042d3dd246e1e",
+                    "tx": {
+                      "feeCurrency": "0x",
+                      "gas": "0x63",
+                      "hash": "0x3c764c8b7e35fb841b57d8409a9210df87b10d6e6334a43ce936cdf569f20d01",
+                      "input": "0x",
+                      "nonce": "0",
+                      "r": "0xdc9e278c10d4b3416f436ef1c3e7ab913391771fee82f7d7f5a810d01561ba34",
+                      "s": "0x7d9d09088d2cfe05345fede2fdfb837be7b5e2ae428e4dda94c042d3dd246e1e",
+                      "to": "0x588e4b68193001e4d10928660ab4165b813717c0",
+                      "v": "0x015e09",
+                      "value": "0x0de0b6b3a7640000",
+                    },
+                    "type": "celo-legacy",
+                  }
+                `)
+                expect(warnSpy).toHaveBeenCalledWith(
+                  'Upgrade your celo ledger app to at least 1.2.0 before cel2 transition'
+                )
               },
               TEST_TIMEOUT_IN_MS
             )
@@ -462,7 +530,7 @@ describe('LedgerWallet class', () => {
                 nonce: 0,
                 gas: 99,
                 gasPrice: 99,
-                feeCurrency: '0x1234',
+                feeCurrency: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
               }
             })
             describe('with old ledger app', () => {
@@ -495,36 +563,63 @@ describe('LedgerWallet class', () => {
                 )
               })
               describe('on celo l1 with old app version', () => {
-                beforeEach(async () => {
-                  wallet = new LedgerWallet(
-                    undefined,
-                    undefined,
-                    undefined,
-                    AddressValidation.never,
-                    false
-                  )
-                  mockForceValidation = jest.fn((): void => {
-                    // do nothing
-                  })
-                  mockLedger(wallet, mockForceValidation, '1.0.0')
-                  await wallet.init()
-                })
                 test(
                   'succeeds with warning',
                   async () => {
+                    wallet = new LedgerWallet(
+                      undefined,
+                      undefined,
+                      undefined,
+                      AddressValidation.never,
+                      false
+                    )
+                    mockForceValidation = jest.fn((): void => {
+                      // do nothing
+                    })
+                    mockLedger(wallet, mockForceValidation, '1.0.0')
+                    await wallet.init()
                     const warnSpy = jest.spyOn(console, 'warn')
+                    // setup complete
 
-                    const signSpy = jest.spyOn(wallet.ledger!, 'signTransaction')
-
-                    await wallet.signTransaction(celoTransaction)
-
-                    expect(signSpy).toHaveBeenCalledWith('0x')
-
-                    expect(warnSpy.mock.calls).toMatchInlineSnapshot()
+                    await expect(wallet.signTransaction(celoTransaction)).resolves
+                      .toMatchInlineSnapshot(`
+                      {
+                        "raw": "0xf87f80636394d8763cba276a3738e6de85b4b3bf5fded6d6ca73808094588e4b68193001e4d10928660ab4165b813717c0880de0b6b3a76400008083015e09a09d8307331534bc7839f055dcaab64d991057da094b021466c734f26b08c3e1f4a02332ec85ff2889e1a05590a97fe0c429fadb2c4260af4dea2b6b69a26c4d60e0",
+                        "tx": {
+                          "feeCurrency": "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73",
+                          "gas": "0x63",
+                          "hash": "0xc0467a86cae1f1a526899e450764c747777dc146f6c021edbe9021c13e1e189b",
+                          "input": "0x",
+                          "nonce": "0",
+                          "r": "0x9d8307331534bc7839f055dcaab64d991057da094b021466c734f26b08c3e1f4",
+                          "s": "0x2332ec85ff2889e1a05590a97fe0c429fadb2c4260af4dea2b6b69a26c4d60e0",
+                          "to": "0x588e4b68193001e4d10928660ab4165b813717c0",
+                          "v": "0x015e09",
+                          "value": "0x0de0b6b3a7640000",
+                        },
+                        "type": "celo-legacy",
+                      }
+                    `)
+                    expect(warnSpy).toHaveBeenCalledWith(
+                      'Upgrade your celo ledger app to at least 1.2.0 before cel2 transition'
+                    )
                   },
                   TEST_TIMEOUT_IN_MS
                 )
               })
+            })
+            describe('with new ledger app', () => {
+              test(
+                'fails with helpful error',
+                async () => {
+                  await expect(
+                    wallet.signTransaction(celoTransaction)
+                  ).rejects.toThrowErrorMatchingInlineSnapshot(
+                    `"celo ledger app above 1.2.0 cannot serialize legacy celo transactions. Replace "gasPrice" with "maxFeePerGas"."`
+                  )
+                },
+                TEST_TIMEOUT_IN_MS
+              )
             })
           })
 

--- a/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts
+++ b/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts
@@ -1,6 +1,14 @@
 import { CELO_DERIVATION_PATH_BASE } from '@celo/base/lib/account'
 import { zeroRange } from '@celo/base/lib/collections'
 import { Address, CeloTx, EncodedTransaction, ReadOnlyWallet } from '@celo/connect'
+import {
+  chainIdTransformationForSigning,
+  encodeTransaction,
+  encode_deprecated_celo_legacy_type_only_for_temporary_ledger_compat,
+  isCIP64,
+  isEIP1559,
+  rlpEncodedTx,
+} from '@celo/wallet-base'
 import { RemoteWallet } from '@celo/wallet-remote'
 import { TransportError, TransportStatusError } from '@ledgerhq/errors'
 import Ledger from '@ledgerhq/hw-app-eth'
@@ -28,13 +36,15 @@ export async function newLedgerWalletWithSetup(
   transport: any,
   derivationPathIndexes?: number[],
   baseDerivationPath?: string,
-  ledgerAddressValidation?: AddressValidation
+  ledgerAddressValidation?: AddressValidation,
+  isCel2?: boolean
 ): Promise<LedgerWallet> {
   const wallet = new LedgerWallet(
     derivationPathIndexes,
     baseDerivationPath,
     transport,
-    ledgerAddressValidation
+    ledgerAddressValidation,
+    isCel2
   )
   await wallet.init()
   return wallet
@@ -43,7 +53,7 @@ export async function newLedgerWalletWithSetup(
 const debug = debugFactory('kit:wallet:ledger')
 
 export class LedgerWallet extends RemoteWallet<LedgerSigner> implements ReadOnlyWallet {
-  private MIN_VERSION_SUPPORTED = '1.2.0'
+  private MIN_VERSION_SUPPORTED = '1.0.0'
   ledger: Ledger | undefined
 
   /**
@@ -58,7 +68,8 @@ export class LedgerWallet extends RemoteWallet<LedgerSigner> implements ReadOnly
     readonly derivationPathIndexes: number[] = zeroRange(ADDRESS_QTY),
     readonly baseDerivationPath: string = CELO_BASE_DERIVATION_PATH,
     readonly transport: any = {},
-    readonly ledgerAddressValidation: AddressValidation = AddressValidation.firstTransactionPerAddress
+    readonly ledgerAddressValidation: AddressValidation = AddressValidation.firstTransactionPerAddress,
+    readonly isCel2?: boolean
   ) {
     super()
     const invalidDPs = derivationPathIndexes.some(
@@ -70,18 +81,65 @@ export class LedgerWallet extends RemoteWallet<LedgerSigner> implements ReadOnly
   }
 
   async signTransaction(txParams: CeloTx): Promise<EncodedTransaction> {
-    if (txParams.gasPrice) {
-      if (txParams.feeCurrency && txParams.feeCurrency !== '0x') {
-        // NOTE: celo-legacy is not supported anymore
+    const rlpEncoded = await this.rlpEncodedTxForLedger(txParams)
+    const addToV =
+      rlpEncoded.type === 'celo-legacy' ? chainIdTransformationForSigning(txParams.chainId!) : 27
+
+    // Get the signer from the 'from' field
+    const fromAddress = txParams.from!.toString()
+    const signer = this.getSigner(fromAddress)
+    const signature = await signer!.signTransaction(addToV, rlpEncoded)
+
+    return encodeTransaction(rlpEncoded, signature)
+  }
+
+  async rlpEncodedTxForLedger(txParams: CeloTx) {
+    if (!txParams) {
+      throw new Error('No transaction object given!')
+    }
+
+    const deviceApp = await this.retrieveAppConfiguration()
+    const version = new SemVer(deviceApp.version)
+
+    // if the app is of minimum version it doesnt matter if chain is cel2 or not
+    if (isAtLeastMinimum(version, { minimum: MINIMUM_VERSION_FOR_STANDARD_TRANSACTIONS })) {
+      if (txParams.gasPrice && txParams.feeCurrency && txParams.feeCurrency !== '0x') {
         throw new Error(
-          'celo-legacy transactions are not supported anymore, please try sending a more modern transaction instead (eip1559, cip64, etc.)'
+          'Cannot serialize both "gasPrice" and "feeCurrency" together. To keep "feeCurrency", replace "gasPrice" with "maxFeePerGas". To keep "gasPrice" and send a type 0 transaction remove "feeCurrency"'
         )
       }
+      if (txParams.gasPrice) {
+        throw new Error(
+          'ethereum-legacy transactions are not supported, please try sending a more modern transaction instead (eip1559, cip64, etc.)'
+        )
+      }
+      // TODO ensure it is building a 1559 or cip64 tx, possibly force it
+      // by deleting/ adding properties instead of throwing.
+      // TODO when cip66 is implemented ensure it is not that
+      if (isEIP1559(txParams) || isCIP64(txParams)) {
+        return rlpEncodedTx(txParams)
+      } else {
+        throw new Error(
+          'only eip1559 and cip64 transactions can be signd by this version of celo ledger app'
+        )
+      }
+      // but if not celo as layer 2 and as layer 1 are different
+    } else if (this.isCel2) {
       throw new Error(
-        'ethereum-legacy transactions are not supported, please try sending a more modern transaction instead (eip1559, cip64, etc.)'
+        `celo ledger app version must be at least ${MINIMUM_VERSION_FOR_STANDARD_TRANSACTIONS.version} to sign transactions supported on celo after the L2 upgrade`
       )
+    } else {
+      console.warn(
+        `Upgrade your celo ledger app to at least ${MINIMUM_VERSION_FOR_STANDARD_TRANSACTIONS}`
+      )
+      if (!txParams.gasPrice) {
+        // this version of app only supports legacy so must have gasPrice
+        txParams.gasPrice = txParams.maxFeePerGas
+        delete txParams.maxFeePerGas
+        delete txParams.maxPriorityFeePerGas
+      }
+      return encode_deprecated_celo_legacy_type_only_for_temporary_ledger_compat(txParams)
     }
-    return super.signTransaction(txParams)
   }
 
   protected async loadAccountSigners(): Promise<Map<Address, LedgerSigner>> {
@@ -146,3 +204,10 @@ export class LedgerWallet extends RemoteWallet<LedgerSigner> implements ReadOnly
     return appConfiguration
   }
 }
+
+function isAtLeastMinimum(version: SemVer, { minimum }: { minimum: SemVer }) {
+  const equality = version.compare(minimum)
+  return equality === 0 || equality === 1
+}
+
+const MINIMUM_VERSION_FOR_STANDARD_TRANSACTIONS = new SemVer('1.2.0')


### PR DESCRIPTION
### Description

allow for easier transition by supporting multiple celo ledger app versions with and without suppot for legacy transactions. 

### Other changes



### Tested

added multiple test cases , no device testing

### Related issues


### Backwards compatibility

yes

### Documentation

_The set of community facing docs that have been added/modified because of this change_

<!-- start pr-codex -->

---

## PR-Codex overview
This PR temporarily supports older celo-legacy transactions and legacy ledger apps. 

### Detailed summary
- Added support for celo-legacy transactions in `BaseCommand` and `LedgerSigner`
- Introduced `isCel2` check in `LedgerWallet`
- Implemented encoding for celo-legacy transactions in signing-utils

> The following files were skipped due to too many changes: `packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts`, `packages/sdk/wallets/wallet-ledger/src/ledger-wallet.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->