### PR TITLE
convert transaction-utils to anvil

### DIFF
--- a/.changeset/nervous-starfishes-return.md
+++ b/.changeset/nervous-starfishes-return.md
@@ -1,0 +1,5 @@
+---
+'@celo/dev-utils': patch
+---
+
+Fix jest force exits,Set default timeout to 1 second

--- a/.changeset/wise-weeks-applaud.md
+++ b/.changeset/wise-weeks-applaud.md
@@ -1,0 +1,5 @@
+---
+'@celo/transactions-uri': patch
+---
+
+Bump bn.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,10 @@ jobs:
     needs: install-dependencies
     steps:
       - uses: actions/checkout@v4
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ env.SUPPORTED_FOUNDRY_VERSION }}
       - name: Sync workspace
         uses: ./.github/actions/sync-workspace
         with:

--- a/docs/sdk/transactions-uri/modules/test_utils_setup_global.md
+++ b/docs/sdk/transactions-uri/modules/test_utils_setup_global.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[test-utils/setup.global.ts:10](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/transactions-uri/src/test-utils/setup.global.ts#L10)
+[test-utils/setup.global.ts:7](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/transactions-uri/src/test-utils/setup.global.ts#L7)

--- a/docs/sdk/transactions-uri/modules/test_utils_teardown_global.md
+++ b/docs/sdk/transactions-uri/modules/test_utils_teardown_global.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[test-utils/teardown.global.ts:3](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/transactions-uri/src/test-utils/teardown.global.ts#L3)
+[test-utils/teardown.global.ts:1](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/transactions-uri/src/test-utils/teardown.global.ts#L1)

--- a/packages/dev-utils/src/anvil-test.ts
+++ b/packages/dev-utils/src/anvil-test.ts
@@ -29,6 +29,7 @@ export function createInstance(): Anvil {
     balance: TEST_BALANCE,
     gasPrice: TEST_GAS_PRICE,
     gasLimit: TEST_GAS_LIMIT,
+    stopTimeout: 1000,
   }
 
   instance = createAnvil(options)
@@ -41,11 +42,11 @@ export function testWithAnvil(name: string, fn: (web3: Web3) => void) {
 
   // for each test case, we start and stop a new anvil instance
   return testWithWeb3(name, `http://127.0.0.1:${anvil.port}`, fn, {
-    beforeAll: () => {
-      return anvil.start()
+    beforeAll: async () => {
+      await anvil.start()
     },
     afterAll: async () => {
-      return anvil.stop()
+      await anvil.stop()
     },
   })
 }

--- a/packages/dev-utils/src/test-utils.ts
+++ b/packages/dev-utils/src/test-utils.ts
@@ -85,7 +85,7 @@ export function testWithWeb3(
         await evmRevert(web3, snapId)
       }
       if (hooks?.afterAll) {
-        // hook must be awaited here or jest doesnt actually wait for it and complains of open handlesc
+        // hook must be awaited here or jest doesnt actually wait for it and complains of open handles
         await hooks.afterAll()
       }
     })

--- a/packages/dev-utils/src/test-utils.ts
+++ b/packages/dev-utils/src/test-utils.ts
@@ -84,11 +84,11 @@ export function testWithWeb3(
       if (snapId != null) {
         await evmRevert(web3, snapId)
       }
+      if (hooks?.afterAll) {
+        // hook must be awaited here or jest doesnt actually wait for it and complains of open handlesc
+        await hooks.afterAll()
+      }
     })
-
-    if (hooks?.afterAll) {
-      afterAll(hooks.afterAll)
-    }
 
     fn(web3)
   })

--- a/packages/sdk/transactions-uri/package.json
+++ b/packages/sdk/transactions-uri/package.json
@@ -17,7 +17,7 @@
     "build": "yarn run --top-level tsc -b .",
     "clean": "yarn run --top-level tsc -b . --clean",
     "docs": "yarn run --top-level typedoc",
-    "test": "yarn run --top-level jest --runInBand",
+    "test": "NODE_OPTIONS='--experimental-vm-modules' yarn run --top-level jest --runInBand",
     "lint": "yarn run --top-level eslint -c .eslintrc.js ",
     "prepublishOnly": "yarn build"
   },

