### PR TITLE
fix: ledger git url

### DIFF
--- a/.changeset/real-months-compare.md
+++ b/.changeset/real-months-compare.md
@@ -1,0 +1,6 @@
+---
+'@celo/wallet-ledger': patch
+'@celo/celocli': patch
+---
+
+Change git url

--- a/packages/sdk/wallets/wallet-ledger/package.json
+++ b/packages/sdk/wallets/wallet-ledger/package.json
@@ -32,7 +32,7 @@
     "@celo/wallet-remote": "^6.0.0-beta.2",
     "@ethereumjs/util": "8.0.5",
     "@ledgerhq/errors": "^6.16.4",
-    "@ledgerhq/hw-app-eth": "git+https://github.com:celo-org/ledgerjs-hw-app-eth.git#commit=49bdd4f163f5ff73daa9f54f8e46aa2882b85f44",
+    "@ledgerhq/hw-app-eth": "git+https://github.com:celo-org/ledgerjs-hw-app-eth.git",
     "@ledgerhq/hw-transport": "^6.30.6",
     "debug": "^4.1.1",
     "semver": "^7.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2191,7 +2191,7 @@ __metadata:
     "@celo/wallet-remote": "npm:^6.0.0-beta.2"
     "@ethereumjs/util": "npm:8.0.5"
     "@ledgerhq/errors": "npm:^6.16.4"
-    "@ledgerhq/hw-app-eth": "git+https://github.com:celo-org/ledgerjs-hw-app-eth.git#commit=49bdd4f163f5ff73daa9f54f8e46aa2882b85f44"
+    "@ledgerhq/hw-app-eth": "git+https://github.com:celo-org/ledgerjs-hw-app-eth.git"
     "@ledgerhq/hw-transport": "npm:^6.30.6"
     "@ledgerhq/hw-transport-node-hid": "npm:^6.28.5"
     "@noble/curves": "npm:^1.4.0"
@@ -3683,7 +3683,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-app-eth@git+https://github.com:celo-org/ledgerjs-hw-app-eth.git#commit=49bdd4f163f5ff73daa9f54f8e46aa2882b85f44":
+"@ledgerhq/hw-app-eth@git+https://github.com:celo-org/ledgerjs-hw-app-eth.git":
   version: 6.37.1
   resolution: "@ledgerhq/hw-app-eth@https://github.com:celo-org/ledgerjs-hw-app-eth.git#commit=49bdd4f163f5ff73daa9f54f8e46aa2882b85f44"
   dependencies:


### PR DESCRIPTION
idk anymore

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the git URL for `@ledgerhq/hw-app-eth` in the `wallet-ledger` package to remove the commit reference.

### Detailed summary
- Updated git URL for `@ledgerhq/hw-app-eth` in `wallet-ledger` package
- Removed commit reference from the URL in `package.json` and `yarn.lock`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->