### PR TITLE
Migrate tests to anvil

### DIFF
--- a/.changeset/afraid-ladybugs-decide.md
+++ b/.changeset/afraid-ladybugs-decide.md
@@ -1,0 +1,5 @@
+---
+'@celo/dev-utils': patch
+---
+
+Added setCommissionUpdateDelay chain setup function

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -20,6 +20,7 @@
     "prepack": "yarn build"
   },
   "dependencies": {
+    "@celo/abis": "^11.0.0",
     "@celo/connect": "^6.0.0-beta.0",
     "@viem/anvil": "^0.0.9",
     "bignumber.js": "^9.0.0",

--- a/packages/dev-utils/src/chain-setup.ts
+++ b/packages/dev-utils/src/chain-setup.ts
@@ -1,0 +1,18 @@
+import { newValidators } from '@celo/abis/web3/Validators'
+import { StrongAddress } from '@celo/base'
+import Web3 from 'web3'
+import { DEFAULT_OWNER_ADDRESS, withImpersonatedAccount } from './anvil-test'
+
+export async function setCommissionUpdateDelay(
+  web3: Web3,
+  validatorsContractAddress: StrongAddress,
+  delayInBlocks: number
+) {
+  withImpersonatedAccount(web3, DEFAULT_OWNER_ADDRESS, async () => {
+    const validators = newValidators(web3, validatorsContractAddress)
+
+    await validators.methods.setCommissionUpdateDelay(delayInBlocks).send({
+      from: DEFAULT_OWNER_ADDRESS,
+    })
+  })
+}

--- a/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
@@ -1,13 +1,13 @@
-import { getParsedSignatureOfAddress } from '../utils/getParsedSignatureOfAddress'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { StrongAddress } from '@celo/base'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'
 import { ContractKit, newKitFromWeb3 } from '../kit'
+import { getParsedSignatureOfAddress } from '../utils/getParsedSignatureOfAddress'
 import { AccountsWrapper } from './Accounts'
 import { valueToBigNumber, valueToFixidityString } from './BaseWrapper'
 import { LockedGoldWrapper } from './LockedGold'
 import { ValidatorsWrapper } from './Validators'
-import { StrongAddress } from '@celo/base'
 jest.setTimeout(10 * 1000)
 
 /*
@@ -23,7 +23,7 @@ const blsPublicKey =
 const blsPoP =
   '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900'
 
-testWithGanache('Accounts Wrapper', (web3) => {
+testWithAnvil('Accounts Wrapper', (web3) => {
   let kit: ContractKit
   let accounts: StrongAddress[] = []
   let accountsInstance: AccountsWrapper
@@ -190,9 +190,7 @@ testWithGanache('Accounts Wrapper', (web3) => {
     await expect(
       accountsInstance.setPaymentDelegation(beneficiary, fractionInvalid).sendAndWaitForReceipt({})
     ).rejects.toEqual(
-      new Error(
-        'Error: VM Exception while processing transaction: revert Fraction must not be greater than 1'
-      )
+      new Error('Error: execution reverted: revert: Fraction must not be greater than 1')
     )
   })
 

--- a/packages/sdk/contractkit/src/wrappers/FeeCurrencyWhitelistWrapper.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/FeeCurrencyWhitelistWrapper.test.ts
@@ -1,7 +1,7 @@
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import { newKitFromWeb3 } from '../kit'
 
-testWithGanache('FeeCurrencyWhitelist', (web3) => {
+testWithAnvil('FeeCurrencyWhitelist', (web3) => {
   const kit = newKitFromWeb3(web3)
 
   it('fetches fee currency information', async () => {
@@ -11,24 +11,24 @@ testWithGanache('FeeCurrencyWhitelist', (web3) => {
       [
         {
           "adaptedToken": undefined,
-          "address": "0x5315e44798395d4a952530d131249fE00f554565",
-          "decimals": 18,
-          "name": "Celo Dollar",
-          "symbol": "cUSD",
-        },
-        {
-          "adaptedToken": undefined,
-          "address": "0x965D352283a3C8A016b9BBbC9bf6306665d495E7",
-          "decimals": 18,
-          "name": "Celo Brazilian Real",
-          "symbol": "cREAL",
-        },
-        {
-          "adaptedToken": undefined,
-          "address": "0xdD66C23e07b4D6925b6089b5Fe6fc9E62941aFE8",
+          "address": "0x0c6a0fde0A72bA3990870f0F99ED79a821703474",
           "decimals": 18,
           "name": "Celo Euro",
-          "symbol": "cEUR",
+          "symbol": "Celo Euro",
+        },
+        {
+          "adaptedToken": undefined,
+          "address": "0x603931FF5E63d2fd3EEF1513a55fB773d8082195",
+          "decimals": 18,
+          "name": "Celo Brazilian Real",
+          "symbol": "Celo Brazilian Real",
+        },
+        {
+          "adaptedToken": undefined,
+          "address": "0x82398F079D742F9D0Ae71ef8C99E5c68b2eD6705",
+          "decimals": 18,
+          "name": "Celo Dollar",
+          "symbol": "Celo Dollar",
         },
       ]
     `)

--- a/packages/sdk/contractkit/src/wrappers/GoldToken.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/GoldToken.test.ts
@@ -56,7 +56,7 @@ testWithGanache('GoldToken Wrapper', (web3) => {
     expect(after.minus(before)).toEqBigNumber(ONE_GOLD)
   })
 
-  it('tranfers from', async () => {
+  it('transfers from', async () => {
     const before = await goldToken.balanceOf(accounts[3])
     // account1 approves account0
     await goldToken.approve(accounts[0], ONE_GOLD).sendAndWaitForReceipt({ from: accounts[1] })

--- a/packages/sdk/contractkit/src/wrappers/GoldToken.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/GoldToken.test.ts
@@ -1,8 +1,39 @@
 import { StrongAddress } from '@celo/base'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { newKitFromWeb3 } from '../kit'
 import { GoldTokenWrapper } from './GoldTokenWrapper'
 
+testWithAnvil('GoldToken Wrapper', (web3) => {
+  const ONE_GOLD = web3.utils.toWei('1', 'ether')
+
+  const kit = newKitFromWeb3(web3)
+  let accounts: StrongAddress[] = []
+  let goldToken: GoldTokenWrapper
+
+  beforeAll(async () => {
+    accounts = (await web3.eth.getAccounts()) as StrongAddress[]
+    kit.defaultAccount = accounts[0]
+    goldToken = await kit.contracts.getGoldToken()
+  })
+
+  it('checks balance', () => expect(goldToken.balanceOf(accounts[0])).resolves.toBeBigNumber())
+  it('checks decimals', () => expect(goldToken.decimals()).resolves.toBe(18))
+  it('checks name', () => expect(goldToken.name()).resolves.toBe('Celo native asset'))
+  it('checks symbol', () => expect(goldToken.symbol()).resolves.toBe('CELO'))
+  it('checks totalSupply', () => expect(goldToken.totalSupply()).resolves.toBeBigNumber())
+
+  it('approves spender', async () => {
+    const before = await goldToken.allowance(accounts[0], accounts[1])
+    expect(before).toEqBigNumber(0)
+
+    await goldToken.approve(accounts[1], ONE_GOLD).sendAndWaitForReceipt()
+    const after = await goldToken.allowance(accounts[0], accounts[1])
+    expect(after).toEqBigNumber(ONE_GOLD)
+  })
+})
+
+// Need to be tested with ganache because of missing transfer precompile
 testWithGanache('GoldToken Wrapper', (web3) => {
   const ONE_GOLD = web3.utils.toWei('1', 'ether')
 
@@ -16,14 +47,7 @@ testWithGanache('GoldToken Wrapper', (web3) => {
     goldToken = await kit.contracts.getGoldToken()
   })
 
-  test('SBAT check balance', () =>
-    expect(goldToken.balanceOf(accounts[0])).resolves.toBeBigNumber())
-  test('SBAT check decimals', () => expect(goldToken.decimals()).resolves.toBe(18))
-  test('SBAT check name', () => expect(goldToken.name()).resolves.toBe('Celo native asset'))
-  test('SBAT check symbol', () => expect(goldToken.symbol()).resolves.toBe('CELO'))
-  test('SBAT check totalSupply', () => expect(goldToken.totalSupply()).resolves.toBeBigNumber())
-
-  test('SBAT transfer', async () => {
+  it('transfers', async () => {
     const before = await goldToken.balanceOf(accounts[1])
     const tx = await goldToken.transfer(accounts[1], ONE_GOLD).send()
     await tx.waitReceipt()
@@ -32,16 +56,7 @@ testWithGanache('GoldToken Wrapper', (web3) => {
     expect(after.minus(before)).toEqBigNumber(ONE_GOLD)
   })
 
-  test('SBAT approve spender', async () => {
-    const before = await goldToken.allowance(accounts[0], accounts[1])
-    expect(before).toEqBigNumber(0)
-
-    await goldToken.approve(accounts[1], ONE_GOLD).sendAndWaitForReceipt()
-    const after = await goldToken.allowance(accounts[0], accounts[1])
-    expect(after).toEqBigNumber(ONE_GOLD)
-  })
-
-  test('SBAT tranfer from', async () => {
+  it('tranfers from', async () => {
     const before = await goldToken.balanceOf(accounts[3])
     // account1 approves account0
     await goldToken.approve(accounts[0], ONE_GOLD).sendAndWaitForReceipt({ from: accounts[1] })

--- a/packages/sdk/contractkit/src/wrappers/LockedGold.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/LockedGold.test.ts
@@ -1,10 +1,10 @@
 import { StrongAddress } from '@celo/base'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 import { newKitFromWeb3 } from '../kit'
 import { AccountsWrapper } from './Accounts'
 import { LockedGoldWrapper } from './LockedGold'
 
-testWithGanache('LockedGold Wrapper', (web3) => {
+testWithAnvil('LockedGold Wrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
   let accounts: AccountsWrapper
   let lockedGold: LockedGoldWrapper

--- a/packages/sdk/contractkit/src/wrappers/Validators.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Validators.test.ts
@@ -1,4 +1,6 @@
-import { mineBlocks, testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { setCommissionUpdateDelay } from '@celo/dev-utils/lib/chain-setup'
+import { mineBlocks } from '@celo/dev-utils/lib/ganache-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
@@ -19,7 +21,7 @@ const blsPublicKey =
 const blsPoP =
   '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900'
 
-testWithGanache('Validators Wrapper', (web3) => {
+testWithAnvil('Validators Wrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
   let accounts: string[] = []
   let accountsInstance: AccountsWrapper
@@ -66,19 +68,19 @@ testWithGanache('Validators Wrapper', (web3) => {
       })
   }
 
-  test('SBAT registerValidatorGroup', async () => {
+  it('registers a validator group', async () => {
     const groupAccount = accounts[0]
     await setupGroup(groupAccount)
     await expect(validators.isValidatorGroup(groupAccount)).resolves.toBe(true)
   })
 
-  test('SBAT registerValidator', async () => {
+  it('registers a validator', async () => {
     const validatorAccount = accounts[1]
     await setupValidator(validatorAccount)
     await expect(validators.isValidator(validatorAccount)).resolves.toBe(true)
   })
 
-  test('SBAT addMember', async () => {
+  it('adds a member', async () => {
     const groupAccount = accounts[0]
     const validatorAccount = accounts[1]
     await setupGroup(groupAccount)
@@ -94,7 +96,7 @@ testWithGanache('Validators Wrapper', (web3) => {
     expect(members).toContain(validatorAccount)
   })
 
-  test('SBAT setNextCommissionUpdate', async () => {
+  it('sets next commission update', async () => {
     const groupAccount = accounts[0]
     await setupGroup(groupAccount)
     await validators.setNextCommissionUpdate('0.2').sendAndWaitForReceipt({
@@ -104,10 +106,14 @@ testWithGanache('Validators Wrapper', (web3) => {
     expect(commission).toEqBigNumber('0.2')
   })
 
-  test('SBAT updateCommission', async () => {
+  it('updates commission', async () => {
     const groupAccount = accounts[0]
     await setupGroup(groupAccount)
     const txOpts = { from: groupAccount }
+
+    // Set commission update delay to 3 blocks for backwards compatibility
+    setCommissionUpdateDelay(web3, validators.address, 3)
+
     await validators.setNextCommissionUpdate('0.2').sendAndWaitForReceipt(txOpts)
     await mineBlocks(3, web3)
     await validators.updateCommission().sendAndWaitForReceipt(txOpts)
@@ -116,7 +122,7 @@ testWithGanache('Validators Wrapper', (web3) => {
     expect(commission).toEqBigNumber('0.2')
   })
 
-  test('SBAT get group affiliates', async () => {
+  it('gets group affiliates', async () => {
     const groupAccount = accounts[0]
     const validatorAccount = accounts[1]
     await setupGroup(groupAccount)
@@ -126,7 +132,7 @@ testWithGanache('Validators Wrapper', (web3) => {
     expect(group.affiliates).toContain(validatorAccount)
   })
 
-  describe('SBAT reorderMember', () => {
+  describe('reorders member', () => {
     jest.setTimeout(30 * 1000)
     let groupAccount: string, validator1: string, validator2: string
 
@@ -155,7 +161,7 @@ testWithGanache('Validators Wrapper', (web3) => {
       expect(members).toEqual([validator1, validator2])
     })
 
-    test('move last to first', async () => {
+    it('moves last to first', async () => {
       jest.setTimeout(30 * 1000)
 
       await validators
@@ -169,7 +175,7 @@ testWithGanache('Validators Wrapper', (web3) => {
       expect(membersAfter).toEqual([validator2, validator1])
     })
 
-    test('move first to last', async () => {
+    it('moves first to last', async () => {
       jest.setTimeout(30 * 1000)
 
       await validators
@@ -183,7 +189,7 @@ testWithGanache('Validators Wrapper', (web3) => {
       expect(membersAfter).toEqual([validator2, validator1])
     })
 
-    test('test address normalization', async () => {
+    it('checks address normalization', async () => {
       jest.setTimeout(30 * 1000)
 
       await validators

--- a/yarn.lock
+++ b/yarn.lock
@@ -1562,7 +1562,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@celo/abis@npm:11.0.0":
+"@celo/abis@npm:11.0.0, @celo/abis@npm:^11.0.0":
   version: 11.0.0
   resolution: "@celo/abis@npm:11.0.0"
   checksum: f54204d2fad17e01201b03efbea02837c9b360130d201f229cca6f048031ca20aeea964599ac8ba8c3a367f8dba861f79ace4d47376cbd5379f9987fec4a10c8
@@ -1808,6 +1808,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@celo/dev-utils@workspace:packages/dev-utils"
   dependencies:
+    "@celo/abis": "npm:^11.0.0"
     "@celo/connect": "npm:^6.0.0-beta.0"
     "@celo/devchain-anvil": "npm:5.0.0-canary.0"
     "@celo/typescript": "workspace:^"


### PR DESCRIPTION
### Description

This PR migrates more tests to anvil.

### Other changes

Abstracts a chain setup function into `dev-utils` package. More will follow.

### Tested

Ran tests locally.

### Backwards compatibility

Backwards compatible.

### Documentation

None.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new chain setup function `setCommissionUpdateDelay` and replaces Ganache tests with Anvil tests for various wrappers. 

### Detailed summary
- Added `setCommissionUpdateDelay` chain setup function
- Replaced Ganache tests with Anvil tests for `LockedGold`, `FeeCurrencyWhitelist`, `Accounts`, `GoldToken`, and `Validators` wrappers
- Updated imports and functions for Anvil testing in multiple files

> The following files were skipped due to too many changes: `packages/sdk/contractkit/src/wrappers/Validators.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->