### PR TITLE
fix it so that when values are printed the order of numbers is numeric

### DIFF
--- a/packages/cli/src/utils/cli.test.ts
+++ b/packages/cli/src/utils/cli.test.ts
@@ -1,0 +1,61 @@
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import { stripAnsiCodesFromNestedArray } from '../test-utils/cliUtils'
+import { printValueMapRecursive } from './cli'
+testWithAnvilL2('printValueMapRecursive', async () => {
+  it('should print the key-value pairs in the value map recursively', () => {
+    const valueMap = {
+      key1: 'value1',
+      key2: {
+        nestedKey1: 'nestedValue1',
+        nestedKey2: 'nestedValue2',
+      },
+    }
+
+    const mock = jest.fn()
+    console.log = mock
+
+    printValueMapRecursive(valueMap)
+
+    expect(stripAnsiCodesFromNestedArray(mock.mock.calls)).toMatchInlineSnapshot(``)
+  })
+
+  it('should print number keys in numeric order', () => {
+    const valueMap = {
+      1: 'jeden',
+      2: {
+        1: '1',
+        2: '2',
+        11: '3',
+        12: '4',
+        21: '5',
+      },
+      3: {
+        '0x1': 'nestedValue1',
+        jupiter: 'nestedValue2',
+        potato: 'nestedValue3',
+      },
+    }
+
+    const mock = jest.fn()
+    console.log = mock
+
+    printValueMapRecursive(valueMap)
+
+    expect(stripAnsiCodesFromNestedArray(mock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "1: jeden
+      2: 
+        1: 1
+        2: 2
+        11: 3
+        12: 4
+        21: 5
+      3: 
+        0x1: nestedValue1
+        jupiter: nestedValue2",
+        ],
+      ]
+    `)
+  })
+})

--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -116,7 +116,12 @@ function toStringValueMapRecursive(valueMap: Record<string, any>, prefix: string
     return chalk`${v}`
   }
   return Object.keys(valueMap)
-    .sort()
+    .sort((a, b) => {
+      if (isNaN(Number(a)) && isNaN(Number(b))) {
+        return a.localeCompare(b)
+      }
+      return Number(a) - Number(b)
+    })
     .map((key) => prefix + chalk.yellowBright.bold(`${key}: `) + printValue(valueMap[key]))
     .join('\n')
 }


### PR DESCRIPTION
### Description

If a list of values was printed that were keyed by numbers such as transactions to be executed in a governance proposal, they would be orderde incorrectly due to numbers being treated like strings. EG `1, 11, 12, 2,3, 4` this fixes that.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

new unit test

### Related issues



### Backwards compatibility

yep

### Documentation

n/a