### PR TITLE
refactor: reads supported Foundry version from an environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ env:
   NODE_MODULE_CACHE_VERSION: 5
   NODE_OPTIONS: '--max-old-space-size=4096'
   TERM: dumb
+  # Supported Foundry version defined at celo-org (GitHub organisation) level, for consistency across workflows.
+  SUPPORTED_FOUNDRY_VERSION: ${{ vars.SUPPORTED_FOUNDRY_VERSION }}
 
 # EXAMPLE on debug ssh step
 #  - name: Setup tmate session
@@ -235,7 +237,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: "nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9"
+          version: ${{ env.SUPPORTED_FOUNDRY_VERSION }}
       # NODE_OPTIONS="--experimental-vm-modules" is needed because @viem/anvil uses dynamic imports
       - name: Run tests
         run: |


### PR DESCRIPTION
### Description

1. reads an environment variable (`SUPPORTED_FOUNDRY_VERSION`) defined at the [celo-org](https://github.com/celo-org) (GitHub org) level. 
2. updates the Foundry installation version to use the defined variable for consistency across workflows in [celo-org/celo-monorepo](https://github.com/celo-org/celo-monorepo/blob/b10b77a5b3b1ac9e8750b246e786a649548a2556/.github/workflows/protocol-devchain-anvil.yml#L77-L80) and [celo-org/developer-tooling](https://github.com/celo-org/developer-tooling/blob/ccc5cbb6c46a7f9f74c5b3fdfb1c3fd9fcee257d/.github/workflows/ci.yml#L221-L224).

The overall objective is to update Foundry versions in lock-steps. See more context on pros and cons in: 
- https://github.com/celo-org/celo-monorepo/issues/11032

### Other changes

None

### Tested

Yes, on CI.

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/11032

### Backwards compatibility

Yes

### Documentation

None.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to define the supported Foundry version at the organization level for consistency in workflows.

### Detailed summary
- Added `SUPPORTED_FOUNDRY_VERSION` variable defined at organization level
- Updated Foundry installation version to use the defined variable for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->