### PR TITLE
NPM deprecate workflow

### DIFF
--- a/.github/workflows/deprecation.yml
+++ b/.github/workflows/deprecation.yml
@@ -1,0 +1,50 @@
+name: Deprecate Packages
+
+on: 
+  workflow_dispatch:
+    inputs:
+      maxVersion: 
+        description: "Any version less than this will be marked"
+        required: true
+        type: string
+      package: 
+        description:  "Name of Package e.g. @celo/base"
+        required: true
+        type: string
+      message:  
+        description: "Message to be displayed to users using deprecated version"
+        required: true
+        type: string
+      dryRun:
+        type: boolean
+        description: Actually run?
+        default: false
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  sunset:
+    name: Deprecate All versions of ${{inputs.package}} prior to ${{inputs.version}}
+    runs-on: ['self-hosted', 'org', 'npm-publish']
+    permissions:
+      id-token: write
+    steps:
+      - name: Akeyless Get Secrets
+        id: get_auth_token
+        uses: docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:latest
+        with:
+          api-url: https://api.gateway.akeyless.celo-networks-dev.org
+          access-id: p-kf9vjzruht6l
+          static-secrets: '{"/static-secrets/NPM/npm-publish-token":"NPM_TOKEN"}'
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Check npm version
+        run: |
+          npm --version
+          echo will deprecate ${{inputs.package}}@"< ${{inputs.version}}" "${{message}}"
+      - name: Run Deprecate Command
+        if: inputs.dryRun == 'false'
+        run: npm deprecate ${{inputs.package}}@"< ${{inputs.version}}" "${{message}}"
+        env:
+          NPM_TOKEN: ${{ env.NPM_TOKEN }}


### PR DESCRIPTION

### Description

Add workflow to manually deprecate versions of package prior to specified version (exclusive). 


Cant run locally because with our  npm security settings these packages only can have write operations (publish, deprecat etc) from the akeyless npm token

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a GitHub workflow to deprecate packages by marking versions below a specified threshold.

### Detailed summary
- Added a GitHub workflow `deprecation.yml`
- Workflow triggers on manual dispatch
- Inputs for `maxVersion`, `package`, `message`, and `dryRun`
- Job `sunset` to deprecate all versions prior to `maxVersion`
- Steps to authenticate, setup Node.js, check npm version, and run deprecate command

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->