### PR TITLE
Migrate CLI validator, validatorgroup and election commands to anvil

### DIFF
--- a/packages/cli/src/commands/election/activate.test.ts
+++ b/packages/cli/src/commands/election/activate.test.ts
@@ -1,5 +1,5 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
@@ -10,18 +10,20 @@ import {
   setupGroupAndAffiliateValidator,
   voteForGroupFrom,
 } from '../../test-utils/chain-setup'
-import { stripAnsiCodesAndTxHashes, testLocally } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import ElectionActivate from './activate'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithGanache('election:activate', (web3: Web3) => {
+testWithAnvilL1('election:activate', (web3: Web3) => {
   afterEach(async () => {
     jest.clearAllMocks()
   })
 
   it('fails when no flags are provided', async () => {
-    await expect(testLocally(ElectionActivate, [])).rejects.toThrow('Missing required flag from')
+    await expect(testLocallyWithWeb3Node(ElectionActivate, [], web3)).rejects.toThrow(
+      'Missing required flag from'
+    )
   })
 
   it('shows no pending votes', async () => {
@@ -31,7 +33,7 @@ testWithGanache('election:activate', (web3: Web3) => {
 
     await registerAccount(kit, userAddress)
 
-    await testLocally(ElectionActivate, ['--from', userAddress])
+    await testLocallyWithWeb3Node(ElectionActivate, ['--from', userAddress], web3)
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`
       [
@@ -53,7 +55,7 @@ testWithGanache('election:activate', (web3: Web3) => {
     await registerAccountWithLockedGold(kit, userAddress)
 
     await voteForGroupFrom(kit, userAddress, groupAddress, new BigNumber(10))
-    await testLocally(ElectionActivate, ['--from', userAddress])
+    await testLocallyWithWeb3Node(ElectionActivate, ['--from', userAddress], web3)
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`
       [
@@ -83,7 +85,7 @@ testWithGanache('election:activate', (web3: Web3) => {
       new BigNumber(0)
     )
 
-    await testLocally(ElectionActivate, ['--from', userAddress])
+    await testLocallyWithWeb3Node(ElectionActivate, ['--from', userAddress], web3)
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`[]`)
     expect((await election.getVotesForGroupByAccount(userAddress, groupAddress)).active).toEqual(
@@ -109,7 +111,7 @@ testWithGanache('election:activate', (web3: Web3) => {
     )
 
     await Promise.all([
-      testLocally(ElectionActivate, ['--from', userAddress, '--wait']),
+      testLocallyWithWeb3Node(ElectionActivate, ['--from', userAddress, '--wait'], web3),
       new Promise<void>((resolve) => {
         // at least the amount the --wait flag waits in the check
         setTimeout(async () => {
@@ -167,7 +169,11 @@ testWithGanache('election:activate', (web3: Web3) => {
       (await election.getVotesForGroupByAccount(otherUserAddress, groupAddress)).active
     ).toEqual(new BigNumber(0))
 
-    await testLocally(ElectionActivate, ['--from', otherUserAddress, '--for', userAddress])
+    await testLocallyWithWeb3Node(
+      ElectionActivate,
+      ['--from', otherUserAddress, '--for', userAddress],
+      web3
+    )
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`[]`)
     expect((await election.getVotesForGroupByAccount(userAddress, groupAddress)).active).toEqual(

--- a/packages/cli/src/commands/election/current.test.ts
+++ b/packages/cli/src/commands/election/current.test.ts
@@ -2,12 +2,12 @@ import { newKitFromWeb3 } from '@celo/contractkit'
 import { WrapperCache } from '@celo/contractkit/lib/contract-cache'
 import { ElectionWrapper } from '@celo/contractkit/lib/wrappers/Election'
 import { ValidatorsWrapper } from '@celo/contractkit/lib/wrappers/Validators'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { registerAccount, setupGroupAndAffiliateValidator } from '../../test-utils/chain-setup'
-import { testLocally } from '../../test-utils/cliUtils'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Current from './current'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -17,7 +17,7 @@ afterEach(async () => {
   jest.restoreAllMocks()
 })
 
-testWithGanache('election:current cmd', async (web3: Web3) => {
+testWithAnvilL1('election:current cmd', async (web3: Web3) => {
   it('shows list with no --valset provided', async () => {
     const kit = newKitFromWeb3(web3)
     const [
@@ -75,7 +75,7 @@ testWithGanache('election:current cmd', async (web3: Web3) => {
     const warnMock = jest.spyOn(console, 'warn')
     const writeMock = jest.spyOn(ux.write, 'stdout')
 
-    await testLocally(Current, ['--csv'])
+    await testLocallyWithWeb3Node(Current, ['--csv'], web3)
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`
       [
@@ -152,7 +152,7 @@ testWithGanache('election:current cmd', async (web3: Web3) => {
     const warnMock = jest.spyOn(console, 'warn')
     const writeMock = jest.spyOn(ux.write, 'stdout')
 
-    await testLocally(Current, ['--csv', '--valset'])
+    await testLocallyWithWeb3Node(Current, ['--csv', '--valset'], web3)
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`
       [

--- a/packages/cli/src/commands/election/list.test.ts
+++ b/packages/cli/src/commands/election/list.test.ts
@@ -1,5 +1,5 @@
 import { ElectionWrapper, ValidatorGroupVote } from '@celo/contractkit/lib/wrappers/Election'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
@@ -8,7 +8,7 @@ import ElectionList from './list'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithGanache('election:list cmd', (web3: Web3) => {
+testWithAnvilL1('election:list cmd', (web3: Web3) => {
   test('shows list when no arguments provided', async () => {
     const getValidatorGroupsVotesMock = jest.spyOn(
       ElectionWrapper.prototype,

--- a/packages/cli/src/commands/election/run.test.ts
+++ b/packages/cli/src/commands/election/run.test.ts
@@ -1,17 +1,17 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { ElectionWrapper } from '@celo/contractkit/lib/wrappers/Election'
 import { ValidatorsWrapper } from '@celo/contractkit/lib/wrappers/Validators'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { setupGroupAndAffiliateValidator } from '../../test-utils/chain-setup'
-import { stripAnsiCodesAndTxHashes, testLocally } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Run from './run'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithGanache('election:run', (web3: Web3) => {
+testWithAnvilL1('election:run', (web3: Web3) => {
   afterEach(async () => {
     jest.clearAllMocks()
   })
@@ -21,7 +21,7 @@ testWithGanache('election:run', (web3: Web3) => {
     const warnMock = jest.spyOn(console, 'warn')
     const writeMock = jest.spyOn(ux.write, 'stdout')
 
-    await testLocally(Run, ['--csv'])
+    await testLocallyWithWeb3Node(Run, ['--csv'], web3)
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`
       [
@@ -89,7 +89,7 @@ testWithGanache('election:run', (web3: Web3) => {
         signer: anotherSignerAddress,
       }))
 
-    await testLocally(Run, ['--csv'])
+    await testLocallyWithWeb3Node(Run, ['--csv'], web3)
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`
       [

--- a/packages/cli/src/commands/election/show.test.ts
+++ b/packages/cli/src/commands/election/show.test.ts
@@ -1,27 +1,29 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { ElectionWrapper, ValidatorGroupVote, Voter } from '@celo/contractkit/lib/wrappers/Election'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { registerAccount, setupGroup } from '../../test-utils/chain-setup'
-import { stripAnsiCodesAndTxHashes, testLocally } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Show from './show'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithGanache('election:show', (web3: Web3) => {
+testWithAnvilL1('election:show', (web3: Web3) => {
   afterEach(async () => {
     jest.clearAllMocks()
   })
 
   it('fails when no args are provided', async () => {
-    await expect(testLocally(Show, [])).rejects.toThrow("Voter or Validator Groups's address")
+    await expect(testLocallyWithWeb3Node(Show, [], web3)).rejects.toThrow(
+      "Voter or Validator Groups's address"
+    )
   })
 
   it('fails when no flags are provided', async () => {
     const [groupAddress] = await web3.eth.getAccounts()
-    await expect(testLocally(Show, [groupAddress])).rejects.toThrow(
+    await expect(testLocallyWithWeb3Node(Show, [groupAddress], web3)).rejects.toThrow(
       'Must select --voter or --group'
     )
   })
@@ -30,7 +32,7 @@ testWithGanache('election:show', (web3: Web3) => {
     const logMock = jest.spyOn(console, 'log')
     const [groupAddress] = await web3.eth.getAccounts()
 
-    await expect(testLocally(Show, [groupAddress, '--group'])).rejects.toThrow(
+    await expect(testLocallyWithWeb3Node(Show, [groupAddress, '--group'], web3)).rejects.toThrow(
       "Some checks didn't pass!"
     )
     expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[1][0])).toContain(
@@ -42,7 +44,7 @@ testWithGanache('election:show', (web3: Web3) => {
     const logMock = jest.spyOn(console, 'log')
     const [voterAddress] = await web3.eth.getAccounts()
 
-    await expect(testLocally(Show, [voterAddress, '--voter'])).rejects.toThrow(
+    await expect(testLocallyWithWeb3Node(Show, [voterAddress, '--voter'], web3)).rejects.toThrow(
       "Some checks didn't pass!"
     )
     expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[1][0])).toContain(
@@ -72,7 +74,7 @@ testWithGanache('election:show', (web3: Web3) => {
       } as ValidatorGroupVote
     })
 
-    await testLocally(Show, [groupAddress, '--group'])
+    await testLocallyWithWeb3Node(Show, [groupAddress, '--group'], web3)
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`[]`)
     expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))
@@ -125,7 +127,7 @@ testWithGanache('election:show', (web3: Web3) => {
       } as Voter
     })
 
-    await testLocally(Show, [voterAddress, '--voter'])
+    await testLocallyWithWeb3Node(Show, [voterAddress, '--voter'], web3)
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`[]`)
     expect(logMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes)))

--- a/packages/cli/src/commands/election/vote.test.ts
+++ b/packages/cli/src/commands/election/vote.test.ts
@@ -1,5 +1,5 @@
 import { newKitFromWeb3 } from '@celo/contractkit'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
@@ -8,18 +8,18 @@ import {
   registerAccountWithLockedGold,
   setupGroupAndAffiliateValidator,
 } from '../../test-utils/chain-setup'
-import { stripAnsiCodesAndTxHashes, testLocally } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Vote from './vote'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithGanache('election:vote', (web3: Web3) => {
+testWithAnvilL1('election:vote', (web3: Web3) => {
   afterEach(async () => {
     jest.clearAllMocks()
   })
 
   it('fails when no flags are provided', async () => {
-    await expect(testLocally(Vote, [])).rejects.toThrow('Missing required flag')
+    await expect(testLocallyWithWeb3Node(Vote, [], web3)).rejects.toThrow('Missing required flag')
   })
 
   it('fails when voter is not an account', async () => {
@@ -27,7 +27,11 @@ testWithGanache('election:vote', (web3: Web3) => {
     const [fromAddress, groupAddress] = await web3.eth.getAccounts()
 
     await expect(
-      testLocally(Vote, ['--from', fromAddress, '--for', groupAddress, '--value', '1'])
+      testLocallyWithWeb3Node(
+        Vote,
+        ['--from', fromAddress, '--for', groupAddress, '--value', '1'],
+        web3
+      )
     ).rejects.toThrow()
 
     expect(logMock.mock.calls[1][0]).toContain(
@@ -43,7 +47,11 @@ testWithGanache('election:vote', (web3: Web3) => {
     await registerAccount(kit, fromAddress)
 
     await expect(
-      testLocally(Vote, ['--from', fromAddress, '--for', groupAddress, '--value', '1'])
+      testLocallyWithWeb3Node(
+        Vote,
+        ['--from', fromAddress, '--for', groupAddress, '--value', '1'],
+        web3
+      )
     ).rejects.toThrow()
 
     expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[2][0])).toContain(
@@ -60,7 +68,11 @@ testWithGanache('election:vote', (web3: Web3) => {
     await setupGroupAndAffiliateValidator(kit, groupAddress, validatorAddress)
 
     await expect(
-      testLocally(Vote, ['--from', fromAddress, '--for', groupAddress, '--value', '1'])
+      testLocallyWithWeb3Node(
+        Vote,
+        ['--from', fromAddress, '--for', groupAddress, '--value', '1'],
+        web3
+      )
     ).rejects.toThrow()
 
     expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[3][0])).toContain(
@@ -84,7 +96,11 @@ testWithGanache('election:vote', (web3: Web3) => {
     )
 
     await expect(
-      testLocally(Vote, ['--from', fromAddress, '--for', groupAddress, '--value', amount.toFixed()])
+      testLocallyWithWeb3Node(
+        Vote,
+        ['--from', fromAddress, '--for', groupAddress, '--value', amount.toFixed()],
+        web3
+      )
     ).resolves.not.toThrow()
 
     expect(await election.getTotalVotesForGroupByAccount(groupAddress, fromAddress)).toEqual(amount)

--- a/packages/cli/src/commands/validator/register.test.ts
+++ b/packages/cli/src/commands/validator/register.test.ts
@@ -1,14 +1,14 @@
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import Web3 from 'web3'
-import { testLocally } from '../../test-utils/cliUtils'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from '../lockedgold/lock'
 import ValidatorRegister from './register'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithGanache('validator:register', (web3: Web3) => {
+testWithAnvilL1('validator:register', (web3: Web3) => {
   let account: string
   let ecdsaPublicKey: string
 
@@ -16,52 +16,36 @@ testWithGanache('validator:register', (web3: Web3) => {
     const accounts = await web3.eth.getAccounts()
     account = accounts[0]
     ecdsaPublicKey = await addressToPublicKey(account, web3.eth.sign)
-    await testLocally(Register, ['--from', account])
-    await testLocally(Lock, ['--from', account, '--value', '10000000000000000000000'])
+    await testLocallyWithWeb3Node(Register, ['--from', account], web3)
+    await testLocallyWithWeb3Node(
+      Lock,
+      ['--from', account, '--value', '10000000000000000000000'],
+      web3
+    )
   })
 
   test('can register validator with 0x prefix', async () => {
-    await testLocally(ValidatorRegister, [
-      '--from',
-      account,
-      '--ecdsaKey',
-      ecdsaPublicKey,
-      '--blsKey',
-      '0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00',
-      '--blsSignature',
-      '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
-      '--yes',
-    ])
+    await testLocallyWithWeb3Node(
+      ValidatorRegister,
+      [
+        '--from',
+        account,
+        '--ecdsaKey',
+        ecdsaPublicKey,
+        '--blsKey',
+        '0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00',
+        '--blsSignature',
+        '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
+        '--yes',
+      ],
+      web3
+    )
   })
 
   test('can register validator without 0x prefix', async () => {
-    await testLocally(ValidatorRegister, [
-      '--from',
-      account,
-      '--ecdsaKey',
-      ecdsaPublicKey,
-      '--blsKey',
-      '4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00',
-      '--blsSignature',
-      'cdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
-      '--yes',
-    ])
-  })
-
-  test('fails if validator already registered', async () => {
-    await testLocally(ValidatorRegister, [
-      '--from',
-      account,
-      '--ecdsaKey',
-      ecdsaPublicKey,
-      '--blsKey',
-      '4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00',
-      '--blsSignature',
-      'cdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
-      '--yes',
-    ])
-    await expect(
-      testLocally(ValidatorRegister, [
+    await testLocallyWithWeb3Node(
+      ValidatorRegister,
+      [
         '--from',
         account,
         '--ecdsaKey',
@@ -71,7 +55,43 @@ testWithGanache('validator:register', (web3: Web3) => {
         '--blsSignature',
         'cdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
         '--yes',
-      ])
+      ],
+      web3
+    )
+  })
+
+  test('fails if validator already registered', async () => {
+    await testLocallyWithWeb3Node(
+      ValidatorRegister,
+      [
+        '--from',
+        account,
+        '--ecdsaKey',
+        ecdsaPublicKey,
+        '--blsKey',
+        '4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00',
+        '--blsSignature',
+        'cdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
+        '--yes',
+      ],
+      web3
+    )
+    await expect(
+      testLocallyWithWeb3Node(
+        ValidatorRegister,
+        [
+          '--from',
+          account,
+          '--ecdsaKey',
+          ecdsaPublicKey,
+          '--blsKey',
+          '4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00',
+          '--blsSignature',
+          'cdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
+          '--yes',
+        ],
+        web3
+      )
     ).rejects.toThrow("Some checks didn't pass!")
   })
 })


### PR DESCRIPTION
### Description

This PR moves CLI `validator`, `validatorgroup` and `election` commands tests to anvil.

### Other changes

None.

### Tested

Ran tests locally.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates test scripts in the election, validator group, and commission commands to use `testWithAnvilL1` and `testLocallyWithWeb3Node` from `dev-utils`. 

### Detailed summary
- Replaced `testWithGanache` with `testWithAnvilL1` in test scripts
- Updated test functions to use `testLocallyWithWeb3Node` with `web3` argument

> The following files were skipped due to too many changes: `packages/cli/src/commands/election/revoke.test.ts`, `packages/cli/src/commands/election/show.test.ts`, `packages/cli/src/commands/election/activate.test.ts`, `packages/cli/src/commands/validator/register.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->