### PR TITLE
Use L2 devchain

### DIFF
--- a/.changeset/light-candles-rest.md
+++ b/.changeset/light-candles-rest.md
@@ -1,5 +1,0 @@
----
-'@celo/celocli': patch
----
-
-Test changes: separate L1 and L2 tests, change stripAnsiCodes to stripAnsiCodesAndTxHashes that now strips transaction hashes as well

--- a/.changeset/light-candles-rest.md
+++ b/.changeset/light-candles-rest.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Test changes: separate L1 and L2 tests, change stripAnsiCodes to stripAnsiCodesAndTxHashes that now strips transaction hashes as well

--- a/.changeset/stupid-icons-drum.md
+++ b/.changeset/stupid-icons-drum.md
@@ -1,0 +1,5 @@
+---
+'@celo/dev-utils': patch
+---
+
+Introduces testWithAnvilL1 and testWithAnvilL2 that replace previously used testWithAnvil to make it explicit in which context given test suite is being run.

--- a/.changeset/wild-maps-tan.md
+++ b/.changeset/wild-maps-tan.md
@@ -1,0 +1,6 @@
+---
+'@celo/transactions-uri': patch
+'@celo/contractkit': patch
+---
+
+Separate L1 and L2 test suites

--- a/.changeset/wild-maps-tan.md
+++ b/.changeset/wild-maps-tan.md
@@ -1,6 +1,0 @@
----
-'@celo/transactions-uri': patch
-'@celo/contractkit': patch
----
-
-Separate L1 and L2 test suites

