### PR TITLE
Contracts, Params and Deprecations notices

### DIFF
--- a/.changeset/silly-rings-juggle.md
+++ b/.changeset/silly-rings-juggle.md
@@ -1,0 +1,5 @@
+---
+'@celo/contractkit': patch
+---
+
+Deprecated methods on kit instance for getting epoch info.

--- a/packages/cli/src/commands/network/parameters-l2.test.ts
+++ b/packages/cli/src/commands/network/parameters-l2.test.ts
@@ -12,13 +12,7 @@ testWithAnvil('network:parameters', (web3) => {
     expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
       [
         [
-          "Attestations: 
-      Failed to fetch config for contract Attestations: 
-      Error: Attestations not (yet) registered
-      BlockchainParameters: 
-        blockGasLimit: 13000000 (~1.300e+7)
-        intrinsicGasForAlternativeFeeCurrency: 50000 (~5.000e+4)
-      DowntimeSlasher: 
+          "DowntimeSlasher: 
         slashableDowntime: 5 minutes
         slashingIncentives: 
           penalty: 100000000000000000000 (~1.000e+20)
@@ -31,29 +25,11 @@ testWithAnvil('network:parameters', (web3) => {
           min: 1 
         maxNumGroupsVotedFor: 10 
         totalVotes: 0 
-      EpochRewards: 
-        carbonOffsetting: 
-          factor: 0.001 
-          partner: 0x0000000000000000000000000000000000000000
-        communityReward: 0.25 
-        rewardsMultiplier: 
-          max: 0 
-          overspendAdjustment: 5 
-          underspendAdjustment: 0.5 
-        targetValidatorEpochPayment: 205479452054794520547 (~2.055e+20)
-        targetVotingYield: 
-          adjustment: 0 
-          max: 0.0005 
-          target: 0 
       FeeCurrencyDirectory: 
         intrinsicGasForAlternativeFeeCurrency: 
           0x2A3733dBc31980f02b12135C809b5da33BF3a1e9: 21000 (~2.100e+4)
           0xb7a33b4ad2B1f6b0a944232F5c71798d27Ad9272: 21000 (~2.100e+4)
           0xe6774BE4E5f97dB10cAFB4c00C74cFbdCDc434D9: 21000 (~2.100e+4)
-      GasPriceMinimum: 
-        adjustmentSpeed: 0.5 
-        gasPriceMinimum: 100000000 (~1.000e+8)
-        targetDensity: 0.5 
       Governance: 
         concurrentProposals: 3 
         dequeueFrequency: 4 hours

--- a/packages/sdk/contractkit/src/kit.ts
+++ b/packages/sdk/contractkit/src/kit.ts
@@ -141,22 +141,33 @@ export class ContractKit {
   async getNetworkConfig(
     humanReadable = false
   ): Promise<NetworkConfig | Record<CeloContract & 'stableTokens', unknown>> {
-    const configContracts: ValidWrappers[] = [
-      CeloContract.Election,
-      CeloContract.Attestations,
-      CeloContract.Governance,
-      CeloContract.LockedGold,
-      CeloContract.SortedOracles,
-      CeloContract.GasPriceMinimum,
-      CeloContract.Reserve,
-      CeloContract.Validators,
-      CeloContract.DowntimeSlasher,
-      CeloContract.BlockchainParameters,
-      CeloContract.EpochRewards,
-    ]
+    let configContracts: ValidWrappers[]
 
     if (await isCel2(this.web3)) {
-      configContracts.push(CeloContract.FeeCurrencyDirectory)
+      configContracts = [
+        CeloContract.Election,
+        CeloContract.Governance,
+        CeloContract.LockedGold,
+        CeloContract.SortedOracles,
+        CeloContract.Reserve,
+        CeloContract.Validators,
+        CeloContract.DowntimeSlasher,
+        CeloContract.FeeCurrencyDirectory,
+      ]
+    } else {
+      configContracts = [
+        CeloContract.Election,
+        CeloContract.Attestations,
+        CeloContract.Governance,
+        CeloContract.LockedGold,
+        CeloContract.SortedOracles,
+        CeloContract.GasPriceMinimum,
+        CeloContract.Reserve,
+        CeloContract.Validators,
+        CeloContract.DowntimeSlasher,
+        CeloContract.BlockchainParameters,
+        CeloContract.EpochRewards,
+      ]
     }
 
     const configMethod = async (contract: ValidWrappers) => {
@@ -201,22 +212,33 @@ export class ContractKit {
     }
     this.connection.defaultFeeCurrency = address
   }
-
+  /*
+   * @deprecated - epoch related methods will be removed from contractkit
+   */
   async getEpochSize(): Promise<number> {
     const blockchainParamsWrapper = await this.contracts.getBlockchainParameters()
     return blockchainParamsWrapper.getEpochSizeNumber()
   }
 
+  /*
+   * @deprecated - epoch related methods will be removed from contractkit
+   */
   async getFirstBlockNumberForEpoch(epochNumber: number): Promise<number> {
     const blockchainParamsWrapper = await this.contracts.getBlockchainParameters()
     return blockchainParamsWrapper.getFirstBlockNumberForEpoch(epochNumber)
   }
 
+  /*
+   * @deprecated - epoch related methods will be removed from contractkit
+   */
   async getLastBlockNumberForEpoch(epochNumber: number): Promise<number> {
     const blockchainParamsWrapper = await this.contracts.getBlockchainParameters()
     return blockchainParamsWrapper.getLastBlockNumberForEpoch(epochNumber)
   }
 
+  /*
+   * @deprecated - epoch related methods will be removed from contractkit
+   */
   async getEpochNumberOfBlock(blockNumber: number): Promise<number> {
     const blockchainParamsWrapper = await this.contracts.getBlockchainParameters()
     return blockchainParamsWrapper.getEpochNumberOfBlock(blockNumber)


### PR DESCRIPTION
1. rather than some complex if cel2 logic, lets just mark these methods on kit as deprecated and remove before cel2 launch. 

2. I noticed the network config . network:parameters was still including some deprecated/unavailable contracts so updated to have explicit l1 and l2 sets.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to deprecate epoch-related methods from the `ContractKit` instance and update contracts in the CLI and SDK.

### Detailed summary
- Deprecated epoch-related methods in `ContractKit`
- Updated contracts in CLI and SDK
- Added `DowntimeSlasher` parameters in CLI
- Modified `configContracts` in `ContractKit` based on network type

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->