--- a/packages/sdk/transactions-uri/package.json
+++ b/packages/sdk/transactions-uri/package.json
@@ -24,14 +24,14 @@
   "dependencies": {
     "@celo/base": "^6.1.0-beta.0",
     "@celo/connect": "^6.0.0-beta.0",
+    "@types/bn.js": "^5.1.0",
     "@types/debug": "^4.1.5",
     "@types/qrcode": "^1.3.4",
-    "bn.js": "4.11.9",
+    "bn.js": "^5.1.0",
     "qrcode": "1.4.4",
     "web3-eth-abi": "1.10.4"
   },
   "devDependencies": {
-    "@celo/celo-devchain": "^7.0.0",
     "@celo/contractkit": "^8.1.0-beta.0",
     "@celo/dev-utils": "0.0.4-beta.0",
     "@celo/typescript": "workspace:^",

--- a/packages/sdk/transactions-uri/src/test-utils/setup.global.ts
+++ b/packages/sdk/transactions-uri/src/test-utils/setup.global.ts
@@ -1,18 +1,7 @@
-import baseSetup from '@celo/dev-utils/lib/ganache-setup'
 // Has to import the matchers somewhere so that typescript knows the matchers have been made available
 import _must_be_imported from '@celo/dev-utils/lib/matchers'
-import { waitForPortOpen } from '@celo/dev-utils/lib/network'
-import * as path from 'path'
 
 // Warning: There should be an unused import of '@celo/dev-utils/lib/matchers' above.
 // If there is not, then your editor probably deleted it automatically.
 
-export default async function globalSetup() {
-  const chainDataPath = path.join(path.dirname(require.resolve('@celo/celo-devchain')), '../chains')
-  // vX refers to core contract release version X
-  await baseSetup(path.resolve(chainDataPath), 'v11.tar.gz', {
-    from_targz: true,
-  })
-  await waitForPortOpen('localhost', 8545, 60)
-  console.log('...ganache started')
-}
+export default async function globalSetup() {}

--- a/packages/sdk/transactions-uri/src/test-utils/teardown.global.ts
+++ b/packages/sdk/transactions-uri/src/test-utils/teardown.global.ts
@@ -1,5 +1,1 @@
-import teardown from '@celo/dev-utils/lib/ganache-teardown'
-
-export default async function globalTeardown() {
-  await teardown()
-}
+export default async function globalTeardown() {}

--- a/packages/sdk/transactions-uri/src/tx-uri.test.ts
+++ b/packages/sdk/transactions-uri/src/tx-uri.test.ts
@@ -1,9 +1,9 @@
 import { CeloTx } from '@celo/connect'
 import { CeloContract, newKitFromWeb3 } from '@celo/contractkit'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import { buildUri, parseUri } from './tx-uri'
 
-testWithGanache('URI utils', (web3) => {
+testWithAnvil('URI utils', (web3) => {
   const recipient = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
   const value = '100'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1998,14 +1998,14 @@ __metadata:
   resolution: "@celo/transactions-uri@workspace:packages/sdk/transactions-uri"
   dependencies:
     "@celo/base": "npm:^6.1.0-beta.0"
-    "@celo/celo-devchain": "npm:^7.0.0"
     "@celo/connect": "npm:^6.0.0-beta.0"
     "@celo/contractkit": "npm:^8.1.0-beta.0"
     "@celo/dev-utils": "npm:0.0.4-beta.0"
     "@celo/typescript": "workspace:^"
+    "@types/bn.js": "npm:^5.1.0"
     "@types/debug": "npm:^4.1.5"
     "@types/qrcode": "npm:^1.3.4"
-    bn.js: "npm:4.11.9"
+    bn.js: "npm:^5.1.0"
     cross-fetch: "npm:3.1.5"
     dotenv: "npm:^8.2.0"
     fetch-mock: "npm:^10.0.7"
@@ -7531,13 +7531,6 @@ __metadata:
   version: 4.11.6
   resolution: "bn.js@npm:4.11.6"
   checksum: 22741b015c9fff60fce32fc9988331b298eb9b6db5bfb801babb23b846eaaf894e440e0d067b2b3ae4e46aab754e90972f8f333b31bf94a686bbcb054bfa7b14
-  languageName: node
-  linkType: hard
-
-"bn.js@npm:4.11.9":
-  version: 4.11.9
-  resolution: "bn.js@npm:4.11.9"
-  checksum: c5a2342f0bc3d0bbe53361d57aa51c489589ad2d7c726c1337e9af7f37b6bc2d2d1b63cfb1972a7aacbc053367832037f699f973c81d9c5844af247650968691
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

transaction-uri tests no longer use anvil at all. 

### Other changes

- fix anvil not closing within jest's 1 second timeout by setting anvil timeout to 1 second too.
- removing the now unneeded celo-devchain exposed that it was indirectly providing @types/bn

### Tested


### Related issues


### Backwards compatibility

yes
### Documentation

n/a

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates packages and dependencies, fixes Jest force exits, and improves Anvil test setup.

### Detailed summary
- Updated `bn.js` to version `5.1.0`
- Fixed Jest force exits in `@celo/dev-utils`
- Improved Anvil test setup in `@celo/dev-utils`
- Modified test script in `packages/sdk/transactions-uri/package.json`
- Removed unnecessary code in `packages/sdk/transactions-uri/src/test-utils/setup.global.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->