--- a/packages/cli/src/commands/account/authorize.test.ts
+++ b/packages/cli/src/commands/account/authorize.test.ts
@@ -1,4 +1,4 @@
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
@@ -10,7 +10,7 @@ import Register from './register'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('account:authorize cmd', (web3: Web3) => {
+testWithAnvilL1('account:authorize cmd', (web3: Web3) => {
   test('can authorize vote signer', async () => {
     const accounts = await web3.eth.getAccounts()
     const notRegisteredAccount = accounts[0]

--- a/packages/cli/src/commands/account/claims.test.ts
+++ b/packages/cli/src/commands/account/claims.test.ts
@@ -1,6 +1,6 @@
 import { ContractKit, IdentityMetadataWrapper, newKitFromWeb3 } from '@celo/contractkit'
 import { ClaimTypes } from '@celo/contractkit/lib/identity'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { readFileSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import Web3 from 'web3'
@@ -12,7 +12,7 @@ import CreateMetadata from './create-metadata'
 import RegisterMetadata from './register-metadata'
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('account metadata cmds', (web3: Web3) => {
+testWithAnvilL1('account metadata cmds', (web3: Web3) => {
   let account: string
   let accounts: string[]
   let kit: ContractKit

--- a/packages/cli/src/commands/account/deauthorize.test.ts
+++ b/packages/cli/src/commands/account/deauthorize.test.ts
@@ -1,4 +1,4 @@
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import { PROOF_OF_POSSESSION_SIGNATURE } from '../../test-utils/constants'
 import Authorize from './authorize'
@@ -7,7 +7,7 @@ import Register from './register'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('account:deauthorize cmd', (web3) => {
+testWithAnvilL1('account:deauthorize cmd', (web3) => {
   test('can deauthorize attestation signer', async () => {
     const accounts = await web3.eth.getAccounts()
     const notRegisteredAccount = accounts[0]

--- a/packages/cli/src/commands/account/list.test.ts
+++ b/packages/cli/src/commands/account/list.test.ts
@@ -1,5 +1,5 @@
 import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { AddressValidation } from '@celo/wallet-ledger/lib/ledger-wallet'
 import { LocalWallet } from '@celo/wallet-local'
 import Web3 from 'web3'
@@ -24,7 +24,7 @@ jest.mock('@celo/wallet-ledger', () => {
   }
 })
 
-testWithAnvil('account:list', (web3: Web3) => {
+testWithAnvilL1('account:list', (web3: Web3) => {
   let account: string
   let accounts: string[]
   let kit: ContractKit

--- a/packages/cli/src/commands/account/register.test.ts
+++ b/packages/cli/src/commands/account/register.test.ts
@@ -1,12 +1,12 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Register from './register'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('account:register cmd', (web3: Web3) => {
+testWithAnvilL1('account:register cmd', (web3: Web3) => {
   test('can register account', async () => {
     const accounts = await web3.eth.getAccounts()
 

--- a/packages/cli/src/commands/account/set-name.test.ts
+++ b/packages/cli/src/commands/account/set-name.test.ts
@@ -1,4 +1,4 @@
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Register from '../account/register'
@@ -6,7 +6,7 @@ import SetName from './set-name'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('account:set-name cmd', (web3: Web3) => {
+testWithAnvilL1('account:set-name cmd', (web3: Web3) => {
   test('can set the name of an account', async () => {
     const accounts = await web3.eth.getAccounts()
     await testLocallyWithWeb3Node(Register, ['--from', accounts[0]], web3)

--- a/packages/cli/src/commands/config/set.test.ts
+++ b/packages/cli/src/commands/config/set.test.ts
@@ -1,5 +1,5 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import Web3 from 'web3'
 import {
@@ -17,7 +17,7 @@ afterEach(async () => {
   jest.restoreAllMocks()
 })
 
-testWithAnvil('config:set cmd', (web3: Web3) => {
+testWithAnvilL1('config:set cmd', (web3: Web3) => {
   it('shows a warning if gasCurrency is passed', async () => {
     const kit = newKitFromWeb3(web3)
     const feeCurrencyDirectory = await kit.contracts.getFeeCurrencyDirectory()

--- a/packages/cli/src/commands/election/activate.test.ts
+++ b/packages/cli/src/commands/election/activate.test.ts
@@ -135,7 +135,7 @@ testWithGanache('election:activate', (web3: Web3) => {
           "SendTransaction: activate",
         ],
         [
-          "txHash: 0xeb8b78386a4a12b607bc7fcd5025f9b831b37eda9b3719a87c7235947a314d49",
+          "txHash: 0xtxhash",
         ],
       ]
     `)

--- a/packages/cli/src/commands/election/activate.test.ts
+++ b/packages/cli/src/commands/election/activate.test.ts
@@ -10,7 +10,7 @@ import {
   setupGroupAndAffiliateValidator,
   voteForGroupFrom,
 } from '../../test-utils/chain-setup'
-import { stripAnsiCodes, testLocally } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocally } from '../../test-utils/cliUtils'
 import ElectionActivate from './activate'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -119,7 +119,8 @@ testWithGanache('election:activate', (web3: Web3) => {
       }),
     ])
 
-    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+      .toMatchInlineSnapshot(`
       [
         [
           "Running Checks:",

--- a/packages/cli/src/commands/election/run.test.ts
+++ b/packages/cli/src/commands/election/run.test.ts
@@ -6,7 +6,7 @@ import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { setupGroupAndAffiliateValidator } from '../../test-utils/chain-setup'
-import { stripAnsiCodes, testLocally } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocally } from '../../test-utils/cliUtils'
 import Run from './run'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -31,8 +31,11 @@ testWithGanache('election:run', (web3: Web3) => {
         ],
       ]
     `)
-    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`[]`)
-    expect(warnMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+    expect(
+      logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes))
+    ).toMatchInlineSnapshot(`[]`)
+    expect(warnMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+      .toMatchInlineSnapshot(`
       [
         [
           "Warning: error running actual elections, retrying with minimum validators at 0",
@@ -104,7 +107,11 @@ testWithGanache('election:run', (web3: Web3) => {
         ],
       ]
     `)
-    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`[]`)
-    expect(warnMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`[]`)
+    expect(
+      logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes))
+    ).toMatchInlineSnapshot(`[]`)
+    expect(
+      warnMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes))
+    ).toMatchInlineSnapshot(`[]`)
   })
 })

--- a/packages/cli/src/commands/election/show.test.ts
+++ b/packages/cli/src/commands/election/show.test.ts
@@ -5,7 +5,7 @@ import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { registerAccount, setupGroup } from '../../test-utils/chain-setup'
-import { stripAnsiCodes, testLocally } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocally } from '../../test-utils/cliUtils'
 import Show from './show'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -33,7 +33,7 @@ testWithGanache('election:show', (web3: Web3) => {
     await expect(testLocally(Show, [groupAddress, '--group'])).rejects.toThrow(
       "Some checks didn't pass!"
     )
-    expect(stripAnsiCodes(logMock.mock.calls[1][0])).toContain(
+    expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[1][0])).toContain(
       `✘  ${groupAddress} is ValidatorGroup`
     )
   })
@@ -45,7 +45,7 @@ testWithGanache('election:show', (web3: Web3) => {
     await expect(testLocally(Show, [voterAddress, '--voter'])).rejects.toThrow(
       "Some checks didn't pass!"
     )
-    expect(stripAnsiCodes(logMock.mock.calls[1][0])).toContain(
+    expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[1][0])).toContain(
       `${voterAddress} is not registered as an account. Try running account:register`
     )
   })
@@ -75,7 +75,8 @@ testWithGanache('election:show', (web3: Web3) => {
     await testLocally(Show, [groupAddress, '--group'])
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`[]`)
-    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+      .toMatchInlineSnapshot(`
       [
         [
           "Running Checks:",
@@ -127,7 +128,8 @@ testWithGanache('election:show', (web3: Web3) => {
     await testLocally(Show, [voterAddress, '--voter'])
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`[]`)
-    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+      .toMatchInlineSnapshot(`
       [
         [
           "Running Checks:",

--- a/packages/cli/src/commands/election/vote.test.ts
+++ b/packages/cli/src/commands/election/vote.test.ts
@@ -110,7 +110,7 @@ testWithGanache('election:vote', (web3: Web3) => {
           "SendTransaction: vote",
         ],
         [
-          "txHash: 0x5427ddef3d99512241b5c61b8c0467674c7278ef86a2258676d864430285b1ad",
+          "txHash: 0xtxhash",
         ],
       ]
     `)

--- a/packages/cli/src/commands/election/vote.test.ts
+++ b/packages/cli/src/commands/election/vote.test.ts
@@ -8,7 +8,7 @@ import {
   registerAccountWithLockedGold,
   setupGroupAndAffiliateValidator,
 } from '../../test-utils/chain-setup'
-import { stripAnsiCodes, testLocally } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocally } from '../../test-utils/cliUtils'
 import Vote from './vote'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -46,7 +46,7 @@ testWithGanache('election:vote', (web3: Web3) => {
       testLocally(Vote, ['--from', fromAddress, '--for', groupAddress, '--value', '1'])
     ).rejects.toThrow()
 
-    expect(stripAnsiCodes(logMock.mock.calls[2][0])).toContain(
+    expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[2][0])).toContain(
       `✘  0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb is ValidatorGroup`
     )
   })
@@ -63,7 +63,7 @@ testWithGanache('election:vote', (web3: Web3) => {
       testLocally(Vote, ['--from', fromAddress, '--for', groupAddress, '--value', '1'])
     ).rejects.toThrow()
 
-    expect(stripAnsiCodes(logMock.mock.calls[3][0])).toContain(
+    expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[3][0])).toContain(
       `✘  Account has at least 0.000000000000000001 non-voting Locked Gold`
     )
   })
@@ -88,7 +88,8 @@ testWithGanache('election:vote', (web3: Web3) => {
     ).resolves.not.toThrow()
 
     expect(await election.getTotalVotesForGroupByAccount(groupAddress, fromAddress)).toEqual(amount)
-    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+      .toMatchInlineSnapshot(`
       [
         [
           "Running Checks:",

--- a/packages/cli/src/commands/governance/approve-l2.test.ts
+++ b/packages/cli/src/commands/governance/approve-l2.test.ts
@@ -8,7 +8,7 @@ import {
 import { ux } from '@oclif/core'
 import Web3 from 'web3'
 import { changeMultiSigOwner } from '../../test-utils/chain-setup'
-import { stripAnsiCodes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Approve from './approve'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -73,7 +73,8 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
           "executionTimeLimit": "0",
         }
       `)
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
@@ -118,7 +119,8 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
           "executionTimeLimit": "0",
         }
       `)
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
@@ -185,7 +187,8 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
           "executionTimeLimit": "0",
         }
       `)
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
@@ -245,7 +248,8 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
           "executionTimeLimit": "0",
         }
       `)
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
@@ -307,7 +311,8 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
           "executionTimeLimit": "0",
         }
       `)
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
@@ -328,7 +333,7 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
             "SendTransaction: approveTx",
           ],
           [
-            "txHash: 0x80e62182c1254c4a04287789754fdfb6291a3923fec30b99a14ed105d48e5d87",
+            "txHash: 0xtxhash",
           ],
           [
             "HotfixApproved:",
@@ -381,7 +386,8 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
           "executionTimeLimit": "0",
         }
       `)
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
@@ -402,7 +408,7 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
             "SendTransaction: approveTx",
           ],
           [
-            "txHash: 0x94e7691bb7871d01d90e77d4d12458e30715ce7145846dc8c785084a0d919ce1",
+            "txHash: 0xtxhash",
           ],
           [
             "HotfixApproved:",
@@ -477,7 +483,8 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
         }
       `)
 
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
@@ -501,7 +508,7 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
             "SendTransaction: approveTx",
           ],
           [
-            "txHash: 0xd3dfa36f21cbece15f6557d868df9372ba83bd05443b7d5a8b2466f84c2ebf5b",
+            "txHash: 0xtxhash",
           ],
         ]
       `)
@@ -532,7 +539,8 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
           "executionTimeLimit": "0",
         }
       `)
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
@@ -556,7 +564,7 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
             "SendTransaction: approveTx",
           ],
           [
-            "txHash: 0x293139f741a926fcd119f0553d5b70735b6a7a676e74be0e1960f98a7513114a",
+            "txHash: 0xtxhash",
           ],
         ]
       `)
@@ -619,7 +627,8 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
           "executionTimeLimit": "0",
         }
       `)
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
@@ -643,7 +652,7 @@ testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
             "SendTransaction: approveTx",
           ],
           [
-            "txHash: 0x3b21e3f7a308fb2e308bb28085065dd965e3b26c436379edf7101a1f7278ca89",
+            "txHash: 0xtxhash",
           ],
         ]
       `)

--- a/packages/cli/src/commands/governance/approve-l2.test.ts
+++ b/packages/cli/src/commands/governance/approve-l2.test.ts
@@ -2,8 +2,7 @@ import { hexToBuffer, StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import {
   DEFAULT_OWNER_ADDRESS,
-  setupL2,
-  testWithAnvil,
+  testWithAnvilL2,
   withImpersonatedAccount,
 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
@@ -14,7 +13,7 @@ import Approve from './approve'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('governance:approve cmd', (web3: Web3) => {
+testWithAnvilL2('governance:approve cmd', (web3: Web3) => {
   const HOTFIX_HASH = '0xbf670baa773b342120e1af45433a465bbd6fa289a5cf72763d63d95e4e22482d'
   const HOTFIX_BUFFER = hexToBuffer(HOTFIX_HASH)
 
@@ -26,8 +25,6 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
       const writeMock = jest.spyOn(ux.write, 'stdout')
       const logMock = jest.spyOn(console, 'log')
       const multisig = await governance.getApproverMultisig()
-
-      await setupL2(web3)
 
       await withImpersonatedAccount(web3, DEFAULT_OWNER_ADDRESS, async () => {
         // setApprover to 0x5409ED021D9299bf6814279A6A1411A7e866A631 to avoid "Council cannot be approver" error
@@ -105,8 +102,6 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
       const writeMock = jest.spyOn(ux.write, 'stdout')
       const logMock = jest.spyOn(console, 'log')
 
-      await setupL2(web3)
-
       await expect(
         testLocallyWithWeb3Node(
           Approve,
@@ -151,8 +146,6 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
       const governance = await kit.contracts.getGovernance()
       const writeMock = jest.spyOn(ux.write, 'stdout')
       const logMock = jest.spyOn(console, 'log')
-
-      await setupL2(web3)
 
       await withImpersonatedAccount(web3, DEFAULT_OWNER_ADDRESS, async () => {
         // setApprover to approver value
@@ -218,8 +211,6 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
       const writeMock = jest.spyOn(ux.write, 'stdout')
       const logMock = jest.spyOn(console, 'log')
 
-      await setupL2(web3)
-
       await withImpersonatedAccount(web3, DEFAULT_OWNER_ADDRESS, async () => {
         // setApprover to approver value
         await (
@@ -280,8 +271,6 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
       const writeMock = jest.spyOn(ux.write, 'stdout')
       const logMock = jest.spyOn(console, 'log')
 
-      await setupL2(web3)
-
       await withImpersonatedAccount(web3, DEFAULT_OWNER_ADDRESS, async () => {
         // setApprover to approver value
         await (
@@ -339,7 +328,7 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
             "SendTransaction: approveTx",
           ],
           [
-            "txHash: 0x45fa0ad89a10cea114171fda54c27fd0f37dbc6596ce8946638c0f389554b04e",
+            "txHash: 0x80e62182c1254c4a04287789754fdfb6291a3923fec30b99a14ed105d48e5d87",
           ],
           [
             "HotfixApproved:",
@@ -359,8 +348,6 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
       const governance = await kit.contracts.getGovernance()
       const writeMock = jest.spyOn(ux.write, 'stdout')
       const logMock = jest.spyOn(console, 'log')
-
-      await setupL2(web3)
 
       await withImpersonatedAccount(web3, DEFAULT_OWNER_ADDRESS, async () => {
         // setApprover to approver value
@@ -415,7 +402,7 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
             "SendTransaction: approveTx",
           ],
           [
-            "txHash: 0x5f7bf72da8b16d6870545d4395462728febd0b5be774f0d9857d5542e2393e7d",
+            "txHash: 0x94e7691bb7871d01d90e77d4d12458e30715ce7145846dc8c785084a0d919ce1",
           ],
           [
             "HotfixApproved:",
@@ -437,7 +424,6 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
       const logMock = jest.spyOn(console, 'log')
       const multisig = await governance.getApproverMultisig()
 
-      await setupL2(web3)
       await changeMultiSigOwner(kit, accounts[0])
 
       await withImpersonatedAccount(web3, DEFAULT_OWNER_ADDRESS, async () => {
@@ -515,7 +501,7 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
             "SendTransaction: approveTx",
           ],
           [
-            "txHash: 0x8a5f48287a3612725ada13534f6b5bc8c795630d153cd4782ef594da60e431dc",
+            "txHash: 0xd3dfa36f21cbece15f6557d868df9372ba83bd05443b7d5a8b2466f84c2ebf5b",
           ],
         ]
       `)
@@ -526,7 +512,6 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
       const kit = newKitFromWeb3(web3)
       const accounts = (await web3.eth.getAccounts()) as StrongAddress[]
 
-      await setupL2(web3)
       await changeMultiSigOwner(kit, accounts[0])
 
       const governance = await kit.contracts.getGovernance()
@@ -538,8 +523,6 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
         ['--from', accounts[0], '--hotfix', HOTFIX_HASH, '--useMultiSig'],
         web3
       )
-
-      await new Promise((resolve) => setTimeout(resolve, 5000))
 
       expect(await governance.getHotfixRecord(HOTFIX_BUFFER)).toMatchInlineSnapshot(`
         {
@@ -573,7 +556,7 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
             "SendTransaction: approveTx",
           ],
           [
-            "txHash: 0xc23094c18b45c064f26058220139891f2101e3cea0f2e76a256645424dba0247",
+            "txHash: 0x293139f741a926fcd119f0553d5b70735b6a7a676e74be0e1960f98a7513114a",
           ],
         ]
       `)
@@ -584,7 +567,6 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
       const kit = newKitFromWeb3(web3)
       const accounts = (await web3.eth.getAccounts()) as StrongAddress[]
 
-      await setupL2(web3)
       await changeMultiSigOwner(kit, accounts[0])
 
       const governance = await kit.contracts.getGovernance()
@@ -661,7 +643,7 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
             "SendTransaction: approveTx",
           ],
           [
-            "txHash: 0xa1805cea4de891d8a43a4c648f6883651743d4970cd8c4d9ce843c3d4975b6ad",
+            "txHash: 0x3b21e3f7a308fb2e308bb28085065dd965e3b26c436379edf7101a1f7278ca89",
           ],
         ]
       `)

--- a/packages/cli/src/commands/governance/approve.test.ts
+++ b/packages/cli/src/commands/governance/approve.test.ts
@@ -6,7 +6,7 @@ import { timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import { ux } from '@oclif/core'
 import Web3 from 'web3'
 import { changeMultiSigOwner } from '../../test-utils/chain-setup'
-import { stripAnsiCodes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Approve from './approve'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -57,7 +57,8 @@ testWithAnvilL1('governance:approve cmd', (web3: Web3) => {
     ).rejects.toThrow("Some checks didn't pass!")
 
     expect(await governance.isApproved(proposalID)).toEqual(false)
-    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+      .toMatchInlineSnapshot(`
       [
         [
           "Running Checks:",
@@ -95,7 +96,8 @@ testWithAnvilL1('governance:approve cmd', (web3: Web3) => {
     )
 
     expect(await governance.isApproved(proposalID)).toEqual(true)
-    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+    expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+      .toMatchInlineSnapshot(`
       [
         [
           "Running Checks:",
@@ -122,7 +124,7 @@ testWithAnvilL1('governance:approve cmd', (web3: Web3) => {
           "SendTransaction: approveTx",
         ],
         [
-          "txHash: 0x4a27466ac2819a4d4a2aa086820bbaef4492b7f1412094b890a34dc9244f67ac",
+          "txHash: 0xtxhash",
         ],
       ]
     `)
@@ -150,7 +152,8 @@ testWithAnvilL1('governance:approve cmd', (web3: Web3) => {
         )
       ).rejects.not.toBeUndefined()
       const schedule = await governance.proposalSchedule(proposalId)
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
@@ -188,8 +191,8 @@ testWithAnvilL1('governance:approve cmd', (web3: Web3) => {
         ['--from', approver, '--proposalID', proposalId.toString()],
         web3
       )
-      const txHash = stripAnsiCodes(logMock.mock.calls.at(-3)![0].split(':')[1].trim())
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
@@ -213,7 +216,7 @@ testWithAnvilL1('governance:approve cmd', (web3: Web3) => {
             "SendTransaction: approveTx",
           ],
           [
-            "txHash: ${txHash}",
+            "txHash: 0xtxhash",
           ],
           [
             "ProposalApproved:",

--- a/packages/cli/src/commands/governance/approve.test.ts
+++ b/packages/cli/src/commands/governance/approve.test.ts
@@ -1,7 +1,7 @@
 import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GovernanceWrapper, ProposalStage } from '@celo/contractkit/lib/wrappers/Governance'
-import { impersonateAccount, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { impersonateAccount, testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import { ux } from '@oclif/core'
 import Web3 from 'web3'
@@ -11,7 +11,7 @@ import Approve from './approve'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('governance:approve cmd', (web3: Web3) => {
+testWithAnvilL1('governance:approve cmd', (web3: Web3) => {
   const kit = newKitFromWeb3(web3)
   const proposalID = '1'
   let minDeposit: string
@@ -122,7 +122,7 @@ testWithAnvil('governance:approve cmd', (web3: Web3) => {
           "SendTransaction: approveTx",
         ],
         [
-          "txHash: 0x52cdb8aa50991657f3b8481094a4f07d31db96998975faa7818bd64767d6ea16",
+          "txHash: 0x4a27466ac2819a4d4a2aa086820bbaef4492b7f1412094b890a34dc9244f67ac",
         ],
       ]
     `)

--- a/packages/cli/src/commands/governance/executehotfix-l2.test.ts
+++ b/packages/cli/src/commands/governance/executehotfix-l2.test.ts
@@ -14,7 +14,7 @@ import Web3 from 'web3'
 import { AbiItem, PROXY_ADMIN_ADDRESS } from '../../../../sdk/connect/lib'
 import {
   EXTRA_LONG_TIMEOUT_MS,
-  stripAnsiCodes,
+  stripAnsiCodesAndTxHashes,
   testLocallyWithWeb3Node,
 } from '../../test-utils/cliUtils'
 import Approve from './approve'
@@ -171,7 +171,8 @@ testWithAnvilL2('governance:executehotfix cmd', (web3: Web3) => {
         await testTransactionsContract.methods.getValue(HOTFIX_TRANSACTION_TEST_KEY).call()
       ).toEqual(HOTFIX_TRANSACTION_TEST_VALUE)
 
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
@@ -195,7 +196,7 @@ testWithAnvilL2('governance:executehotfix cmd', (web3: Web3) => {
             "SendTransaction: executeHotfixTx",
           ],
           [
-            "txHash: 0x6a71d61809c970505aca3a38d8aaa531e87dedc96696bc2531e8d413071ead47",
+            "txHash: 0xtxhash",
           ],
           [
             "HotfixExecuted:",
@@ -321,7 +322,8 @@ testWithAnvilL2('governance:executehotfix cmd', (web3: Web3) => {
         await testTransactionsContract.methods.getValue(HOTFIX_TRANSACTION_TEST_KEY).call()
       ).toEqual('0')
 
-      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodes))).toMatchInlineSnapshot(`
+      expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
+        .toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",

--- a/packages/cli/src/commands/governance/preparehotfix-l2.test.ts
+++ b/packages/cli/src/commands/governance/preparehotfix-l2.test.ts
@@ -3,8 +3,7 @@ import { newKitFromWeb3 } from '@celo/contractkit'
 import {
   DEFAULT_OWNER_ADDRESS,
   setNextBlockTimestamp,
-  setupL2,
-  testWithAnvil,
+  testWithAnvilL2,
   withImpersonatedAccount,
 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
@@ -15,7 +14,7 @@ import PrepareHotfix from './preparehotfix'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('governance:preparehotfix cmd', (web3: Web3) => {
+testWithAnvilL2('governance:preparehotfix cmd', (web3: Web3) => {
   const HOTFIX_HASH = '0x8ad3719bb2577b277bcafc1f00ac2f1c3fa5e565173303684d0a8d4f3661680c'
   const HOTFIX_BUFFER = hexToBuffer(HOTFIX_HASH)
   const EXECUTION_TIME_LIMIT = 86400
@@ -27,8 +26,6 @@ testWithAnvil('governance:preparehotfix cmd', (web3: Web3) => {
     // arbitrary 100 seconds to the future to avoid
     // Timestamp error: X is lower than or equal to previous block's timestamp
     const nextTimestamp = getCurrentTimestamp() + 100
-
-    await setupL2(web3)
 
     // send some funds to DEFAULT_OWNER_ADDRESS to execute transactions
     await (

--- a/packages/cli/src/commands/governance/propose.test.ts
+++ b/packages/cli/src/commands/governance/propose.test.ts
@@ -2,7 +2,7 @@ import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GoldTokenWrapper } from '@celo/contractkit/lib/wrappers/GoldTokenWrapper'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import * as fs from 'fs'
 import Web3 from 'web3'
@@ -137,7 +137,7 @@ const structAbiDefinition = {
   type: 'function',
 }
 
-testWithAnvil('governance:propose cmd', (web3: Web3) => {
+testWithAnvilL1('governance:propose cmd', (web3: Web3) => {
   let governance: GovernanceWrapper
   let goldToken: GoldTokenWrapper
   let minDeposit: string

--- a/packages/cli/src/commands/governance/upvote.test.ts
+++ b/packages/cli/src/commands/governance/upvote.test.ts
@@ -1,7 +1,7 @@
 import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
@@ -13,7 +13,7 @@ import Upvote from './upvote'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('governance:upvote cmd', (web3: Web3) => {
+testWithAnvilL1('governance:upvote cmd', (web3: Web3) => {
   let minDeposit: string
   const kit = newKitFromWeb3(web3)
   const proposalID = new BigNumber(1)

--- a/packages/cli/src/commands/governance/vote.test.ts
+++ b/packages/cli/src/commands/governance/vote.test.ts
@@ -1,7 +1,7 @@
 import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { NetworkConfig, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
@@ -17,7 +17,7 @@ process.env.NO_SYNCCHECK = 'true'
 
 const expConfig = NetworkConfig.governance
 
-testWithAnvil('governance:vote cmd', (web3: Web3) => {
+testWithAnvilL1('governance:vote cmd', (web3: Web3) => {
   let minDeposit: string
   const kit = newKitFromWeb3(web3)
   const proposalID = new BigNumber(1)

--- a/packages/cli/src/commands/governance/votePartially.test.ts
+++ b/packages/cli/src/commands/governance/votePartially.test.ts
@@ -1,7 +1,7 @@
 import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { NetworkConfig, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
@@ -17,7 +17,7 @@ process.env.NO_SYNCCHECK = 'true'
 
 const expConfig = NetworkConfig.governance
 
-testWithAnvil('governance:vote-partially cmd', (web3: Web3) => {
+testWithAnvilL1('governance:vote-partially cmd', (web3: Web3) => {
   let minDeposit: string
   const kit = newKitFromWeb3(web3)
   const proposalID = new BigNumber(1)

--- a/packages/cli/src/commands/governance/withdraw.test.ts
+++ b/packages/cli/src/commands/governance/withdraw.test.ts
@@ -1,7 +1,7 @@
 import { StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { GovernanceWrapper, Proposal } from '@celo/contractkit/lib/wrappers/Governance'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { NetworkConfig, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import { ProposalBuilder } from '@celo/governance'
 import BigNumber from 'bignumber.js'
@@ -13,7 +13,7 @@ process.env.NO_SYNCCHECK = 'true'
 
 const expConfig = NetworkConfig.governance
 
-testWithAnvil('governance:withdraw', (web3: Web3) => {
+testWithAnvilL1('governance:withdraw', (web3: Web3) => {
   let minDeposit: string
   const kit = newKitFromWeb3(web3)
 

--- a/packages/cli/src/commands/lockedgold/delegate-info.test.ts
+++ b/packages/cli/src/commands/lockedgold/delegate-info.test.ts
@@ -1,14 +1,14 @@
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Delegate from './delegate'
 import DelegateInfo from './delegate-info'
 import Lock from './lock'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('lockedgold:delegate-info cmd', (web3: Web3) => {
+testWithAnvilL1('lockedgold:delegate-info cmd', (web3: Web3) => {
   test('gets the info', async () => {
     const accounts = await web3.eth.getAccounts()
     const account = accounts[0]

--- a/packages/cli/src/commands/lockedgold/delegate.test.ts
+++ b/packages/cli/src/commands/lockedgold/delegate.test.ts
@@ -1,14 +1,14 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Delegate from './delegate'
 import Lock from './lock'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('lockedgold:delegate cmd', (web3: Web3) => {
+testWithAnvilL1('lockedgold:delegate cmd', (web3: Web3) => {
   test('can delegate', async () => {
     const accounts = await web3.eth.getAccounts()
     const account = accounts[0]

--- a/packages/cli/src/commands/lockedgold/lock.test.ts
+++ b/packages/cli/src/commands/lockedgold/lock.test.ts
@@ -67,7 +67,7 @@ testWithAnvilL1('lockedgold:lock cmd', (web3: Web3) => {
             "SendTransaction: register",
           ],
           [
-            "txHash: 0xc16e27382dc3d3e4546c3869a0147c49390a1cd0e758301e9b3e06927c48033f",
+            "txHash: 0xtxhash",
           ],
           [
             "Running Checks:",
@@ -82,7 +82,7 @@ testWithAnvilL1('lockedgold:lock cmd', (web3: Web3) => {
             "SendTransaction: lock",
           ],
           [
-            "txHash: 0x84859d5c23b7c3ba7efd3168bcde9fff5c0b6355c01f20efc90a34b83beaa1bc",
+            "txHash: 0xtxhash",
           ],
         ]
       `)

--- a/packages/cli/src/commands/lockedgold/lock.test.ts
+++ b/packages/cli/src/commands/lockedgold/lock.test.ts
@@ -1,4 +1,5 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
@@ -10,11 +11,10 @@ import {
 import Register from '../account/register'
 import Lock from './lock'
 import Unlock from './unlock'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('lockedgold:lock cmd', (web3: Web3) => {
+testWithAnvilL1('lockedgold:lock cmd', (web3: Web3) => {
   test(
     'can lock with pending withdrawals',
     async () => {
@@ -67,7 +67,7 @@ testWithAnvil('lockedgold:lock cmd', (web3: Web3) => {
             "SendTransaction: register",
           ],
           [
-            "txHash: 0x060e8980ac61a571dd9eb8b7a63d57b013ad006f49e99eb46ed11b3ce1bed3ee",
+            "txHash: 0xc16e27382dc3d3e4546c3869a0147c49390a1cd0e758301e9b3e06927c48033f",
           ],
           [
             "Running Checks:",
@@ -82,7 +82,7 @@ testWithAnvil('lockedgold:lock cmd', (web3: Web3) => {
             "SendTransaction: lock",
           ],
           [
-            "txHash: 0xef3f6797fbb8d6ecfb506d6d46d4870b6cc7d71fdafcb2f158f2c2d8fcdee6d8",
+            "txHash: 0x84859d5c23b7c3ba7efd3168bcde9fff5c0b6355c01f20efc90a34b83beaa1bc",
           ],
         ]
       `)

--- a/packages/cli/src/commands/lockedgold/revoke-delegate.test.ts
+++ b/packages/cli/src/commands/lockedgold/revoke-delegate.test.ts
@@ -1,15 +1,15 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Delegate from './delegate'
 import Lock from './lock'
 import RevokeDelegate from './revoke-delegate'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('lockedgold:revoke-delegate cmd', (web3: Web3) => {
+testWithAnvilL1('lockedgold:revoke-delegate cmd', (web3: Web3) => {
   test('can revoke delegate', async () => {
     const accounts = await web3.eth.getAccounts()
     const account = accounts[0]

--- a/packages/cli/src/commands/lockedgold/unlock.test.ts
+++ b/packages/cli/src/commands/lockedgold/unlock.test.ts
@@ -1,4 +1,5 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'
 import { LONG_TIMEOUT_MS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
@@ -10,11 +11,10 @@ import ValidatorGroupMember from '../validatorgroup/member'
 import ValidatorGroupRegister from '../validatorgroup/register'
 import Lock from './lock'
 import Unlock from './unlock'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('lockedgold:unlock cmd', (web3: Web3) => {
+testWithAnvilL1('lockedgold:unlock cmd', (web3: Web3) => {
   test(
     'can unlock correctly from registered validator group',
     async () => {

--- a/packages/cli/src/commands/lockedgold/update-delegated-amount.test.ts
+++ b/packages/cli/src/commands/lockedgold/update-delegated-amount.test.ts
@@ -1,14 +1,14 @@
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 import { LONG_TIMEOUT_MS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Delegate from './delegate'
 import Lock from './lock'
 import UpdateDelegatedAmount from './update-delegated-amount'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('lockedgold:update-delegated-amount cmd', (web3: Web3) => {
+testWithAnvilL1('lockedgold:update-delegated-amount cmd', (web3: Web3) => {
   test(
     'can update delegated amount',
     async () => {

--- a/packages/cli/src/commands/network/__snapshots__/contracts-l2.test.ts.snap
+++ b/packages/cli/src/commands/network/__snapshots__/contracts-l2.test.ts.snap
@@ -7,7 +7,7 @@ exports[`network:contracts runs 1`] = `
   {
     "contract": "Accounts",
     "proxy": "0x570cc7D1f4404689F309bC091751C8115AbBB1Ae",
-    "implementation": "0x06c08d782e2495216df33d9d19a3d5a63B57D8dc",
+    "implementation": "0xA5BcC0165A7D6f6c238f4BC78F1BACCa89f63EDf",
     "version": "1.1.5.0"
   },
   {
@@ -19,31 +19,31 @@ exports[`network:contracts runs 1`] = `
   {
     "contract": "CeloDistributionSchedule",
     "proxy": "0xA16cF67AFa80BB9Ce7a325597F80057c6B290fD4",
-    "implementation": "0xe215Cd3d2450c013812d70dA2c5Cee8A34bD311b",
+    "implementation": "0xd527Ff1eF7f68753C3eFB03830b3d507a0bB92f2",
     "version": "1.1.0.0"
   },
   {
     "contract": "DoubleSigningSlasher",
     "proxy": "0x515e7966df0A7BBE4cfd6Ead22EfBE9d3506F0a0",
-    "implementation": "0x91bFb40d7Bb979b86688882dBA1dc0DFE40F8351",
+    "implementation": "0xC71980008Bb4F07195ce7B7bb4b04fb811f8dCBa",
     "version": "1.1.2.0"
   },
   {
     "contract": "DowntimeSlasher",
     "proxy": "0x1bcD39557a6420F37cDBD9eBc3085D03d9d73668",
-    "implementation": "0xeA3807aB4649C2B9a09eF3Fe80fe2aA37643464b",
+    "implementation": "0x54F7Cea8B2361114B80B7aCD1a4Ed608AEB6b1a9",
     "version": "2.0.1.0"
   },
   {
     "contract": "Election",
     "proxy": "0x778F5D194040A36c90865F02BEa4060297310609",
-    "implementation": "0x8D9CdBEae45017Bf408890C3f218841152281262",
+    "implementation": "0x667ef60a07cf50eeC675125Fca2C95c6fB116d5e",
     "version": "1.1.4.0"
   },
   {
     "contract": "EpochRewards",
     "proxy": "0x6dA691c7b03273310B7De55187cC911D91f2b437",
-    "implementation": "0xE55269E3446B6FA3B6df910aD8eF06daCF3279C3",
+    "implementation": "0x082C34Dc84a0Ae0214bB754BA63afA680a2A2a2a",
     "version": "1.1.2.0"
   },
   {
@@ -73,7 +73,7 @@ exports[`network:contracts runs 1`] = `
   {
     "contract": "FeeHandler",
     "proxy": "0x17c32B4036C68950F1b3fe4068f4F10AADa0d6a3",
-    "implementation": "0x0b7e5d2Db72Dd7ED137dB42253C8477B25438944",
+    "implementation": "0x00B00F97C60B7d87cda0470DFf25eF479A53C40d",
     "version": "1.1.0.1"
   },
   {
@@ -91,25 +91,25 @@ exports[`network:contracts runs 1`] = `
   {
     "contract": "GoldToken",
     "proxy": "0x2365F470a061B8333BAdE225eb7B34E2f9A3B4B2",
-    "implementation": "0x3BA4c2B49a88d6CF3372e9bAFc29d5790e2a000C",
+    "implementation": "0x2f16Ca901004271605b5Fe247E1953F17A8BbF80",
     "version": "1.1.3.0"
   },
   {
     "contract": "Governance",
     "proxy": "0x8345D9Fe2954ECa19cf6437EbA884609fb95B8a4",
-    "implementation": "0x9F4A368A7CBE1bde244cCC2883BF10f978EfFDAc",
+    "implementation": "0xE6D9BDcFcA7c240ac42963cf216648e3d670955b",
     "version": "1.5.0.0"
   },
   {
     "contract": "LockedGold",
     "proxy": "0x8CcF2E718ff8A3a3356045B9e28F2717d734E190",
-    "implementation": "0xaB3d124507E118859871fE18C7fB160ACD55a996",
+    "implementation": "0x76ae174e3E18a1E83B234063D010AA255e24F87e",
     "version": "1.1.5.0"
   },
   {
     "contract": "MentoFeeHandlerSeller",
     "proxy": "0xBc5AFaB0842bA88283f0379F5ad39FBA61ddc4c3",
-    "implementation": "0x55B2f8bB277a90570b5B519606817656FA56F8F8",
+    "implementation": "0x8dF962Afff35F23D9953b198Db3451B1664876f0",
     "version": "1.1.0.1"
   },
   {
@@ -163,13 +163,13 @@ exports[`network:contracts runs 1`] = `
   {
     "contract": "UniswapFeeHandlerSeller",
     "proxy": "0x3d3D4D5101504944f7AF4A7b4485c598cfE58B7a",
-    "implementation": "0xefBdEec6DF24ab3448f8296E45DB621B933C4E1b",
+    "implementation": "0x87e2B146C6226250fCDc5600070cb0B37Fe1F383",
     "version": "1.1.0.1"
   },
   {
     "contract": "Validators",
     "proxy": "0xDC9289b80E1ea63640C809664b891b1df517D567",
-    "implementation": "0xf057a3575E3778567c636673c13AE90AC5217ec4",
+    "implementation": "0xA45f627ebF37cf2A72BF6Af91F0c17D470E354fF",
     "version": "1.3.0.0"
   }
 ]

--- a/packages/cli/src/commands/network/contracts-l2.test.ts
+++ b/packages/cli/src/commands/network/contracts-l2.test.ts
@@ -1,12 +1,11 @@
-import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import write from '@oclif/core/lib/cli-ux/write'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Contracts from './contracts'
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('network:contracts', (web3) => {
+testWithAnvilL2('network:contracts', (web3) => {
   test('runs', async () => {
-    await setupL2(web3)
     const spy = jest.spyOn(write, 'stdout')
     await testLocallyWithWeb3Node(Contracts, ['--output', 'json'], web3)
     expect(spy.mock.calls).toMatchSnapshot()

--- a/packages/cli/src/commands/network/info-l2.test.ts
+++ b/packages/cli/src/commands/network/info-l2.test.ts
@@ -1,19 +1,16 @@
-import { newKitFromWeb3 } from '@celo/contractkit'
-import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Info from './info'
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('network:info', (web3) => {
+testWithAnvilL2('network:info', (web3) => {
   test('runs', async () => {
-    const kit = newKitFromWeb3(web3)
-    await setupL2(kit.web3)
     const spy = jest.spyOn(console, 'log')
     await testLocallyWithWeb3Node(Info, [], web3)
     expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
       [
         [
-          "blockNumber: 272",
+          "blockNumber: 269",
         ],
       ]
     `)

--- a/packages/cli/src/commands/network/parameters-l2.test.ts
+++ b/packages/cli/src/commands/network/parameters-l2.test.ts
@@ -1,13 +1,12 @@
 import { CeloDistributionScheduleWrapper } from '@celo/contractkit/lib/wrappers/CeloDistributionScheduleWrapper'
-import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Parameters from './parameters'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('network:parameters', (web3) => {
+testWithAnvilL2('network:parameters', (web3) => {
   test('runs', async () => {
-    await setupL2(web3)
     jest
       .spyOn(CeloDistributionScheduleWrapper.prototype, 'getConfig')
       .mockImplementation(async () => {
@@ -83,7 +82,7 @@ testWithAnvil('network:parameters', (web3) => {
       Reserve: 
         frozenReserveGoldDays: 0 
         frozenReserveGoldStartBalance: 0 
-        frozenReserveGoldStartDay: 19920 (~1.992e+4)
+        frozenReserveGoldStartDay: 19927 (~1.993e+4)
         otherReserveAddresses: 
 
         tobinTaxStalenessThreshold: 3153600000 (~3.154e+9)

--- a/packages/cli/src/commands/network/whitelist-l2.test.ts
+++ b/packages/cli/src/commands/network/whitelist-l2.test.ts
@@ -1,4 +1,4 @@
-import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import Web3 from 'web3'
 import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
@@ -6,11 +6,7 @@ import Whitelist from './whitelist'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvil('network:whitelist cmd', (web3: Web3) => {
-  beforeEach(async () => {
-    await setupL2(web3)
-  })
-
+testWithAnvilL2('network:whitelist cmd', (web3: Web3) => {
   const writeMock = jest.spyOn(ux.write, 'stdout')
 
   afterAll(() => {

--- a/packages/cli/src/commands/transfer/dollars.test.ts
+++ b/packages/cli/src/commands/transfer/dollars.test.ts
@@ -1,18 +1,18 @@
 import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
 import { ContractKit, StableToken, newKitFromWeb3 } from '@celo/contractkit'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
+import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { topUpWithToken } from '../../test-utils/chain-setup'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import TransferCUSD from './dollars'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
-import { topUpWithToken } from '../../test-utils/chain-setup'
-import BigNumber from 'bignumber.js'
 
 process.env.NO_SYNCCHECK = 'true'
 
 // Lots of commands, sometimes times out
 jest.setTimeout(15000)
 
-testWithAnvil('transfer:dollars cmd', (web3: Web3) => {
+testWithAnvilL1('transfer:dollars cmd', (web3: Web3) => {
   let accounts: string[] = []
   let kit: ContractKit
 

--- a/packages/cli/src/commands/transfer/euros.test.ts
+++ b/packages/cli/src/commands/transfer/euros.test.ts
@@ -1,18 +1,18 @@
 import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
 import { ContractKit, StableToken, newKitFromWeb3 } from '@celo/contractkit'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
+import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { topUpWithToken } from '../../test-utils/chain-setup'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import TransferEURO from './euros'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
-import { topUpWithToken } from '../../test-utils/chain-setup'
-import BigNumber from 'bignumber.js'
 
 process.env.NO_SYNCCHECK = 'true'
 
 // Lots of commands, sometimes times out
 jest.setTimeout(15000)
 
-testWithAnvil('transfer:euros cmd', (web3: Web3) => {
+testWithAnvilL1('transfer:euros cmd', (web3: Web3) => {
   let accounts: string[] = []
   let kit: ContractKit
 

--- a/packages/cli/src/test-utils/chain-setup.test.ts
+++ b/packages/cli/src/test-utils/chain-setup.test.ts
@@ -1,15 +1,15 @@
 import { isCel2 } from '@celo/connect'
-import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1, testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 
-testWithAnvil('chain setup', (web3: Web3) => {
-  describe('setupL2()', () => {
-    it('sets up L2 context', async () => {
-      expect(await isCel2(web3)).toEqual(false)
+testWithAnvilL1('chain setup', (web3: Web3) => {
+  it('checks for L1 context', async () => {
+    expect(await isCel2(web3)).toEqual(false)
+  })
+})
 
-      await setupL2(web3)
-
-      expect(await isCel2(web3)).toEqual(true)
-    })
+testWithAnvilL2('chain setup', (web3: Web3) => {
+  it('checks for L2 context', async () => {
+    expect(await isCel2(web3)).toEqual(true)
   })
 })

--- a/packages/cli/src/test-utils/cliUtils.ts
+++ b/packages/cli/src/test-utils/cliUtils.ts
@@ -47,18 +47,20 @@ export async function testLocally(
   return command.run(extendedArgv, config)
 }
 
-// Removes font-formatting ANSI codes (colors/styles) from a string
-export const stripAnsiCodes = (text: string): string => {
+// Removes font-formatting ANSI codes (colors/styles) and transaction hashes from a string
+export const stripAnsiCodesAndTxHashes = (text: string): string => {
   if (typeof text !== 'string') {
     // Not everything that comes in here is a string (you can console.log anything), so we just return it as is
     return text
   }
 
-  return text.replace(/\u001b\[.*?m/g, '')
+  return text
+    .replace(/\u001b\[.*?m/g, '')
+    .replace(/^txHash: 0x([A-Fa-f0-9]{64})$/, 'txHash: 0xtxhash')
 }
 
 export function stripAnsiCodesFromNestedArray(arrays: Array<string[]>) {
-  return arrays.map((level0) => level0.map((level1) => stripAnsiCodes(level1)))
+  return arrays.map((level0) => level0.map((level1) => stripAnsiCodesAndTxHashes(level1)))
 }
 
 export const LONG_TIMEOUT_MS = 10 * 1000

--- a/packages/cli/src/utils/fee-currency.test.ts
+++ b/packages/cli/src/utils/fee-currency.test.ts
@@ -2,22 +2,22 @@ import { isCel2 } from '@celo/connect'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { FeeCurrencyDirectoryWrapper } from '@celo/contractkit/lib/wrappers/FeeCurrencyDirectoryWrapper'
 import { FeeCurrencyWhitelistWrapper } from '@celo/contractkit/lib/wrappers/FeeCurrencyWhitelistWrapper'
-import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1, testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 import { getFeeCurrencyContractWrapper } from './fee-currency'
 
-testWithAnvil('getFeeCurrencyContractWrapper', async (web3: Web3) => {
+testWithAnvilL1('getFeeCurrencyContractWrapper', async (web3: Web3) => {
   it('returns FeeCurrencyWhitelist for L1 context', async () => {
     const kit = newKitFromWeb3(web3)
 
     const wrapper = await getFeeCurrencyContractWrapper(kit, await isCel2(web3))
     expect(wrapper).toBeInstanceOf(FeeCurrencyWhitelistWrapper)
   })
+})
 
+testWithAnvilL2('getFeeCurrencyContractWrapper', async (web3: Web3) => {
   it('returns FeeCurrencyDirectory for L2 context', async () => {
     const kit = newKitFromWeb3(web3)
-
-    await setupL2(web3)
 
     const wrapper = await getFeeCurrencyContractWrapper(kit, await isCel2(web3))
     expect(wrapper).toBeInstanceOf(FeeCurrencyDirectoryWrapper)

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -32,7 +32,7 @@
     "web3-core-helpers": "1.10.4"
   },
   "devDependencies": {
-    "@celo/devchain-anvil": "5.0.0-canary.0",
+    "@celo/devchain-anvil": "9.0.0-canary.0",
     "@celo/typescript": "workspace:^",
     "@tsconfig/recommended": "^1.0.3",
     "@types/fs-extra": "^8.1.0",

--- a/packages/sdk/contractkit/src/utils/signing.test.ts
+++ b/packages/sdk/contractkit/src/utils/signing.test.ts
@@ -1,10 +1,10 @@
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ACCOUNT_ADDRESSES, ACCOUNT_PRIVATE_KEYS } from '@celo/dev-utils/lib/ganache-setup'
 import { LocalSigner, NativeSigner, parseSignature } from '@celo/utils/lib/signatureUtils'
 
 // This only really tests signatureUtils in @celo/utils, but is tested here
 // to avoid the web3/ganache setup in @celo/utils
-testWithAnvil('Signing', (web3) => {
+testWithAnvilL1('Signing', (web3) => {
   const account = ACCOUNT_ADDRESSES[0]
   const pKey = ACCOUNT_PRIVATE_KEYS[0]
 

--- a/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
@@ -1,5 +1,5 @@
 import { StrongAddress } from '@celo/base'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'
 import { ContractKit, newKitFromWeb3 } from '../kit'
@@ -23,7 +23,7 @@ const blsPublicKey =
 const blsPoP =
   '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900'
 
-testWithAnvil('Accounts Wrapper', (web3) => {
+testWithAnvilL1('Accounts Wrapper', (web3) => {
   let kit: ContractKit
   let accounts: StrongAddress[] = []
   let accountsInstance: AccountsWrapper

--- a/packages/sdk/contractkit/src/wrappers/CeloDistributionScheduleWrapper.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/CeloDistributionScheduleWrapper.test.ts
@@ -1,13 +1,12 @@
-import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import { newKitFromWeb3 } from '../kit'
 
-testWithAnvil('CeloDistributionScheduleWrapper', (web3) => {
+// doesn't work
+testWithAnvilL2('CeloDistributionScheduleWrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
 
-  it.failing('fetches config', async () => {
+  it.only('fetches config', async () => {
     const celoDistributionScheduleWrapper = await kit.contracts.getCeloDistributionSchedule()
-
-    await setupL2(web3)
 
     const config = await celoDistributionScheduleWrapper.getConfig()
     expect(config).toMatchInlineSnapshot(`

--- a/packages/sdk/contractkit/src/wrappers/CeloDistributionScheduleWrapper.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/CeloDistributionScheduleWrapper.test.ts
@@ -1,11 +1,11 @@
 import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import { newKitFromWeb3 } from '../kit'
 
-// doesn't work
 testWithAnvilL2('CeloDistributionScheduleWrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
 
-  it.only('fetches config', async () => {
+  // https://github.com/celo-org/celo-monorepo/issues/11175
+  it.failing('fetches config', async () => {
     const celoDistributionScheduleWrapper = await kit.contracts.getCeloDistributionSchedule()
 
     const config = await celoDistributionScheduleWrapper.getConfig()

--- a/packages/sdk/contractkit/src/wrappers/FederatedAttestations.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/FederatedAttestations.test.ts
@@ -1,9 +1,9 @@
 import { StrongAddress } from '@celo/base'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { newKitFromWeb3 } from '../kit'
 import { FederatedAttestationsWrapper } from './FederatedAttestations'
 
-testWithAnvil('FederatedAttestations Wrapper', (web3) => {
+testWithAnvilL1('FederatedAttestations Wrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
   const TIME_STAMP = 1665080820
   let accounts: StrongAddress[] = []

--- a/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/FeeCurrencyDirectoryWrapper.test.ts
@@ -1,8 +1,8 @@
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import BigNumber from 'bignumber.js'
 import { newKitFromWeb3 } from '../kit'
 
-testWithAnvil('FeeCurrencyDirectory', (web3) => {
+testWithAnvilL1('FeeCurrencyDirectory', (web3) => {
   const kit = newKitFromWeb3(web3)
 
   it('fetches fee currency information', async () => {

--- a/packages/sdk/contractkit/src/wrappers/FeeCurrencyWhitelistWrapper.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/FeeCurrencyWhitelistWrapper.test.ts
@@ -1,7 +1,7 @@
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { newKitFromWeb3 } from '../kit'
 
-testWithAnvil('FeeCurrencyWhitelist', (web3) => {
+testWithAnvilL1('FeeCurrencyWhitelist', (web3) => {
   const kit = newKitFromWeb3(web3)
 
   it('fetches fee currency information', async () => {

--- a/packages/sdk/contractkit/src/wrappers/GoldToken.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/GoldToken.test.ts
@@ -1,10 +1,10 @@
 import { StrongAddress } from '@celo/base'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { newKitFromWeb3 } from '../kit'
 import { GoldTokenWrapper } from './GoldTokenWrapper'
 
-testWithAnvil('GoldToken Wrapper', (web3) => {
+testWithAnvilL1('GoldToken Wrapper', (web3) => {
   const ONE_GOLD = web3.utils.toWei('1', 'ether')
 
   const kit = newKitFromWeb3(web3)

--- a/packages/sdk/contractkit/src/wrappers/Governance-l2.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Governance-l2.test.ts
@@ -1,16 +1,14 @@
-import { setupL2, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 import { newKitFromWeb3 } from '../kit'
 import { ContractVersion } from '../versions'
 
-testWithAnvil('GovernanceWrapper', (web3: Web3) => {
+testWithAnvilL2('GovernanceWrapper', (web3: Web3) => {
   describe('Hotfixes', () => {
     it('gets L2 hotfix record for version >= 1.5.0.0', async () => {
       const kit = newKitFromWeb3(web3)
       const governance = await kit.contracts.getGovernance()
       const hotfixHash = Buffer.from('0x', 'hex')
-
-      await setupL2(web3)
 
       // Sanity check to make sure we're on at least 1.5.0.0 version
       expect((await governance.version()).isAtLeast(new ContractVersion(1, 5, 0, 0)))

--- a/packages/sdk/contractkit/src/wrappers/Governance.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Governance.test.ts
@@ -1,6 +1,6 @@
 import { Registry } from '@celo/abis/web3/Registry'
 import { Address, StrongAddress } from '@celo/base/lib/address'
-import { asCoreContractsOwner, testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { asCoreContractsOwner, testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { setDequeueFrequency, setReferendumStageDuration } from '@celo/dev-utils/lib/chain-setup'
 import { NetworkConfig, testWithGanache, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
@@ -36,7 +36,7 @@ testWithGanache('Governance Wrapper', (web3: Web3) => {
   })
 })
 
-testWithAnvil('Governance Wrapper', (web3: Web3) => {
+testWithAnvilL1('Governance Wrapper', (web3: Web3) => {
   const ONE_SEC = 1000
   const kit = newKitFromWeb3(web3)
   const ONE_CGLD = web3.utils.toWei('1', 'ether')
@@ -298,7 +298,8 @@ testWithAnvil('Governance Wrapper', (web3: Web3) => {
   })
 })
 
-testWithAnvil('Governance Wrapper', (web3: Web3) => {
+// TODO couldn't this be merged with the previous test suite?
+testWithAnvilL1('Governance Wrapper', (web3: Web3) => {
   describe('Hotfixes', () => {
     it('gets L1 hotfix record for version >= 1.5.0.0', async () => {
       const kit = newKitFromWeb3(web3)

--- a/packages/sdk/contractkit/src/wrappers/Governance.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Governance.test.ts
@@ -296,10 +296,7 @@ testWithAnvilL1('Governance Wrapper', (web3: Web3) => {
       expect(voter.votes[0]).toEqual(expectedVoteRecord)
     })
   })
-})
 
-// TODO couldn't this be merged with the previous test suite?
-testWithAnvilL1('Governance Wrapper', (web3: Web3) => {
   describe('Hotfixes', () => {
     it('gets L1 hotfix record for version >= 1.5.0.0', async () => {
       const kit = newKitFromWeb3(web3)

--- a/packages/sdk/contractkit/src/wrappers/LockedGold.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/LockedGold.test.ts
@@ -1,10 +1,10 @@
 import { StrongAddress } from '@celo/base'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { newKitFromWeb3 } from '../kit'
 import { AccountsWrapper } from './Accounts'
 import { LockedGoldWrapper } from './LockedGold'
 
-testWithAnvil('LockedGold Wrapper', (web3) => {
+testWithAnvilL1('LockedGold Wrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
   let accounts: AccountsWrapper
   let lockedGold: LockedGoldWrapper

--- a/packages/sdk/contractkit/src/wrappers/Validators.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Validators.test.ts
@@ -1,4 +1,4 @@
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { setCommissionUpdateDelay } from '@celo/dev-utils/lib/chain-setup'
 import { mineBlocks } from '@celo/dev-utils/lib/ganache-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
@@ -21,7 +21,7 @@ const blsPublicKey =
 const blsPoP =
   '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900'
 
-testWithAnvil('Validators Wrapper', (web3) => {
+testWithAnvilL1('Validators Wrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
   let accounts: string[] = []
   let accountsInstance: AccountsWrapper
@@ -112,7 +112,7 @@ testWithAnvil('Validators Wrapper', (web3) => {
     const txOpts = { from: groupAccount }
 
     // Set commission update delay to 3 blocks for backwards compatibility
-    setCommissionUpdateDelay(web3, validators.address, 3)
+    await setCommissionUpdateDelay(web3, validators.address, 3)
 
     await validators.setNextCommissionUpdate('0.2').sendAndWaitForReceipt(txOpts)
     await mineBlocks(3, web3)

--- a/packages/sdk/transactions-uri/src/tx-uri.test.ts
+++ b/packages/sdk/transactions-uri/src/tx-uri.test.ts
@@ -1,9 +1,9 @@
 import { CeloTx } from '@celo/connect'
 import { CeloContract, newKitFromWeb3 } from '@celo/contractkit'
-import { testWithAnvil } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { buildUri, parseUri } from './tx-uri'
 
-testWithAnvil('URI utils', (web3) => {
+testWithAnvilL1('URI utils', (web3) => {
   const recipient = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
   const value = '100'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1803,7 +1803,7 @@ __metadata:
   dependencies:
     "@celo/abis": "npm:^11.0.0"
     "@celo/connect": "npm:^6.0.0"
-    "@celo/devchain-anvil": "npm:5.0.0-canary.0"
+    "@celo/devchain-anvil": "npm:9.0.0-canary.0"
     "@celo/typescript": "workspace:^"
     "@tsconfig/recommended": "npm:^1.0.3"
     "@types/fs-extra": "npm:^8.1.0"
@@ -1819,10 +1819,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@celo/devchain-anvil@npm:5.0.0-canary.0":
-  version: 5.0.0-canary.0
-  resolution: "@celo/devchain-anvil@npm:5.0.0-canary.0"
-  checksum: a720d49ae4c701ffb6ade978de43cc7518effd383ae3fcf7e56f63b955262cf2f24dda739c44fb6a2674f9aa65bfb2ce6d8204b34724f68b52689468ff73e4fd
+"@celo/devchain-anvil@npm:9.0.0-canary.0":
+  version: 9.0.0-canary.0
+  resolution: "@celo/devchain-anvil@npm:9.0.0-canary.0"
+  checksum: 9f599569765eb4475211394478c19fb8c3661cd6a4b4ed2e6e1f2456e9575eeb74d767de77f5f2ea30c9f4450cc5cc75fdcb575626541e29d78b1683e3b27841
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This PR introduces `testWithAnvilL1` and `testWithAnvilL2` that replace previously used `testWithAnvil` to make it explicit in which context given test suite is being run.

### Other changes

- fixed a minor issue when calling commission delay update without `await` resulted in a flakey test
- fixed time-sensitive L2 hotfix approval test
- refactored `stripAnsiCodes` to `stripAnsiCodesAndTxHashes` that will now replace all valid tx hashes with `0xtxhash` not to have update the snapshots every time there's a minor change in the devchain that results in different hashes

### TODO

- [x] `packages/sdk/contractkit/src/wrappers/CeloDistributionScheduleWrapper.test.ts` is failing with `execution reverted: panic: arithmetic underflow or overflow (0x11)` error
- [x] 2 usages of `testWithAnvilL1` in `packages/sdk/contractkit/src/wrappers/Governance.test.ts` - consider merging
- [x] changesets

### Tested

Ran tests locally.

### Backwards compatibility

Backwards compatible.

### Documentation

None.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new test functions `testWithAnvilL1` and `testWithAnvilL2` to replace `testWithAnvil` for better context clarity in different test suites.

### Detailed summary
- Replaced `testWithAnvil` with `testWithAnvilL1` in multiple test files
- Updated `devchain-anvil` version to `9.0.0-canary.0`
- Updated test functions in various test files to use the new test functions for better context clarity

> The following files were skipped due to too many changes: `packages/cli/src/commands/account/claims.test.ts`, `packages/sdk/contractkit/src/wrappers/Accounts.test.ts`, `packages/cli/src/commands/governance/propose.test.ts`, `packages/cli/src/commands/lockedgold/revoke-delegate.test.ts`, `packages/cli/src/commands/governance/upvote.test.ts`, `packages/sdk/contractkit/src/wrappers/Governance-l2.test.ts`, `packages/cli/src/commands/network/info-l2.test.ts`, `packages/cli/src/test-utils/chain-setup.test.ts`, `packages/cli/src/commands/governance/vote.test.ts`, `packages/cli/src/commands/governance/withdraw.test.ts`, `packages/cli/src/commands/governance/votePartially.test.ts`, `packages/cli/src/commands/lockedgold/unlock.test.ts`, `packages/cli/src/commands/transfer/euros.test.ts`, `packages/cli/src/commands/transfer/dollars.test.ts`, `packages/cli/src/commands/election/activate.test.ts`, `yarn.lock`, `packages/cli/src/commands/network/parameters-l2.test.ts`, `packages/cli/src/test-utils/cliUtils.ts`, `packages/cli/src/commands/governance/preparehotfix-l2.test.ts`, `packages/cli/src/commands/lockedgold/lock.test.ts`, `packages/sdk/contractkit/src/wrappers/Validators.test.ts`, `packages/sdk/contractkit/src/wrappers/Governance.test.ts`, `packages/cli/src/utils/fee-currency.test.ts`, `packages/cli/src/commands/election/run.test.ts`, `packages/cli/src/commands/election/vote.test.ts`, `packages/cli/src/commands/election/show.test.ts`, `packages/dev-utils/src/anvil-test.ts`, `packages/cli/src/commands/governance/executehotfix-l2.test.ts`, `packages/cli/src/commands/governance/approve.test.ts`, `packages/cli/src/commands/network/__snapshots__/contracts-l2.test.ts.snap`, `packages/sdk/contractkit/src/kit.test.ts`, `packages/cli/src/commands/governance/approve-l2.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->