### PR TITLE
chore: exit beta

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@celo/celocli": "5.0.0",


### PR DESCRIPTION
Exits beta mode

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the mode in the pre.json file from "pre" to "exit" and changes the initial version of `@celo/celocli` to "5.0.0".

### Detailed summary
- Updated mode in `pre.json` from "pre" to "exit"
- Changed initial version of `@celo/celocli` to "5.0.0"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->