### PR TITLE
fix: sort signers

### DIFF
--- a/packages/cli/src/commands/election/run.ts
+++ b/packages/cli/src/commands/election/run.ts
@@ -33,7 +33,7 @@ export default class ElectionRun extends BaseCommand {
     const signers = await performElections(kit)
 
     const validatorList = await Promise.all(
-      signers.map((addr) => validators.getValidatorFromSigner(addr))
+      signers.sort().map((addr) => validators.getValidatorFromSigner(addr))
     )
     ux.action.stop()
 


### PR DESCRIPTION
Making sure we can release beta as  https://github.com/celo-org/developer-tooling/actions/runs/9647826271/job/26608672382  failed

<!-- start pr-codex -->

---

## PR-Codex overview
This PR sorts the `signers` array before fetching validator information in the `run.ts` file of the election command.

### Detailed summary
- Sorts the `signers` array before fetching validator information.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->