### PR TITLE
Finalize anvil migration

### DIFF
--- a/packages/cli/src/commands/network/__snapshots__/contracts.test.ts.snap
+++ b/packages/cli/src/commands/network/__snapshots__/contracts.test.ts.snap
@@ -6,165 +6,171 @@ exports[`network:contracts runs 1`] = `
     "[
   {
     "contract": "Accounts",
-    "proxy": "0xa9a65D631f8c8577f543B64B35909030C84676A2",
-    "implementation": "0x038C860fd0d598B3DF5577B466c8b0a074867f56",
-    "version": "1.1.4.1"
-  },
-  {
-    "contract": "Attestations",
-    "proxy": "0x54a582397Ace3F9a6F5A28cE6Dc50473E4A9d375",
-    "implementation": "0xc650825Ca03EeB83d0d075c2737022cBb01F5799",
-    "version": "1.2.0.0"
+    "proxy": "0x570cc7D1f4404689F309bC091751C8115AbBB1Ae",
+    "implementation": "0xA5BcC0165A7D6f6c238f4BC78F1BACCa89f63EDf",
+    "version": "1.1.5.0"
   },
   {
     "contract": "BlockchainParameters",
-    "proxy": "0xd418d14C9b8aA740E8D18C6dfda3af6f023A27A5",
-    "implementation": "0x4CF20BEf2FBe159601939bE49B760457B11C1d52",
-    "version": "1.3.0.0"
+    "proxy": "0x38f95b6c6C45b68e03954f6BbE9d8fAcb96ac080",
+    "implementation": "0x97877ee036DAEEbb03b147b649547BecbAA5a9fc",
+    "version": "1.3.1.0"
+  },
+  {
+    "contract": "CeloDistributionSchedule",
+    "proxy": "0xA16cF67AFa80BB9Ce7a325597F80057c6B290fD4",
+    "implementation": "0xd527Ff1eF7f68753C3eFB03830b3d507a0bB92f2",
+    "version": "1.1.0.0"
   },
   {
     "contract": "DoubleSigningSlasher",
-    "proxy": "0x175Ac784563DE645647C6350F0CFc577Dcc7eE5b",
-    "implementation": "0xA47aA5fCecBfb374E79144F05fDf91D0F50fA351",
-    "version": "1.1.1.0"
+    "proxy": "0x515e7966df0A7BBE4cfd6Ead22EfBE9d3506F0a0",
+    "implementation": "0xC71980008Bb4F07195ce7B7bb4b04fb811f8dCBa",
+    "version": "1.1.2.0"
   },
   {
     "contract": "DowntimeSlasher",
-    "proxy": "0x0C5173a51e26b29d6126C686756FB9FBEf71f762",
-    "implementation": "0x33a89cA59bc3A9221456ffE461de17C8deF24684",
-    "version": "2.0.0.0"
+    "proxy": "0x1bcD39557a6420F37cDBD9eBc3085D03d9d73668",
+    "implementation": "0x54F7Cea8B2361114B80B7aCD1a4Ed608AEB6b1a9",
+    "version": "2.0.1.0"
   },
   {
     "contract": "Election",
-    "proxy": "0xcBAe15A320F56Fc9ad6c8319D55Be1FeF0750070",
-    "implementation": "0x51815ebd3C922B215b0d0B9b41a4Daa0dB70b841",
-    "version": "1.1.3.0"
+    "proxy": "0x778F5D194040A36c90865F02BEa4060297310609",
+    "implementation": "0x667ef60a07cf50eeC675125Fca2C95c6fB116d5e",
+    "version": "1.1.4.0"
   },
   {
     "contract": "EpochRewards",
-    "proxy": "0x537732b0bAC4F2A1a97b1a60cEa0df5C3f0DEF16",
-    "implementation": "0x1E28a5fB7B112291F088bBB8ab693D2214DB7895",
-    "version": "1.1.1.0"
+    "proxy": "0x6dA691c7b03273310B7De55187cC911D91f2b437",
+    "implementation": "0x082C34Dc84a0Ae0214bB754BA63afA680a2A2a2a",
+    "version": "1.1.2.0"
   },
   {
     "contract": "Escrow",
-    "proxy": "0xE8593eFb73423D86e5F337A46B3450eEec1027c6",
-    "implementation": "0xc51B43db0Cea40E36207993F0aB1883E7A865417",
+    "proxy": "0x221BbCfE8e148c83f28aBef4cd44804A48A0979D",
+    "implementation": "0x6C9f18245726D34d95905B0e78e295Ab66668dCE",
     "version": "1.2.0.0"
   },
   {
     "contract": "FederatedAttestations",
-    "proxy": "0x8C3d218745c360A399285c0176714530Ce0af3B1",
-    "implementation": "0x9d0e84A58Bb5B9b94F5c34fD4f310ed3F41A2D69",
+    "proxy": "0x838657d02B4A110A5eec7Ea1eE370b81ceC13b2d",
+    "implementation": "0xDD5d5C001A41Cca679346Ac949d22958a6402a4b",
+    "version": "1.1.0.0"
+  },
+  {
+    "contract": "FeeCurrencyDirectory",
+    "proxy": "0x32d3Fa78c85842C7F55550dfc13d7440E650978e",
+    "implementation": "0xAB0f45164119Da3523e94aeAfa97f8Af402f3931",
     "version": "1.1.0.0"
   },
   {
     "contract": "FeeCurrencyWhitelist",
-    "proxy": "0xE86bB98fcF9BFf3512C74589B78Fb168200CC546",
-    "implementation": "0xDc688D29394a3f1E6f1E5100862776691afAf3d2",
+    "proxy": "0xE6D8431e15C0E2Ebc2c4cC32C6aA283D2A9f7637",
+    "implementation": "0x444e17f7D12a55682588C5aC8FD75E6415858Fa8",
     "version": "NONE"
   },
   {
     "contract": "FeeHandler",
-    "proxy": "0x176097114008844bCb75Ea58998B7f8303b4C2d4",
-    "implementation": "0x123d0530A2a37FA4d4efA3999e79203BAf5bE517",
-    "version": "1.1.0.0"
+    "proxy": "0x17c32B4036C68950F1b3fe4068f4F10AADa0d6a3",
+    "implementation": "0x00B00F97C60B7d87cda0470DFf25eF479A53C40d",
+    "version": "1.1.0.1"
   },
   {
     "contract": "Freezer",
-    "proxy": "0xcFC18CEc799fBD1793B5C43E773C98D4d61Cc2dB",
-    "implementation": "0xF22469F31527adc53284441bae1665A7b9214DBA",
+    "proxy": "0xAF64491fc6f744833F57caAD9a3e7041A64d322E",
+    "implementation": "0x2cE041EFA055795ed86d3749375626A960A31b36",
     "version": "NONE"
   },
   {
     "contract": "GasPriceMinimum",
-    "proxy": "0x038F9B392Fb9A9676DbAddF78EA5fdbf6C7d9710",
-    "implementation": "0x371b13d97f4bF77d724E78c16B7dC74099f40e84",
-    "version": "1.2.0.1"
+    "proxy": "0xaB21B082c398fAC79358163aEcAEEc577105DA97",
+    "implementation": "0x6886C0Be3AAD36bAaE412c451AcB7A2da6980e8A",
+    "version": "1.2.1.0"
   },
   {
     "contract": "GoldToken",
-    "proxy": "0x04B5dAdd2c0D6a261bfafBc964E0cAc48585dEF3",
-    "implementation": "0x8726C7414ac023D23348326B47AF3205185Fd035",
-    "version": "1.1.2.0"
+    "proxy": "0x2365F470a061B8333BAdE225eb7B34E2f9A3B4B2",
+    "implementation": "0x2f16Ca901004271605b5Fe247E1953F17A8BbF80",
+    "version": "1.1.3.0"
   },
   {
     "contract": "Governance",
-    "proxy": "0x82E9A894F6b752E5c1058ea69898Ff5D3EBA3939",
-    "implementation": "0xc98E260cBF7041cc2C42D7e055fb4350DF22dd68",
-    "version": "1.4.1.0"
+    "proxy": "0x8345D9Fe2954ECa19cf6437EbA884609fb95B8a4",
+    "implementation": "0xE6D9BDcFcA7c240ac42963cf216648e3d670955b",
+    "version": "1.5.0.0"
   },
   {
     "contract": "LockedGold",
-    "proxy": "0x4A86aD5f263260f24483Df2B1B3a23ea4788B6AB",
-    "implementation": "0x0221652D4306F6b3CB7B23E43C3e25D8F9a142Ca",
-    "version": "1.1.4.0"
+    "proxy": "0x8CcF2E718ff8A3a3356045B9e28F2717d734E190",
+    "implementation": "0x76ae174e3E18a1E83B234063D010AA255e24F87e",
+    "version": "1.1.5.0"
   },
   {
     "contract": "MentoFeeHandlerSeller",
-    "proxy": "0x98942DE2B8eaC1c264e41cA981b82032762d72a4",
-    "implementation": "0x8501835ac2B234147F766bB6e6423D6Ef50A9247",
-    "version": "1.1.0.0"
+    "proxy": "0xBc5AFaB0842bA88283f0379F5ad39FBA61ddc4c3",
+    "implementation": "0x8dF962Afff35F23D9953b198Db3451B1664876f0",
+    "version": "1.1.0.1"
   },
   {
     "contract": "OdisPayments",
-    "proxy": "0x347BfD5F56F04210603c9cC7c6c1f88E9E5c9676",
-    "implementation": "0x05E0c172eB6244A564B0D9e59Ce63074584a1e7A",
+    "proxy": "0x4b37Fe822B332616D5355c2E34495f61259aF2F8",
+    "implementation": "0x013b9d221dB9946f520862B5a538d31C1658F020",
     "version": "1.1.0.0"
   },
   {
     "contract": "Random",
-    "proxy": "0xd2dBF3250a764eaaa94fa0C84ED87C0Edc8eD04E",
-    "implementation": "0x39c3Fc9F4D8430af2713306CE80C584752d9e1C7",
-    "version": "1.1.1.0"
+    "proxy": "0xba7574365c34e24119C5751B77722268B1B31117",
+    "implementation": "0x5971E1E2A749974B7E1f31499C0364aE31E47D2F",
+    "version": "1.1.2.0"
   },
   {
     "contract": "Registry",
     "proxy": "0x000000000000000000000000000000000000ce10",
-    "implementation": "0x07f96Aa816C1F244CbC6ef114bB2b023Ba54a2EB",
+    "implementation": "0x600ed1f58Dfe89b1baBB04611b3B69be409C49E1",
     "version": "NONE"
   },
   {
     "contract": "Reserve",
-    "proxy": "0xCA9717a4A6e8009B3518648C9f3E7676255471A1",
-    "implementation": "0x4586649629F699f9A4B61D0e962DC3c9025Fe488",
+    "proxy": "0x903f4b9523c23Db2a631CB111EFc55776D811ae2",
+    "implementation": "0x843Ea04327C2D6E48FfDa66977Be24591B718FBD",
     "version": "1.1.2.2"
   },
   {
     "contract": "SortedOracles",
-    "proxy": "0x4D3d5c850Dd5bD9D6F4AdDA3DD039a3C8054CA29",
-    "implementation": "0xA31E64EA55B9B6Bbb9d6A676738e9A5b23149f84",
-    "version": "1.1.3.0"
+    "proxy": "0xF0358Ffb1DC83CbFAD879735918f3E3570c9ae05",
+    "implementation": "0xd275F2F2605f8bAddfDc8e56FEf092DdE3C74D7E",
+    "version": "1.1.4.0"
   },
   {
     "contract": "StableToken",
-    "proxy": "0x5315e44798395d4a952530d131249fE00f554565",
-    "implementation": "0xDFF540fE764855D3175DcfAe9d91AE8aEE5C6D6F",
+    "proxy": "0x82398F079D742F9D0Ae71ef8C99E5c68b2eD6705",
+    "implementation": "0xf50DF42DA1685033D684dbA711042B87eB00282b",
     "version": "NONE"
   },
   {
     "contract": "StableTokenBRL",
-    "proxy": "0x965D352283a3C8A016b9BBbC9bf6306665d495E7",
-    "implementation": "0x9a1df498af690a7EB43E10A28AB51345a3A33F75",
+    "proxy": "0x603931FF5E63d2fd3EEF1513a55fB773d8082195",
+    "implementation": "0x1dbdc8B4616004724436348ae22b20C6265F7444",
     "version": "NONE"
   },
   {
     "contract": "StableTokenEUR",
-    "proxy": "0xdD66C23e07b4D6925b6089b5Fe6fc9E62941aFE8",
-    "implementation": "0x4609e0ED27A8BAAc57b753D36a5D2971915588f9",
+    "proxy": "0x0c6a0fde0A72bA3990870f0F99ED79a821703474",
+    "implementation": "0x58e9F2416b1FCBa8A61AC46d480d2d92e471b22E",
     "version": "NONE"
   },
   {
     "contract": "UniswapFeeHandlerSeller",
-    "proxy": "0x9EF3dACB3367d7741099b5607A7a93E99a119F7b",
-    "implementation": "0x0F3723fB2a7C147357868702164f9beEf54E1E85",
-    "version": "1.1.0.0"
+    "proxy": "0x3d3D4D5101504944f7AF4A7b4485c598cfE58B7a",
+    "implementation": "0x87e2B146C6226250fCDc5600070cb0B37Fe1F383",
+    "version": "1.1.0.1"
   },
   {
     "contract": "Validators",
-    "proxy": "0x6AC7189BD267c81c55d7d7d0321f9B23639cB9db",
-    "implementation": "0x3E809c563c15a295E832e37053798DdC8d6C8dab",
-    "version": "1.2.0.5"
+    "proxy": "0xDC9289b80E1ea63640C809664b891b1df517D567",
+    "implementation": "0xA45f627ebF37cf2A72BF6Af91F0c17D470E354fF",
+    "version": "1.3.0.0"
   }
 ]
 ",

--- a/packages/cli/src/commands/network/contracts.test.ts
+++ b/packages/cli/src/commands/network/contracts.test.ts
@@ -1,13 +1,14 @@
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import write from '@oclif/core/lib/cli-ux/write'
-import { testLocally } from '../../test-utils/cliUtils'
+import Web3 from 'web3'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Contracts from './contracts'
 process.env.NO_SYNCCHECK = 'true'
 
-testWithGanache('network:contracts', () => {
+testWithAnvilL1('network:contracts', (web3: Web3) => {
   test('runs', async () => {
     const spy = jest.spyOn(write, 'stdout')
-    await testLocally(Contracts, ['--output', 'json'])
+    await testLocallyWithWeb3Node(Contracts, ['--output', 'json'], web3)
     expect(spy.mock.calls).toMatchSnapshot()
   })
 })

--- a/packages/cli/src/commands/network/parameters.test.ts
+++ b/packages/cli/src/commands/network/parameters.test.ts
@@ -1,32 +1,21 @@
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
-import { stripAnsiCodesFromNestedArray, testLocally } from '../../test-utils/cliUtils'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
+import Web3 from 'web3'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Parameters from './parameters'
 process.env.NO_SYNCCHECK = 'true'
 
-testWithGanache('network:parameters', () => {
+testWithAnvilL1('network:parameters', (web3: Web3) => {
   test('runs', async () => {
     const spy = jest.spyOn(console, 'log')
-    await testLocally(Parameters, [])
+    await testLocallyWithWeb3Node(Parameters, [], web3)
     expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
       [
         [
           "Attestations: 
-        attestationExpiry: 1 hour
-        attestationRequestFees: 
-          0: 
-            address: 0x04B5dAdd2c0D6a261bfafBc964E0cAc48585dEF3
-            fee: 0 
-          1: 
-            address: 0x5315e44798395d4a952530d131249fE00f554565
-            fee: 50000000000000000 (~5.000e+16)
-          2: 
-            address: 0xdD66C23e07b4D6925b6089b5Fe6fc9E62941aFE8
-            fee: 0 
-          3: 
-            address: 0x965D352283a3C8A016b9BBbC9bf6306665d495E7
-            fee: 0 
+      Failed to fetch config for contract Attestations: 
+      Error: Attestations not (yet) registered
       BlockchainParameters: 
-        blockGasLimit: 20000000 (~2.000e+7)
+        blockGasLimit: 13000000 (~1.300e+7)
         intrinsicGasForAlternativeFeeCurrency: 50000 (~5.000e+4)
       DowntimeSlasher: 
         slashableDowntime: 5 minutes
@@ -38,7 +27,7 @@ testWithGanache('network:parameters', () => {
         electabilityThreshold: 0.001 
         electableValidators: 
           max: 100 
-          min: 10 
+          min: 1 
         maxNumGroupsVotedFor: 10 
         totalVotes: 0 
       EpochRewards: 
@@ -47,7 +36,7 @@ testWithGanache('network:parameters', () => {
           partner: 0x0000000000000000000000000000000000000000
         communityReward: 0.25 
         rewardsMultiplier: 
-          max: 2 
+          max: 0 
           overspendAdjustment: 5 
           underspendAdjustment: 0.5 
         targetValidatorEpochPayment: 205479452054794520547 (~2.055e+20)
@@ -60,33 +49,32 @@ testWithGanache('network:parameters', () => {
         gasPriceMinimum: 100000000 (~1.000e+8)
         targetDensity: 0.5 
       Governance: 
-        concurrentProposals: 5 
-        dequeueFrequency: 30 seconds
-        minDeposit: 1000000000000000000 (~1.000e+18)
+        concurrentProposals: 3 
+        dequeueFrequency: 4 hours
+        minDeposit: 100000000000000000000 (~1.000e+20)
         participationParameters: 
           baseline: 0.005 
           baselineFloor: 0.01 
           baselineQuorumFactor: 1 
           baselineUpdateFactor: 0.2 
-        queueExpiry: 16 minutes, 40 seconds
+        queueExpiry: 4 weeks
         stageDurations: 
-          Execution: 1 minute, 40 seconds
-          Referendum: 1 minute, 40 seconds
+          Execution: 1 week
+          Referendum: 1 day
       LockedGold: 
-        totalLockedGold: 0 
-        unlockingPeriod: 3 days
+        totalLockedGold: 60000000000000000000000 (~6.000e+22)
+        unlockingPeriod: 6 hours
       Reserve: 
         frozenReserveGoldDays: 0 
         frozenReserveGoldStartBalance: 0 
-        frozenReserveGoldStartDay: 19787 (~1.979e+4)
+        frozenReserveGoldStartDay: 19927 (~1.993e+4)
         otherReserveAddresses: 
-          0: 0x91c987bf62D25945dB517BDAa840A6c661374402
-          1: 0x298FbD6dad2Fc2cB56d7E37d8aCad8Bf07324f67
+
         tobinTaxStalenessThreshold: 3153600000 (~3.154e+9)
       SortedOracles: 
         reportExpiry: 5 minutes
       Validators: 
-        commissionUpdateDelay: 15 seconds
+        commissionUpdateDelay: 3 days
         downtimeGracePeriod: 0 
         groupLockedGoldRequirements: 
           duration: 6 months

--- a/packages/cli/src/commands/network/whitelist.test.ts
+++ b/packages/cli/src/commands/network/whitelist.test.ts
@@ -1,7 +1,8 @@
 import { FeeCurrencyWhitelistWrapper } from '@celo/contractkit/lib/wrappers/FeeCurrencyWhitelistWrapper'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
-import { stripAnsiCodesFromNestedArray, testLocally } from '../../test-utils/cliUtils'
+import Web3 from 'web3'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Whitelist from './whitelist'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -15,29 +16,29 @@ beforeEach(() => {
   writeMock.mockClear()
 })
 
-testWithGanache('network:whitelist cmd', () => {
+testWithAnvilL1('network:whitelist cmd', (web3: Web3) => {
   test('can print the whitelist', async () => {
-    await testLocally(Whitelist, [])
+    await testLocallyWithWeb3Node(Whitelist, [], web3)
     expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
       [
         [
-          " Name                Symbol Whitelisted Address                        Token Address                              Decimals Uses Adapter? 
+          " Name                Symbol              Whitelisted Address                        Token Address                              Decimals Uses Adapter? 
       ",
         ],
         [
-          " ─────────────────── ────── ────────────────────────────────────────── ────────────────────────────────────────── ──────── ───────────── 
+          " ─────────────────── ─────────────────── ────────────────────────────────────────── ────────────────────────────────────────── ──────── ───────────── 
       ",
         ],
         [
-          " Celo Dollar         cUSD   0x5315e44798395d4a952530d131249fE00f554565 0x5315e44798395d4a952530d131249fE00f554565 18       false         
+          " Celo Euro           Celo Euro           0x0c6a0fde0A72bA3990870f0F99ED79a821703474 0x0c6a0fde0A72bA3990870f0F99ED79a821703474 18       false         
       ",
         ],
         [
-          " Celo Brazilian Real cREAL  0x965D352283a3C8A016b9BBbC9bf6306665d495E7 0x965D352283a3C8A016b9BBbC9bf6306665d495E7 18       false         
+          " Celo Brazilian Real Celo Brazilian Real 0x603931FF5E63d2fd3EEF1513a55fB773d8082195 0x603931FF5E63d2fd3EEF1513a55fB773d8082195 18       false         
       ",
         ],
         [
-          " Celo Euro           cEUR   0xdD66C23e07b4D6925b6089b5Fe6fc9E62941aFE8 0xdD66C23e07b4D6925b6089b5Fe6fc9E62941aFE8 18       false         
+          " Celo Dollar         Celo Dollar         0x82398F079D742F9D0Ae71ef8C99E5c68b2eD6705 0x82398F079D742F9D0Ae71ef8C99E5c68b2eD6705 18       false         
       ",
         ],
       ]
@@ -59,7 +60,7 @@ testWithGanache('network:whitelist cmd', () => {
         ])
       )
 
-    await testLocally(Whitelist, [])
+    await testLocallyWithWeb3Node(Whitelist, [], web3)
 
     expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
       [

--- a/packages/cli/src/commands/reserve/transfergold.test.ts
+++ b/packages/cli/src/commands/reserve/transfergold.test.ts
@@ -1,57 +1,107 @@
+import { newReserve } from '@celo/abis/web3/mento/Reserve'
+import { newMultiSig } from '@celo/abis/web3/MultiSig'
 import { StrongAddress } from '@celo/base'
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { CeloContract, newKitFromWeb3 } from '@celo/contractkit'
 import { GoldTokenWrapper } from '@celo/contractkit/lib/wrappers/GoldTokenWrapper'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import {
+  asCoreContractsOwner,
+  DEFAULT_OWNER_ADDRESS,
+  setBalance,
+  testWithAnvilL1,
+  withImpersonatedAccount,
+} from '@celo/dev-utils/lib/anvil-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
-import { testLocally } from '../../test-utils/cliUtils'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import TransferGold from './transfergold'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithGanache('reserve:transfergold cmd', (web3: Web3) => {
+testWithAnvilL1('reserve:transfergold cmd', (web3: Web3) => {
   const transferAmt = new BigNumber(100000)
   const kit = newKitFromWeb3(web3)
 
   let accounts: StrongAddress[] = []
+  let otherReserveAddress: StrongAddress
+  let otherSpender: StrongAddress
   let goldToken: GoldTokenWrapper
 
   beforeEach(async () => {
     accounts = (await web3.eth.getAccounts()) as StrongAddress[]
     goldToken = await kit.contracts.getGoldToken()
+
+    otherReserveAddress = accounts[9]
+    otherSpender = accounts[7]
+    const multiSigAddress = await kit.registry.addressFor('ReserveSpenderMultiSig' as CeloContract)
+    const reserveSpenderMultiSig = await kit.contracts.getMultiSig(multiSigAddress)
+    const reserve = await kit.contracts.getReserve()
+
+    const reserveContract = newReserve(web3, reserve.address)
+    const reserveSpenderMultiSigContract = newMultiSig(web3, reserveSpenderMultiSig.address)
+
+    await withImpersonatedAccount(
+      web3,
+      multiSigAddress,
+      async () => {
+        await reserveSpenderMultiSig
+          .replaceOwner(DEFAULT_OWNER_ADDRESS, accounts[0])
+          .sendAndWaitForReceipt({ from: multiSigAddress })
+        await reserveSpenderMultiSigContract.methods
+          .addOwner(otherSpender)
+          .send({ from: multiSigAddress })
+        await reserveSpenderMultiSigContract.methods
+          .changeRequirement(2)
+          .send({ from: multiSigAddress })
+      },
+      new BigNumber(web3.utils.toWei('1', 'ether'))
+    )
+
+    await asCoreContractsOwner(web3, async (ownerAdress: StrongAddress) => {
+      await reserveContract.methods.addSpender(multiSigAddress).send({ from: ownerAdress })
+      await reserveContract.methods
+        .addOtherReserveAddress(otherReserveAddress)
+        .send({ from: ownerAdress })
+    })
+
+    await setBalance(web3, reserve.address, new BigNumber(web3.utils.toWei('1', 'ether')))
   })
   test('transferGold fails if spender not passed in', async () => {
     await expect(
-      testLocally(TransferGold, [
+      testLocallyWithWeb3Node(
+        TransferGold,
+        ['--from', accounts[0], '--value', transferAmt.toString(10), '--to', otherReserveAddress],
+        web3
+      )
+    ).rejects.toThrow("Some checks didn't pass!")
+  })
+  test('can transferGold with multisig option', async () => {
+    const initialBalance = await goldToken.balanceOf(otherReserveAddress)
+    await testLocallyWithWeb3Node(
+      TransferGold,
+      [
         '--from',
         accounts[0],
         '--value',
         transferAmt.toString(10),
         '--to',
-        accounts[9],
-      ])
-    ).rejects.toThrow("Some checks didn't pass!")
-  })
-  test('can transferGold with multisig option', async () => {
-    const initialBalance = await goldToken.balanceOf(accounts[9])
-    await testLocally(TransferGold, [
-      '--from',
-      accounts[0],
-      '--value',
-      transferAmt.toString(10),
-      '--to',
-      accounts[9],
-      '--useMultiSig',
-    ])
-    await testLocally(TransferGold, [
-      '--from',
-      accounts[7],
-      '--value',
-      transferAmt.toString(10),
-      '--to',
-      accounts[9],
-      '--useMultiSig',
-    ])
+        otherReserveAddress,
+        '--useMultiSig',
+      ],
+      web3
+    )
+    await testLocallyWithWeb3Node(
+      TransferGold,
+      [
+        '--from',
+        otherSpender,
+        '--value',
+        transferAmt.toString(10),
+        '--to',
+        otherReserveAddress,
+        '--useMultiSig',
+      ],
+      web3
+    )
     expect(await goldToken.balanceOf(accounts[9])).toEqual(initialBalance.plus(transferAmt))
   })
 })

--- a/packages/dev-utils/src/anvil-test.ts
+++ b/packages/dev-utils/src/anvil-test.ts
@@ -20,6 +20,12 @@ export const STABLES_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
 // Introducing a different name for the same address to avoid confusion
 export const DEFAULT_OWNER_ADDRESS = STABLES_ADDRESS
 
+// Addresses are generated during migrations and need to be extracted from logs
+export enum LinkedLibraryAddress {
+  AddressSortedLinkedListWithMedian = '0x5fbdb2315678afecb367f032d93f642f64180aa3',
+  Signatures = '0xe7f1725e7734ce288f8367e1bb143e90bb3f0512',
+}
+
 function createInstance(stateFilePath: string): Anvil {
   const port = ANVIL_PORT + (process.pid - process.ppid)
   const options: CreateAnvilOptions = {
@@ -29,6 +35,7 @@ function createInstance(stateFilePath: string): Anvil {
     balance: TEST_BALANCE,
     gasPrice: TEST_GAS_PRICE,
     gasLimit: TEST_GAS_LIMIT,
+    blockBaseFeePerGas: 0,
     stopTimeout: 1000,
   }
 
@@ -93,11 +100,17 @@ export const withImpersonatedAccount = async (
 
 export const asCoreContractsOwner = async (
   web3: Web3,
-  fn: (ownerAddress: StrongAddress) => Promise<void>
+  fn: (ownerAddress: StrongAddress) => Promise<void>,
+  withBalance?: number | bigint | BigNumber
 ) => {
-  await withImpersonatedAccount(web3, DEFAULT_OWNER_ADDRESS, async () => {
-    await fn(DEFAULT_OWNER_ADDRESS)
-  })
+  await withImpersonatedAccount(
+    web3,
+    DEFAULT_OWNER_ADDRESS,
+    async () => {
+      await fn(DEFAULT_OWNER_ADDRESS)
+    },
+    withBalance
+  )
 }
 
 export function setCode(web3: Web3, address: string, code: string) {

--- a/packages/dev-utils/src/contracts.ts
+++ b/packages/dev-utils/src/contracts.ts
@@ -1,0 +1,26 @@
+import { StrongAddress } from '@celo/base'
+import AttestationsArtifacts from '@celo/celo-devchain/contracts/contracts-0.5/Attestations.json'
+import Web3 from 'web3'
+import { AbiItem } from 'web3-utils'
+import { LinkedLibraryAddress } from './anvil-test'
+
+export const deployAttestationsContract = async (
+  web3: Web3,
+  owner: StrongAddress
+): Promise<StrongAddress> => {
+  const contract = new web3.eth.Contract(AttestationsArtifacts.abi as AbiItem[])
+
+  const deployTx = contract.deploy({
+    data: AttestationsArtifacts.bytecode.replace(
+      /__Signatures____________________________/g,
+      LinkedLibraryAddress.Signatures.replace('0x', '')
+    ),
+    // By providing true to the contract constructor
+    // we don't need to call initialize() on the contract
+    arguments: [true],
+  })
+
+  const txResult = await deployTx.send({ from: owner })
+
+  return txResult.options.address as StrongAddress
+}

--- a/packages/sdk/contractkit/src/identity/claims/account.test.ts
+++ b/packages/sdk/contractkit/src/identity/claims/account.test.ts
@@ -1,5 +1,5 @@
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ACCOUNT_ADDRESSES, ACCOUNT_PRIVATE_KEYS } from '@celo/dev-utils/lib/ganache-setup'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { privateKeyToAddress, privateKeyToPublicKey } from '@celo/utils/lib/address'
 import { NativeSigner } from '@celo/utils/lib/signatureUtils'
 import { newKitFromWeb3 } from '../../kit'
@@ -8,7 +8,7 @@ import { createAccountClaim } from './account'
 import { Claim } from './claim'
 import { verifyClaim } from './verify'
 
-testWithGanache('Account claims', (web3) => {
+testWithAnvilL1('Account claims', (web3) => {
   const kit = newKitFromWeb3(web3)
   const address = ACCOUNT_ADDRESSES[0]
   const otherAddress = ACCOUNT_ADDRESSES[1]
@@ -64,9 +64,9 @@ testWithGanache('Account claims', (web3) => {
 
       const myUrl = 'https://www.example.com/'
       const accounts = await kit.contracts.getAccounts()
-      await accounts.createAccount().send({ from: address })
+      await accounts.createAccount().sendAndWaitForReceipt({ from: address })
       await accounts.setMetadataURL(myUrl).sendAndWaitForReceipt({ from: address, gas: 0 })
-      await accounts.createAccount().send({ from: otherAddress })
+      await accounts.createAccount().sendAndWaitForReceipt({ from: otherAddress })
       await accounts.setMetadataURL(myUrl).sendAndWaitForReceipt({ from: otherAddress, gas: 0 })
 
       IdentityMetadataWrapper.fetchFromURL = () => Promise.resolve(otherMetadata)

--- a/packages/sdk/contractkit/src/identity/claims/domain.test.ts
+++ b/packages/sdk/contractkit/src/identity/claims/domain.test.ts
@@ -1,12 +1,12 @@
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ACCOUNT_ADDRESSES } from '@celo/dev-utils/lib/ganache-setup'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { NativeSigner, Signer, verifySignature } from '@celo/utils/lib/signatureUtils'
 import { newKitFromWeb3 } from '../../kit'
 import { IdentityMetadataWrapper } from '../metadata'
 import { DomainClaim, createDomainClaim, serializeClaim } from './claim'
 import { verifyDomainRecord } from './verify'
 
-testWithGanache('Domain claims', (web3) => {
+testWithAnvilL1('Domain claims', (web3) => {
   const kit = newKitFromWeb3(web3)
   const address = ACCOUNT_ADDRESSES[0]
   const secondAddress = ACCOUNT_ADDRESSES[1]

--- a/packages/sdk/contractkit/src/identity/metadata.test.ts
+++ b/packages/sdk/contractkit/src/identity/metadata.test.ts
@@ -1,11 +1,12 @@
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ACCOUNT_ADDRESSES } from '@celo/dev-utils/lib/ganache-setup'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { Address } from '@celo/utils/lib/address'
 import { NativeSigner } from '@celo/utils/lib/signatureUtils'
 import { newKitFromWeb3 } from '../kit'
 import { createNameClaim } from './claims/claim'
 import { ClaimTypes, IdentityMetadataWrapper } from './metadata'
-testWithGanache('Metadata', (web3) => {
+
+testWithAnvilL1('Metadata', (web3) => {
   const kit = newKitFromWeb3(web3)
   const address = ACCOUNT_ADDRESSES[0]
   const otherAddress = ACCOUNT_ADDRESSES[1]

--- a/packages/sdk/contractkit/src/kit-l2.test.ts
+++ b/packages/sdk/contractkit/src/kit-l2.test.ts
@@ -1,0 +1,71 @@
+import { StrongAddress } from '@celo/base'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import Web3 from 'web3'
+import { ContractKit, newKitFromWeb3 } from './kit'
+
+testWithAnvilL2('kit', (web3: Web3) => {
+  let kit: ContractKit
+  let feeToken: StrongAddress
+
+  beforeAll(async () => {
+    kit = newKitFromWeb3(web3)
+
+    const feeCurrencyWhitelist = await kit.contracts.getFeeCurrencyWhitelist()
+    const gasOptions = await feeCurrencyWhitelist.getWhitelist()
+    feeToken = gasOptions[0]
+  })
+
+  describe('when on cel2', () => {
+    describe('when gas is missing', () => {
+      it('fills the gas and works as normal', async () => {
+        await expect(
+          kit.populateMaxFeeInToken({
+            feeCurrency: feeToken,
+          })
+        ).resolves.toMatchInlineSnapshot(`
+          {
+            "feeCurrency": "0x0c6a0fde0A72bA3990870f0F99ED79a821703474",
+            "gas": 53001,
+            "maxFeeInFeeCurrency": "54061020000000",
+            "maxFeePerGas": "1000000000",
+            "maxPriorityFeePerGas": "1000000000",
+          }
+        `)
+      })
+    })
+    describe('when maxFeePerFeeCurrency exists', () => {
+      it('returns without modification', async () => {
+        const maxFeeInFeeCurrency = '2000000'
+        await expect(
+          kit.populateMaxFeeInToken({
+            maxFeeInFeeCurrency,
+            feeCurrency: feeToken,
+            gas: '102864710371401736267367367',
+          })
+        ).resolves.toMatchObject({
+          maxFeeInFeeCurrency,
+          feeCurrency: feeToken,
+          gas: '102864710371401736267367367',
+        })
+      })
+    })
+    describe('when feeCurrency provided with gas', () => {
+      it('returns with maxFeePerFeeCurrency estimated', async () => {
+        await expect(
+          kit.populateMaxFeeInToken({
+            feeCurrency: feeToken,
+            gas: '102864710371401736267367367',
+          })
+        ).resolves.toMatchInlineSnapshot(`
+          {
+            "feeCurrency": "0x0c6a0fde0A72bA3990870f0F99ED79a821703474",
+            "gas": "102864710371401736267367367",
+            "maxFeeInFeeCurrency": "104922004578829770992714714340000000",
+            "maxFeePerGas": "1000000000",
+            "maxPriorityFeePerGas": "1000000000",
+          }
+        `)
+      })
+    })
+  })
+})

--- a/packages/sdk/contractkit/src/kit.test.ts
+++ b/packages/sdk/contractkit/src/kit.test.ts
@@ -1,7 +1,6 @@
 import { StrongAddress } from '@celo/base'
 import { CeloTx, CeloTxObject, CeloTxReceipt, PromiEvent } from '@celo/connect'
-import { testWithAnvilL1, testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 import {
   ContractKit,
@@ -139,85 +138,77 @@ describe('newKitWithApiKey()', () => {
   })
 })
 
-testWithGanache('Fetch whitelisted fee currencies', (web3: Web3) => {
+testWithAnvilL1('kit', (web3: Web3) => {
   let kit: ContractKit
   let accounts: string[]
-
-  beforeEach(async () => {
-    accounts = await web3.eth.getAccounts()
-    kit = newKitFromWeb3(web3)
-  })
-
-  describe('When whitelisted fee currencies are fetched on-chain', () => {
-    test('Then the result includes addresses', async () => {
-      const feeCurrencyWhitelist = await kit.contracts.getFeeCurrencyWhitelist()
-      const gasOptions = await feeCurrencyWhitelist.getWhitelist()
-      for (let i = 0; i < gasOptions.length; i++) {
-        expect(web3.utils.isAddress(gasOptions[i])).toBeTruthy()
-      }
-    })
-
-    test.failing('Then the resulting addresses are valid fee currencies', async () => {
-      const celo = await kit.contracts.getGoldToken()
-      const feeCurrencyWhitelist = await kit.contracts.getFeeCurrencyWhitelist()
-      const gasOptions = await feeCurrencyWhitelist.getWhitelist()
-      const sender = accounts[0]
-      const recipient = accounts[1]
-      const amount = kit.web3.utils.toWei('0.01', 'ether')
-
-      for (let gasOption of gasOptions.filter((x) => x !== celo.address)) {
-        const recipientBalanceBefore = await kit.getTotalBalance(recipient)
-        const feeAsErc20 = await kit.contracts.getErc20(gasOption)
-        // const transactionObject = celo.transfer(recipient, amount)
-        const feeCurrencyBalanceBefore = await feeAsErc20.balanceOf(sender)
-        await kit.connection.sendTransaction({
-          from: sender,
-          to: recipient,
-          value: amount,
-          feeCurrency: gasOption,
-        })
-        const recipientBalanceAfter = await kit.getTotalBalance(recipient)
-        const feeCurrencyBalanceAfter = await feeAsErc20.balanceOf(sender)
-
-        expect(recipientBalanceAfter.CELO!.eq(recipientBalanceBefore.CELO!.plus(amount))).toBe(true)
-
-        // This is failing because celo-ganache doesn't support feeCurrency
-        // https://github.com/celo-org/ganache-cli/tree/master
-        expect(feeCurrencyBalanceBefore.isGreaterThan(feeCurrencyBalanceAfter)).toBe(true)
-      }
-    })
-
-    test.failing('Then using a wrong address will fail', async () => {
-      // This is failing because celo-ganache doesn't support feeCurrency
-      // https://github.com/celo-org/ganache-cli/tree/master
-
-      const sender = accounts[0]
-      const recipient = accounts[1]
-      const amount = kit.web3.utils.toWei('0.01', 'ether')
-      await expect(
-        kit.connection.sendTransaction({
-          from: sender,
-          to: recipient,
-          value: amount,
-          feeCurrency: '0123' as StrongAddress,
-        })
-      ).rejects.toThrowErrorMatchingInlineSnapshot()
-    })
-  })
-})
-
-testWithAnvilL1('kit', (web3) => {
-  let kit: ContractKit
   let feeToken: StrongAddress
   beforeAll(async () => {
-    // when this is beforeEach the web3 instance is reused so the second time it already is attached to a celo provider
-    // but if the provider is already an instance of celo provider then  rpccaller is not attached to connection class instance
-    //  web3 must be a new instance when creating a kit not a an instance that was already used by a different kit
+    accounts = await web3.eth.getAccounts()
     kit = newKitFromWeb3(web3)
 
     const feeCurrencyWhitelist = await kit.contracts.getFeeCurrencyWhitelist()
     const gasOptions = await feeCurrencyWhitelist.getWhitelist()
     feeToken = gasOptions[0]
+  })
+  describe('Fetch whitelisted fee currencies', () => {
+    describe('When whitelisted fee currencies are fetched on-chain', () => {
+      test('Then the result includes addresses', async () => {
+        const feeCurrencyWhitelist = await kit.contracts.getFeeCurrencyWhitelist()
+        const gasOptions = await feeCurrencyWhitelist.getWhitelist()
+        for (let i = 0; i < gasOptions.length; i++) {
+          expect(web3.utils.isAddress(gasOptions[i])).toBeTruthy()
+        }
+      })
+
+      test.failing('Then the resulting addresses are valid fee currencies', async () => {
+        const celo = await kit.contracts.getGoldToken()
+        const feeCurrencyWhitelist = await kit.contracts.getFeeCurrencyWhitelist()
+        const gasOptions = await feeCurrencyWhitelist.getWhitelist()
+        const sender = accounts[0]
+        const recipient = accounts[1]
+        const amount = kit.web3.utils.toWei('0.01', 'ether')
+
+        for (let gasOption of gasOptions.filter((x) => x !== celo.address)) {
+          const recipientBalanceBefore = await kit.getTotalBalance(recipient)
+          const feeAsErc20 = await kit.contracts.getErc20(gasOption)
+          // const transactionObject = celo.transfer(recipient, amount)
+          const feeCurrencyBalanceBefore = await feeAsErc20.balanceOf(sender)
+          await kit.connection.sendTransaction({
+            from: sender,
+            to: recipient,
+            value: amount,
+            feeCurrency: gasOption,
+          })
+          const recipientBalanceAfter = await kit.getTotalBalance(recipient)
+          const feeCurrencyBalanceAfter = await feeAsErc20.balanceOf(sender)
+
+          expect(recipientBalanceAfter.CELO!.eq(recipientBalanceBefore.CELO!.plus(amount))).toBe(
+            true
+          )
+
+          // This is failing because celo-ganache doesn't support feeCurrency
+          // https://github.com/celo-org/ganache-cli/tree/master
+          expect(feeCurrencyBalanceBefore.isGreaterThan(feeCurrencyBalanceAfter)).toBe(true)
+        }
+      })
+
+      test.failing('Then using a wrong address will fail', async () => {
+        // This is failing because celo-ganache doesn't support feeCurrency
+        // https://github.com/celo-org/ganache-cli/tree/master
+
+        const sender = accounts[0]
+        const recipient = accounts[1]
+        const amount = kit.web3.utils.toWei('0.01', 'ether')
+        await expect(
+          kit.connection.sendTransaction({
+            from: sender,
+            to: recipient,
+            value: amount,
+            feeCurrency: '0123' as StrongAddress,
+          })
+        ).rejects.toThrowErrorMatchingInlineSnapshot()
+      })
+    })
   })
   describe('populateMaxFeeInToken', () => {
     describe('when not on cel2', () => {
@@ -279,74 +270,6 @@ testWithAnvilL1('kit', (web3) => {
         })
         // 10 * 10 * 1.2 * 1/2
       ).resolves.toEqual(BigInt(51))
-    })
-  })
-})
-
-testWithAnvilL2('kit', (web3) => {
-  let kit: ContractKit
-  let feeToken: StrongAddress
-
-  beforeAll(async () => {
-    // when this is beforeEach the web3 instance is reused so the second time it already is attached to a celo provider
-    // but if the provider is already an instance of celo provider then  rpccaller is not attached to connection class instance
-    //  web3 must be a new instance when creating a kit not a an instance that was already used by a different kit
-    kit = newKitFromWeb3(web3)
-
-    const feeCurrencyWhitelist = await kit.contracts.getFeeCurrencyWhitelist()
-    const gasOptions = await feeCurrencyWhitelist.getWhitelist()
-    feeToken = gasOptions[0]
-  })
-
-  describe('when on cel2', () => {
-    describe('when gas is missing', () => {
-      it('fills the gas and works as normal', async () => {
-        await expect(
-          kit.populateMaxFeeInToken({
-            feeCurrency: feeToken,
-          })
-        ).resolves.toMatchInlineSnapshot(`
-          {
-            "feeCurrency": "0x0c6a0fde0A72bA3990870f0F99ED79a821703474",
-            "gas": 53001,
-            "maxFeeInFeeCurrency": "108122040000000",
-            "maxFeePerGas": "2000000000",
-            "maxPriorityFeePerGas": "1000000000",
-          }
-        `)
-      })
-    })
-    describe('when maxFeePerFeeCurrency exists', () => {
-      it('returns without modification', async () => {
-        const maxFeeInFeeCurrency = '2000000'
-        await expect(
-          kit.populateMaxFeeInToken({
-            maxFeeInFeeCurrency,
-            feeCurrency: feeToken,
-            gas: '102864710371401736267367367',
-          })
-        ).resolves.toMatchObject({
-          maxFeeInFeeCurrency,
-          feeCurrency: feeToken,
-          gas: '102864710371401736267367367',
-        })
-      })
-    })
-    describe('when feeCurrency provided with gas', () => {
-      it('returns with maxFeePerFeeCurrency estimated', async () => {
-        await expect(
-          kit.populateMaxFeeInToken({
-            feeCurrency: feeToken,
-            gas: '102864710371401736267367367',
-          })
-        ).resolves.toEqual({
-          feeCurrency: feeToken,
-          gas: '102864710371401736267367367',
-          maxFeeInFeeCurrency: '209844009157659541985429428680000000',
-          maxFeePerGas: '2000000000',
-          maxPriorityFeePerGas: '1000000000',
-        })
-      })
     })
   })
 })

--- a/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Accounts.test.ts
@@ -54,19 +54,12 @@ testWithAnvilL1('Accounts Wrapper', (web3) => {
     accountsInstance = await kit.contracts.getAccounts()
   })
 
-  afterAll(async () => {
-    kit.connection.stop()
-  })
-
   const setupValidator = async (validatorAccount: string) => {
     await registerAccountWithLockedGold(validatorAccount)
     const ecdsaPublicKey = await addressToPublicKey(validatorAccount, kit.connection.sign)
-    await validators
-      // @ts-ignore
-      .registerValidator(ecdsaPublicKey, blsPublicKey, blsPoP)
-      .sendAndWaitForReceipt({
-        from: validatorAccount,
-      })
+    await validators.registerValidator(ecdsaPublicKey, blsPublicKey, blsPoP).sendAndWaitForReceipt({
+      from: validatorAccount,
+    })
   }
 
   test('SBAT authorize attestation key', async () => {

--- a/packages/sdk/contractkit/src/wrappers/Attestations.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Attestations.test.ts
@@ -1,10 +1,12 @@
+import { newAttestations } from '@celo/abis/web3/Attestations'
 import { StrongAddress } from '@celo/base'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
+import { deployAttestationsContract } from '@celo/dev-utils/lib/contracts'
 import { getIdentifierHash, IdentifierPrefix } from '@celo/odis-identifiers'
 import { newKitFromWeb3 } from '../kit'
 import { AttestationsWrapper } from './Attestations'
 
-testWithGanache('Attestations Wrapper', (web3) => {
+testWithAnvilL1('AttestationsWrapper', (web3) => {
   const PHONE_NUMBER = '+15555555555'
   const IDENTIFIER = getIdentifierHash(
     web3.utils.sha3,
@@ -20,7 +22,14 @@ testWithGanache('Attestations Wrapper', (web3) => {
   beforeAll(async () => {
     accounts = (await web3.eth.getAccounts()) as StrongAddress[]
     kit.defaultAccount = accounts[0]
-    attestations = await kit.contracts.getAttestations()
+
+    const attestationsContractAddress = await deployAttestationsContract(web3, accounts[0])
+
+    attestations = new AttestationsWrapper(
+      kit.connection,
+      newAttestations(web3, attestationsContractAddress),
+      newKitFromWeb3(web3).contracts
+    )
   })
 
   describe('Verification with default values', () => {

--- a/packages/sdk/contractkit/src/wrappers/BlockChainParameters.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/BlockChainParameters.test.ts
@@ -1,12 +1,11 @@
+import { newBlockchainParameters } from '@celo/abis/web3/BlockchainParameters'
 import { Connection } from '@celo/connect'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
-import BigNumber from 'bignumber.js'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { AddressRegistry } from '../address-registry'
 import { CeloContract } from '../base'
-import { newBlockchainParameters } from '@celo/abis/web3/BlockchainParameters'
 import { BlockchainParametersWrapper } from './BlockchainParameters'
 
-testWithGanache('BlockChainParametersWrapper', (web3) => {
+testWithAnvilL1('BlockChainParametersWrapper', (web3) => {
   const connection = new Connection(web3)
   let blockchainParamsWrapper: BlockchainParametersWrapper
 
@@ -50,8 +49,13 @@ testWithGanache('BlockChainParametersWrapper', (web3) => {
   describe('#getConfig', () => {
     it('returns config', async () => {
       const config = await blockchainParamsWrapper.getConfig()
-      expect(config.blockGasLimit).toEqual(new BigNumber('20000000'))
-      expect(config.intrinsicGasForAlternativeFeeCurrency).toEqual(new BigNumber('50000'))
+
+      expect(config).toMatchInlineSnapshot(`
+        {
+          "blockGasLimit": "13000000",
+          "intrinsicGasForAlternativeFeeCurrency": "50000",
+        }
+      `)
     })
   })
 

--- a/packages/sdk/contractkit/src/wrappers/GoldToken.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/GoldToken.test.ts
@@ -1,20 +1,25 @@
+import { GoldToken, newGoldToken } from '@celo/abis-12/web3/GoldToken'
 import { StrongAddress } from '@celo/base'
 import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
 import { newKitFromWeb3 } from '../kit'
 import { GoldTokenWrapper } from './GoldTokenWrapper'
 
+// TODO checking for account balance directly won't work because of missing transfer precompile
+// instead we can check for the Transfer event instead and/or lowered allowance value (they both
+// happen after the call to transfer precompile)
 testWithAnvilL1('GoldToken Wrapper', (web3) => {
   const ONE_GOLD = web3.utils.toWei('1', 'ether')
 
   const kit = newKitFromWeb3(web3)
   let accounts: StrongAddress[] = []
   let goldToken: GoldTokenWrapper
+  let goldTokenContract: GoldToken
 
   beforeAll(async () => {
     accounts = (await web3.eth.getAccounts()) as StrongAddress[]
     kit.defaultAccount = accounts[0]
     goldToken = await kit.contracts.getGoldToken()
+    goldTokenContract = newGoldToken(web3, goldToken.address)
   })
 
   it('checks balance', () => expect(goldToken.balanceOf(accounts[0])).resolves.toBeBigNumber())
@@ -31,38 +36,32 @@ testWithAnvilL1('GoldToken Wrapper', (web3) => {
     const after = await goldToken.allowance(accounts[0], accounts[1])
     expect(after).toEqBigNumber(ONE_GOLD)
   })
-})
-
-// Need to be tested with ganache because of missing transfer precompile
-testWithGanache('GoldToken Wrapper', (web3) => {
-  const ONE_GOLD = web3.utils.toWei('1', 'ether')
-
-  const kit = newKitFromWeb3(web3)
-  let accounts: StrongAddress[] = []
-  let goldToken: GoldTokenWrapper
-
-  beforeAll(async () => {
-    accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit.defaultAccount = accounts[0]
-    goldToken = await kit.contracts.getGoldToken()
-  })
 
   it('transfers', async () => {
-    const before = await goldToken.balanceOf(accounts[1])
-    const tx = await goldToken.transfer(accounts[1], ONE_GOLD).send()
-    await tx.waitReceipt()
+    await goldToken.transfer(accounts[1], ONE_GOLD).sendAndWaitForReceipt()
 
-    const after = await goldToken.balanceOf(accounts[1])
-    expect(after.minus(before)).toEqBigNumber(ONE_GOLD)
+    const events = await goldTokenContract.getPastEvents('Transfer', { fromBlock: 'latest' })
+
+    expect(events.length).toBe(1)
+    expect(events[0].returnValues.from).toEqual(accounts[0])
+    expect(events[0].returnValues.to).toEqual(accounts[1])
+    expect(events[0].returnValues.value).toEqual(ONE_GOLD)
   })
 
   it('transfers from', async () => {
-    const before = await goldToken.balanceOf(accounts[3])
     // account1 approves account0
     await goldToken.approve(accounts[0], ONE_GOLD).sendAndWaitForReceipt({ from: accounts[1] })
-    const tx = await goldToken.transferFrom(accounts[1], accounts[3], ONE_GOLD).send()
-    await tx.waitReceipt()
-    const after = await goldToken.balanceOf(accounts[3])
-    expect(after.minus(before)).toEqBigNumber(ONE_GOLD)
+
+    expect(await goldToken.allowance(accounts[1], accounts[0])).toEqBigNumber(ONE_GOLD)
+
+    await goldToken.transferFrom(accounts[1], accounts[3], ONE_GOLD).sendAndWaitForReceipt()
+
+    const events = await goldTokenContract.getPastEvents('Transfer', { fromBlock: 'latest' })
+
+    expect(events.length).toBe(1)
+    expect(events[0].returnValues.from).toEqual(accounts[1])
+    expect(events[0].returnValues.to).toEqual(accounts[3])
+    expect(events[0].returnValues.value).toEqual(ONE_GOLD)
+    expect(await goldToken.allowance(accounts[1], accounts[0])).toEqBigNumber(0)
   })
 })

--- a/packages/sdk/contractkit/src/wrappers/OdisPayments.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/OdisPayments.test.ts
@@ -1,10 +1,12 @@
 import { StableToken, StrongAddress } from '@celo/base'
-import { testWithGanache } from '@celo/dev-utils/lib/ganache-test'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
+import BigNumber from 'bignumber.js'
 import { newKitFromWeb3 } from '../kit'
+import { topUpWithToken } from '../test-utils/utils'
 import { OdisPaymentsWrapper } from './OdisPayments'
 import { StableTokenWrapper } from './StableTokenWrapper'
 
-testWithGanache('OdisPayments Wrapper', (web3) => {
+testWithAnvilL1('OdisPayments Wrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
   let accounts: StrongAddress[] = []
   let odisPayments: OdisPaymentsWrapper
@@ -15,6 +17,8 @@ testWithGanache('OdisPayments Wrapper', (web3) => {
     kit.defaultAccount = accounts[0]
     odisPayments = await kit.contracts.getOdisPayments()
     stableToken = await kit.contracts.getStableToken(StableToken.cUSD)
+
+    await topUpWithToken(kit, StableToken.cUSD, accounts[0], new BigNumber(10000))
   })
 
   describe('#payInCUSD', () => {

--- a/packages/sdk/wallets/wallet-rpc/src/rpc-wallet.test.ts
+++ b/packages/sdk/wallets/wallet-rpc/src/rpc-wallet.test.ts
@@ -83,6 +83,7 @@ describe.skip('rpc-wallet', () => {
   })
 })
 
+// It uses personal_importKey RPC call which is not supported in anvil
 testWithGanache('rpc-wallet', (web3) => {
   const provider = web3.currentProvider
   const rpcWallet = new RpcWallet(provider as Provider)


### PR DESCRIPTION
### Description

This PR migrates all remaining tests to anvil (assuming they can be migrated).

### Other changes

None.

### Tested

Ran tests locally.

### Backwards compatibility

Yes.

### Documentation

None.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating test functions to use `testWithAnvilL1` instead of `testWithGanache` and making necessary adjustments for compatibility with Anvil L1 network.

### Detailed summary
- Updated test functions to use `testWithAnvilL1` for Anvil L1 network compatibility
- Adjusted RPC calls for Anvil network compatibility
- Deployed contracts for Anvil network testing
- Updated contract deployment functions for Anvil network
- Updated contract wrapper initialization for Anvil network
- Added necessary imports and adjustments for Anvil network testing

> The following files were skipped due to too many changes: `packages/sdk/contractkit/src/kit-l2.test.ts`, `packages/cli/src/commands/network/whitelist.test.ts`, `packages/sdk/contractkit/src/wrappers/SortedOracles.test.ts`, `packages/sdk/contractkit/src/wrappers/Escrow.test.ts`, `packages/cli/src/commands/network/parameters.test.ts`, `packages/sdk/contractkit/src/wrappers/GoldToken.test.ts`, `packages/cli/src/commands/transfer/celo.test.ts`, `packages/cli/src/commands/reserve/transfergold.test.ts`, `packages/sdk/contractkit/src/wrappers/Reserve.test.ts`, `packages/sdk/contractkit/src/kit.test.ts`, `packages/cli/src/commands/network/__snapshots__/contracts.test.ts.snap`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->