### PR TITLE
Bump up dependencies and move setupL2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "yarn test-pure && yarn test-needing-ganache",
     "test-pure": "yarn workspaces foreach -piv --all --exclude celo --exclude \"@celo/{celocli,contractkit,transactions-uri}\" run test",
     "test-needing-ganache": "yarn workspace @celo/contractkit test && yarn workspace @celo/celocli test && yarn workspace @celo/transactions-uri test",
-    "build": "yarn workspaces foreach -pitv --all run build",
+    "build": "yarn workspaces foreach -piv --all --topological-dev run build",
     "clean": "yarn workspaces foreach -piv --all run clean",
     "docs": "yarn workspaces foreach -piv --all run docs",
     "cs": "yarn changeset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,6 @@
     "@celo/connect": "^5.3.0",
     "@celo/contractkit": "^8.0.0",
     "@celo/cryptographic-utils": "^5.0.8",
-    "@celo/devchain-anvil": "^0.0.11007",
     "@celo/explorer": "^5.0.10",
     "@celo/governance": "^5.1.1",
     "@celo/identity": "^5.1.2",
@@ -75,6 +74,7 @@
   "devDependencies": {
     "@celo/celo-devchain": "^7.0.0",
     "@celo/dev-utils": "0.0.3",
+    "@celo/devchain-anvil": "0.0.10957",
     "@celo/typescript": "workspace:^",
     "@types/debug": "^4.1.4",
     "@types/fs-extra": "^8.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@celo/celo-devchain": "^7.0.0",
     "@celo/dev-utils": "0.0.3",
-    "@celo/devchain-anvil": "0.0.10957",
+    "@celo/devchain-anvil": "0.0.11007",
     "@celo/typescript": "workspace:^",
     "@types/debug": "^4.1.4",
     "@types/fs-extra": "^8.0.0",

--- a/packages/cli/src/commands/network/contracts-l2.test.ts
+++ b/packages/cli/src/commands/network/contracts-l2.test.ts
@@ -1,6 +1,5 @@
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import write from '@oclif/core/lib/cli-ux/write'
-import { setupL2 } from '../../test-utils/chain-setup'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Contracts from './contracts'
 process.env.NO_SYNCCHECK = 'true'

--- a/packages/cli/src/commands/network/info-l2.test.ts
+++ b/packages/cli/src/commands/network/info-l2.test.ts
@@ -1,6 +1,5 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
-import { setupL2 } from '../../test-utils/chain-setup'
+import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Info from './info'
 process.env.NO_SYNCCHECK = 'true'

--- a/packages/cli/src/commands/network/parameters-l2.test.ts
+++ b/packages/cli/src/commands/network/parameters-l2.test.ts
@@ -1,5 +1,4 @@
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
-import { setupL2 } from '../../test-utils/chain-setup'
+import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Parameters from './parameters'
 

--- a/packages/cli/src/commands/network/whitelist-l2.test.ts
+++ b/packages/cli/src/commands/network/whitelist-l2.test.ts
@@ -1,6 +1,5 @@
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
-import { setupL2 } from '../../test-utils/chain-setup'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Whitelist from './whitelist'
 

--- a/packages/cli/src/test-utils/chain-setup.test.ts
+++ b/packages/cli/src/test-utils/chain-setup.test.ts
@@ -1,7 +1,6 @@
 import { isCel2 } from '@celo/connect'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
-import { setupL2 } from './chain-setup'
 
 testWithAnvil('chain setup', (web3: Web3) => {
   describe('setupL2()', () => {

--- a/packages/cli/src/test-utils/chain-setup.ts
+++ b/packages/cli/src/test-utils/chain-setup.ts
@@ -1,18 +1,15 @@
 import { StrongAddress } from '@celo/base'
-import { PROXY_ADMIN_ADDRESS } from '@celo/connect'
 import { ContractKit, StableToken } from '@celo/contractkit'
 import {
   DEFAULT_OWNER_ADDRESS,
   STABLES_ADDRESS,
   impersonateAccount,
-  setCode,
   stopImpersonatingAccount,
 } from '@celo/dev-utils/lib/anvil-test'
 import { mineBlocks } from '@celo/dev-utils/lib/ganache-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
-import { proxyBytecode } from './constants'
 
 export const GANACHE_EPOCH_SIZE = 100
 export const MIN_LOCKED_CELO_VALUE = new BigNumber(Web3.utils.toWei('10000', 'ether')) // 10k CELO
@@ -140,13 +137,6 @@ export const topUpWithToken = async (
     from: STABLES_ADDRESS,
   })
   await stopImpersonatingAccount(kit.web3, STABLES_ADDRESS)
-}
-
-// TODO remove this once no longer needed
-export const setupL2 = async (web3: Web3) => {
-  // Temporarily deploying any bytecode, so it's just there,
-  // isCel2 should hence return true as it just checks for bytecode existence
-  await setCode(web3, PROXY_ADMIN_ADDRESS, proxyBytecode)
 }
 
 // replace the original owner in the devchain, so we can act as the multisig owner

--- a/packages/cli/src/utils/fee-currency.test.ts
+++ b/packages/cli/src/utils/fee-currency.test.ts
@@ -2,9 +2,8 @@ import { isCel2 } from '@celo/connect'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { FeeCurrencyDirectoryWrapper } from '@celo/contractkit/lib/wrappers/FeeCurrencyDirectoryWrapper'
 import { FeeCurrencyWhitelistWrapper } from '@celo/contractkit/lib/wrappers/FeeCurrencyWhitelistWrapper'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
-import { setupL2 } from '../test-utils/chain-setup'
 import { getFeeCurrencyContractWrapper } from './fee-currency'
 
 testWithAnvil('getFeeCurrencyContractWrapper', async (web3: Web3) => {

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -20,6 +20,7 @@
     "prepack": "yarn build"
   },
   "dependencies": {
+    "@celo/connect": "^5.3.0",
     "@viem/anvil": "^0.0.9",
     "bignumber.js": "^9.0.0",
     "fs-extra": "^8.1.0",

--- a/packages/dev-utils/src/anvil-test.ts
+++ b/packages/dev-utils/src/anvil-test.ts
@@ -1,3 +1,4 @@
+import { PROXY_ADMIN_ADDRESS } from '@celo/connect'
 import { Anvil, CreateAnvilOptions, createAnvil } from '@viem/anvil'
 import Web3 from 'web3'
 import {
@@ -57,6 +58,23 @@ export function stopImpersonatingAccount(web3: Web3, address: string) {
   return jsonRpcCall(web3, 'anvil_stopImpersonatingAccount', [address])
 }
 
+export const withImpersonatedAccount = async (
+  web3: Web3,
+  account: string,
+  fn: () => Promise<void>
+) => {
+  await impersonateAccount(web3, account)
+  await fn()
+  await stopImpersonatingAccount(web3, account)
+}
+
 export function setCode(web3: Web3, address: string, code: string) {
   return jsonRpcCall(web3, 'anvil_setCode', [address, code])
+}
+
+// TODO remove this once no longer needed
+export const setupL2 = async (web3: Web3) => {
+  // Temporarily deploying any bytecode, so it's just there,
+  // isCel2 should hence return true as it just checks for bytecode existence
+  await setCode(web3, PROXY_ADMIN_ADDRESS, '0x1234567890')
 }

--- a/packages/sdk/contractkit/package.json
+++ b/packages/sdk/contractkit/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@celo/abis": "11.0.0",
-    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.0",
+    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.2",
     "@celo/base": "^6.0.1",
     "@celo/connect": "^5.3.0",
     "@celo/utils": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,6 +1799,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@celo/dev-utils@workspace:packages/dev-utils"
   dependencies:
+    "@celo/connect": "npm:^5.3.0"
     "@tsconfig/recommended": "npm:^1.0.3"
     "@types/fs-extra": "npm:^8.1.0"
     "@types/targz": "npm:1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1619,7 +1619,7 @@ __metadata:
     "@celo/contractkit": "npm:^8.0.0"
     "@celo/cryptographic-utils": "npm:^5.0.8"
     "@celo/dev-utils": "npm:0.0.3"
-    "@celo/devchain-anvil": "npm:0.0.10903"
+    "@celo/devchain-anvil": "npm:0.0.10957"
     "@celo/explorer": "npm:^5.0.10"
     "@celo/governance": "npm:^5.1.1"
     "@celo/identity": "npm:^5.1.2"
@@ -1813,10 +1813,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@celo/devchain-anvil@npm:0.0.10903":
-  version: 0.0.10903
-  resolution: "@celo/devchain-anvil@npm:0.0.10903"
-  checksum: d4772116f4c62447348074740944318d8783551a5c0624d3fe933383e7d8688c10532c784581a96d710640547d6233b14033cb7fca35b90867c720df2087e8bd
+"@celo/devchain-anvil@npm:0.0.10957":
+  version: 0.0.10957
+  resolution: "@celo/devchain-anvil@npm:0.0.10957"
+  checksum: b74167cbb6902a5e7d6c88e7f74691c4fef02a2e2e03cc8cf3fac676088289fe9571cbaaeb63a32510ff36ef3a47f774ef18db6243d4c94efc620d18f263b22e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1619,7 +1619,7 @@ __metadata:
     "@celo/contractkit": "npm:^8.0.0"
     "@celo/cryptographic-utils": "npm:^5.0.8"
     "@celo/dev-utils": "npm:0.0.3"
-    "@celo/devchain-anvil": "npm:0.0.10957"
+    "@celo/devchain-anvil": "npm:0.0.11007"
     "@celo/explorer": "npm:^5.0.10"
     "@celo/governance": "npm:^5.1.1"
     "@celo/identity": "npm:^5.1.2"
@@ -1813,10 +1813,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@celo/devchain-anvil@npm:0.0.10957":
-  version: 0.0.10957
-  resolution: "@celo/devchain-anvil@npm:0.0.10957"
-  checksum: b74167cbb6902a5e7d6c88e7f74691c4fef02a2e2e03cc8cf3fac676088289fe9571cbaaeb63a32510ff36ef3a47f774ef18db6243d4c94efc620d18f263b22e
+"@celo/devchain-anvil@npm:0.0.11007":
+  version: 0.0.11007
+  resolution: "@celo/devchain-anvil@npm:0.0.11007"
+  checksum: 08ff1904363969996e5b747781c317c45150a6ddee4868ae6aae6e515114ebb0b953a0abaecce1c2f7550544facc53beaf0081b8dfdfb5757ceece4e1c69e2e1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1555,10 +1555,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@celo/abis-12@npm:@celo/abis@12.0.0-canary.0":
-  version: 12.0.0-canary.0
-  resolution: "@celo/abis@npm:12.0.0-canary.0"
-  checksum: a7bc515a936b9ee8c198f3d5699c56ebe144df2a3123625e7f5f1480e248f4667efa16669997f6547a85cbdf329d903eea88ecf6ace222e334e34609910da656
+"@celo/abis-12@npm:@celo/abis@12.0.0-canary.2":
+  version: 12.0.0-canary.2
+  resolution: "@celo/abis@npm:12.0.0-canary.2"
+  checksum: 01d62e7b11b1d2f2b8feaaedbed1615b016b09b2903bcb48695de855399548f9ab150a38add32f2887ae6dba958586d49ee12c809b867699b2808de2ea8796e2
   languageName: node
   linkType: hard
 
@@ -1619,7 +1619,7 @@ __metadata:
     "@celo/contractkit": "npm:^8.0.0"
     "@celo/cryptographic-utils": "npm:^5.0.8"
     "@celo/dev-utils": "npm:0.0.3"
-    "@celo/devchain-anvil": "npm:^0.0.11007"
+    "@celo/devchain-anvil": "npm:0.0.10903"
     "@celo/explorer": "npm:^5.0.10"
     "@celo/governance": "npm:^5.1.1"
     "@celo/identity": "npm:^5.1.2"
@@ -1750,7 +1750,7 @@ __metadata:
   resolution: "@celo/contractkit@workspace:packages/sdk/contractkit"
   dependencies:
     "@celo/abis": "npm:11.0.0"
-    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.0"
+    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.2"
     "@celo/base": "npm:^6.0.1"
     "@celo/celo-devchain": "npm:^7.0.0"
     "@celo/connect": "npm:^5.3.0"
@@ -1813,10 +1813,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@celo/devchain-anvil@npm:^0.0.11007":
-  version: 0.0.11007
-  resolution: "@celo/devchain-anvil@npm:0.0.11007"
-  checksum: 08ff1904363969996e5b747781c317c45150a6ddee4868ae6aae6e515114ebb0b953a0abaecce1c2f7550544facc53beaf0081b8dfdfb5757ceece4e1c69e2e1
+"@celo/devchain-anvil@npm:0.0.10903":
+  version: 0.0.10903
+  resolution: "@celo/devchain-anvil@npm:0.0.10903"
+  checksum: d4772116f4c62447348074740944318d8783551a5c0624d3fe933383e7d8688c10532c784581a96d710640547d6233b14033cb7fca35b90867c720df2087e8bd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This PR bumps up dependencies and moves `setupL2` outside of CLI as it's needed in other packages as well.

### Other changes

None.

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Backwards compatibility

Backwards compatible.

### Documentation

None.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates dependencies, adds `@celo/connect` to various packages, and refactors test imports to use `@celo/dev-utils/lib/anvil-test`.

### Detailed summary
- Updated `@celo/abis-12` to version `12.0.0-canary.2`
- Added `@celo/connect` to multiple packages
- Refactored test imports to use `@celo/dev-utils/lib/anvil-test`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->