### PR TITLE
fix tether display

### DIFF
--- a/.changeset/thirty-tomatoes-dream.md
+++ b/.changeset/thirty-tomatoes-dream.md
@@ -1,0 +1,6 @@
+---
+'@celo/contractkit': patch
+'@celo/celocli': patch
+---
+
+fix: USTD not showing that it uses an adapter by supporting Tether's tokenAdapter implementation

--- a/docs/sdk/contractkit/classes/wrappers_AbstractFeeCurrencyWrapper.AbstractFeeCurrencyWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_AbstractFeeCurrencyWrapper.AbstractFeeCurrencyWrapper.md
@@ -150,7 +150,7 @@ BaseWrapper.address
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts:39](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts#L39)
+[packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts:47](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts#L47)
 
 ___
 
@@ -170,7 +170,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts:41](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts#L41)
+[packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts:49](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts#L49)
 
 ___
 

--- a/docs/sdk/contractkit/classes/wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_FeeCurrencyDirectoryWrapper.FeeCurrencyDirectoryWrapper.md
@@ -261,7 +261,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts:41](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts#L41)
+[packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts:49](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts#L49)
 
 ___
 

--- a/docs/sdk/contractkit/classes/wrappers_FeeCurrencyWhitelistWrapper.FeeCurrencyWhitelistWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_FeeCurrencyWhitelistWrapper.FeeCurrencyWhitelistWrapper.md
@@ -246,7 +246,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts:41](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts#L41)
+[packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts:49](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts#L49)
 
 ___
 

--- a/packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts
+++ b/packages/sdk/contractkit/src/wrappers/AbstractFeeCurrencyWrapper.ts
@@ -24,6 +24,14 @@ const MINIMAL_TOKEN_INFO_ABI = [
     outputs: [{ type: 'address', name: '', internalType: 'address' }],
     name: 'adaptedToken',
   },
+  //  usdt adapter uses slightly different interface this adaptedToken/getAdaptedToken are aliases
+  {
+    type: 'function' as const,
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'address', name: '', internalType: 'address' }],
+    name: 'getAdaptedToken',
+  },
   {
     type: 'function' as const,
     stateMutability: 'view',
@@ -49,7 +57,13 @@ export abstract class AbstractFeeCurrencyWrapper<
         const adaptedToken = (await contract.methods
           .adaptedToken()
           .call()
-          .catch(() => undefined)) as StrongAddress | undefined
+          .catch(() =>
+            contract.methods
+              .getAdaptedToken()
+              .call()
+              .catch(() => undefined)
+          )) as StrongAddress | undefined
+        // if standard didnt work try alt
 
         if (adaptedToken) {
           // @ts-expect-error abi typing is not 100% correct but works


### PR DESCRIPTION
### Description

usdt adapter implemented this external view function using slightly different name than usdc so we are hacking it support both here https://github.com/orgs/celo-org/projects/174/views/37?pane=issue&itemId=67981300

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes an issue where USTD did not display the use of an adapter by supporting Tether's tokenAdapter implementation.

### Detailed summary
- Added `getAdaptedToken` function to handle USDT adapter interface
- Updated method to call `getAdaptedToken` if standard method fails

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->