### PR TITLE
Refactor network:info for L2 epochs

### DIFF
--- a/.changeset/dull-kangaroos-reply.md
+++ b/.changeset/dull-kangaroos-reply.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+Adds support for L2 epoch data for network:info command

--- a/.changeset/dull-kangaroos-reply.md
+++ b/.changeset/dull-kangaroos-reply.md
@@ -2,4 +2,4 @@
 '@celo/celocli': patch
 ---
 
-Adds support for L2 epoch data for network:info command
+Fix network:info command when in L2 

--- a/.changeset/dull-kangaroos-reply.md
+++ b/.changeset/dull-kangaroos-reply.md
@@ -1,5 +1,5 @@
 ---
-'@celo/celocli': minor
+'@celo/celocli': patch
 ---
 
 Adds support for L2 epoch data for network:info command

--- a/.changeset/twenty-fans-listen.md
+++ b/.changeset/twenty-fans-listen.md
@@ -1,0 +1,5 @@
+---
+'@celo/contractkit': minor
+---
+
+Adds support for firstKnownEpoch, getFirstBlockAtEpoch, getLastBlockAtEpoch on EpochManager wrapper

--- a/docs/command-line-interface/network.md
+++ b/docs/command-line-interface/network.md
@@ -65,18 +65,18 @@ View general network information such as the current block number
 ```
 USAGE
   $ celocli network:info [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [-n <value>]
+    0x1234567890123456789012345678901234567890] [--globalHelp] [--lastN <value>]
 
 FLAGS
-  -n, --lastN=<value>
-      [default: 1] Fetch info about the last n epochs
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
+  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
+                                                            for transaction fees
+                                                            (defaults to CELO if no gas
+                                                            currency is supplied). It
+                                                            must be a whitelisted token.
+  --globalHelp                                              View all available global
+                                                            flags
+  --lastN=<value>                                           [default: 1] Fetch info
+                                                            about the last n epochs
 
 DESCRIPTION
   View general network information such as the current block number

--- a/docs/sdk/contractkit/classes/wrappers_EpochManager.EpochManagerWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_EpochManager.EpochManagerWrapper.md
@@ -24,9 +24,12 @@ Contract handling epoch management.
 - [eventTypes](wrappers_EpochManager.EpochManagerWrapper.md#eventtypes)
 - [events](wrappers_EpochManager.EpochManagerWrapper.md#events)
 - [finishNextEpochProcess](wrappers_EpochManager.EpochManagerWrapper.md#finishnextepochprocess)
+- [firstKnownEpoch](wrappers_EpochManager.EpochManagerWrapper.md#firstknownepoch)
 - [getCurrentEpochNumber](wrappers_EpochManager.EpochManagerWrapper.md#getcurrentepochnumber)
 - [getElected](wrappers_EpochManager.EpochManagerWrapper.md#getelected)
 - [getEpochProcessingStatus](wrappers_EpochManager.EpochManagerWrapper.md#getepochprocessingstatus)
+- [getFirstBlockAtEpoch](wrappers_EpochManager.EpochManagerWrapper.md#getfirstblockatepoch)
+- [getLastBlockAtEpoch](wrappers_EpochManager.EpochManagerWrapper.md#getlastblockatepoch)
 - [isOnEpochProcess](wrappers_EpochManager.EpochManagerWrapper.md#isonepochprocess)
 - [isTimeForNextEpoch](wrappers_EpochManager.EpochManagerWrapper.md#istimefornextepoch)
 - [methodIds](wrappers_EpochManager.EpochManagerWrapper.md#methodids)
@@ -157,7 +160,31 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:54](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L54)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:61](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L61)
+
+___
+
+### firstKnownEpoch
+
+• **firstKnownEpoch**: (...`args`: []) => `Promise`\<`number`\>
+
+#### Type declaration
+
+▸ (`...args`): `Promise`\<`number`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [] |
+
+##### Returns
+
+`Promise`\<`number`\>
+
+#### Defined in
+
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:31](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L31)
 
 ___
 
@@ -181,7 +208,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:31](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L31)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:32](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L32)
 
 ___
 
@@ -205,7 +232,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:38](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L38)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:45](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L45)
 
 ___
 
@@ -229,7 +256,55 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:39](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L39)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:46](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L46)
+
+___
+
+### getFirstBlockAtEpoch
+
+• **getFirstBlockAtEpoch**: (...`args`: [epoch: string \| number]) => `Promise`\<`number`\>
+
+#### Type declaration
+
+▸ (`...args`): `Promise`\<`number`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [epoch: string \| number] |
+
+##### Returns
+
+`Promise`\<`number`\>
+
+#### Defined in
+
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:37](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L37)
+
+___
+
+### getLastBlockAtEpoch
+
+• **getLastBlockAtEpoch**: (...`args`: [epoch: string \| number]) => `Promise`\<`number`\>
+
+#### Type declaration
+
+▸ (`...args`): `Promise`\<`number`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [epoch: string \| number] |
+
+##### Returns
+
+`Promise`\<`number`\>
+
+#### Defined in
+
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:42](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L42)
 
 ___
 
@@ -253,7 +328,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:36](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L36)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:43](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L43)
 
 ___
 
@@ -277,7 +352,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:37](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L37)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:44](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L44)
 
 ___
 
@@ -315,7 +390,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:53](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L53)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:60](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L60)
 
 ## Accessors
 
@@ -349,7 +424,7 @@ BaseWrapperForGoverning.address
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:56](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L56)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:63](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L63)
 
 ___
 
@@ -363,7 +438,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:118](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L118)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:125](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L125)
 
 ___
 
@@ -383,7 +458,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:69](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L69)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:76](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L76)
 
 ___
 

--- a/docs/sdk/contractkit/modules/test_utils_utils.md
+++ b/docs/sdk/contractkit/modules/test_utils_utils.md
@@ -8,6 +8,7 @@
 
 - [currentEpochNumber](test_utils_utils.md#currentepochnumber)
 - [mineToNextEpoch](test_utils_utils.md#minetonextepoch)
+- [startAndFinishEpochProcess](test_utils_utils.md#startandfinishepochprocess)
 - [topUpWithToken](test_utils_utils.md#topupwithtoken)
 
 ## Functions
@@ -54,6 +55,26 @@ ___
 
 ___
 
+### startAndFinishEpochProcess
+
+▸ **startAndFinishEpochProcess**(`kit`): `Promise`\<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `kit` | [`ContractKit`](../classes/kit.ContractKit.md) |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[packages/sdk/contractkit/src/test-utils/utils.ts:43](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/test-utils/utils.ts#L43)
+
+___
+
 ### topUpWithToken
 
 ▸ **topUpWithToken**(`kit`, `stableToken`, `recipientAddress`, `amount`): `Promise`\<`void`\>
@@ -73,4 +94,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/test-utils/utils.ts:43](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/test-utils/utils.ts#L43)
+[packages/sdk/contractkit/src/test-utils/utils.ts:58](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/test-utils/utils.ts#L58)

--- a/docs/sdk/contractkit/modules/wrappers_EpochManager.md
+++ b/docs/sdk/contractkit/modules/wrappers_EpochManager.md
@@ -29,4 +29,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:131](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L131)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:138](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L138)

--- a/packages/cli/src/commands/network/info-l2.test.ts
+++ b/packages/cli/src/commands/network/info-l2.test.ts
@@ -1,16 +1,95 @@
+import { newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import { timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import EpochsSwitch from '../epochs/switch'
 import Info from './info'
 process.env.NO_SYNCCHECK = 'true'
 
 testWithAnvilL2('network:info', (web3) => {
-  test('runs', async () => {
+  beforeAll(async () => {
+    const kit = newKitFromWeb3(web3)
+    const epochManager = await kit.contracts.getEpochManager()
+    const epochDuration = await epochManager.epochDuration()
+    const accounts = await web3.eth.getAccounts()
+
+    // Switch epochs 3 times
+    for (let i = 0; i < 3; i++) {
+      await timeTravel(epochDuration + 1, web3)
+      await testLocallyWithWeb3Node(EpochsSwitch, ['--from', accounts[0]], web3)
+    }
+  })
+
+  it('runs for latest epoch', async () => {
     const spy = jest.spyOn(console, 'log')
     await testLocallyWithWeb3Node(Info, [], web3)
+
     expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
       [
         [
-          "blockNumber: 350",
+          "blockNumber: 359
+      epochs: 
+        number: 7
+        start: 359
+      epochSize: 86400",
+        ],
+      ]
+    `)
+  })
+
+  it('runs for last 3 epochs', async () => {
+    const spy = jest.spyOn(console, 'log')
+
+    await testLocallyWithWeb3Node(Info, ['--lastN', '3'], web3)
+
+    expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "blockNumber: 359
+      epochs:
+        0:
+          number: 7
+          start: 359
+        1:
+          end: 358
+          number: 6
+          start: 356
+        2:
+          end: 355
+          number: 5
+          start: 353
+      epochSize: 86400",
+        ],
+      ]
+    `)
+  })
+
+  it('runs for last 100 epochs, but displays only epoch that exist', async () => {
+    const spy = jest.spyOn(console, 'log')
+
+    await testLocallyWithWeb3Node(Info, ['--lastN', '100'], web3)
+
+    expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "blockNumber: 359
+      epochs: 
+        0: 
+          number: 7
+          start: 359
+        1: 
+          end: 358
+          number: 6
+          start: 356
+        2: 
+          end: 355
+          number: 5
+          start: 353
+        3: 
+          end: 352
+          number: 4
+          start: 300
+      epochSize: 86400",
         ],
       ]
     `)

--- a/packages/cli/src/commands/network/info-l2.test.ts
+++ b/packages/cli/src/commands/network/info-l2.test.ts
@@ -15,7 +15,7 @@ testWithAnvilL2('network:info', (web3) => {
 
     // Switch epochs 3 times
     for (let i = 0; i < 3; i++) {
-      await timeTravel(epochDuration + 1, web3)
+      await timeTravel(epochDuration * 2, web3)
       await testLocallyWithWeb3Node(EpochsSwitch, ['--from', accounts[0]], web3)
     }
   })
@@ -28,10 +28,10 @@ testWithAnvilL2('network:info', (web3) => {
       [
         [
           "blockNumber: 359
+      epochDuration: 86400
       epochs: 
         number: 7
-        start: 359
-      epochSize: 86400",
+        start: 359",
         ],
       ]
     `)
@@ -39,26 +39,25 @@ testWithAnvilL2('network:info', (web3) => {
 
   it('runs for last 3 epochs', async () => {
     const spy = jest.spyOn(console, 'log')
-
     await testLocallyWithWeb3Node(Info, ['--lastN', '3'], web3)
 
     expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
       [
         [
           "blockNumber: 359
-      epochs:
-        0:
+      epochDuration: 86400
+      epochs: 
+        0: 
           number: 7
           start: 359
-        1:
+        1: 
           end: 358
           number: 6
           start: 356
-        2:
+        2: 
           end: 355
           number: 5
-          start: 353
-      epochSize: 86400",
+          start: 353",
         ],
       ]
     `)
@@ -66,13 +65,13 @@ testWithAnvilL2('network:info', (web3) => {
 
   it('runs for last 100 epochs, but displays only epoch that exist', async () => {
     const spy = jest.spyOn(console, 'log')
-
     await testLocallyWithWeb3Node(Info, ['--lastN', '100'], web3)
 
     expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
       [
         [
           "blockNumber: 359
+      epochDuration: 86400
       epochs: 
         0: 
           number: 7
@@ -88,8 +87,7 @@ testWithAnvilL2('network:info', (web3) => {
         3: 
           end: 352
           number: 4
-          start: 300
-      epochSize: 86400",
+          start: 300",
         ],
       ]
     `)

--- a/packages/cli/src/commands/network/info.test.ts
+++ b/packages/cli/src/commands/network/info.test.ts
@@ -1,0 +1,84 @@
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import Info from './info'
+process.env.NO_SYNCCHECK = 'true'
+
+testWithAnvilL1('network:info', (web3) => {
+  it('runs for latest epoch', async () => {
+    const spy = jest.spyOn(console, 'log')
+    await testLocallyWithWeb3Node(Info, [], web3)
+
+    expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "blockNumber: 349
+      epochs: 
+        end: 400
+        number: 4
+        start: 301
+      epochSize: 100",
+        ],
+      ]
+    `)
+  })
+
+  it('runs for last 3 epochs', async () => {
+    const spy = jest.spyOn(console, 'log')
+
+    await testLocallyWithWeb3Node(Info, ['--lastN', '3'], web3)
+
+    expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "blockNumber: 349
+      epochs: 
+        0: 
+          end: 400
+          number: 4
+          start: 301
+        1: 
+          end: 300
+          number: 3
+          start: 201
+        2: 
+          end: 200
+          number: 2
+          start: 101
+      epochSize: 100",
+        ],
+      ]
+    `)
+  })
+
+  it('runs for last 100 epochs, but displays only epoch that exist', async () => {
+    const spy = jest.spyOn(console, 'log')
+
+    await testLocallyWithWeb3Node(Info, ['--lastN', '100'], web3)
+
+    expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "blockNumber: 349
+      epochs: 
+        0: 
+          end: 400
+          number: 4
+          start: 301
+        1: 
+          end: 300
+          number: 3
+          start: 201
+        2: 
+          end: 200
+          number: 2
+          start: 101
+        3: 
+          end: 100
+          number: 1
+          start: 1
+      epochSize: 100",
+        ],
+      ]
+    `)
+  })
+})

--- a/packages/cli/src/commands/network/info.ts
+++ b/packages/cli/src/commands/network/info.ts
@@ -68,8 +68,9 @@ export default class Info extends BaseCommand {
 
     printValueMapRecursive({
       blockNumber,
-      epochSize,
       epochs: epochs.length === 1 ? epochs[0] : epochs,
+      ...(isL2 && { epochDuration: epochSize }),
+      ...(!isL2 && { epochSize }),
     })
   }
 }

--- a/packages/cli/src/commands/network/info.ts
+++ b/packages/cli/src/commands/network/info.ts
@@ -1,5 +1,5 @@
 import { isCel2 } from '@celo/connect'
-import { Flags, ux } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { BaseCommand } from '../../base'
 import { printValueMapRecursive } from '../../utils/cli'
 
@@ -9,7 +9,7 @@ export default class Info extends BaseCommand {
   static flags = {
     ...BaseCommand.flags,
     lastN: Flags.integer({
-      char: 'n',
+      // We cannot use char: 'n' here because it conflicts with the node flag
       description: 'Fetch info about the last n epochs',
       required: false,
       default: 1,
@@ -20,29 +20,49 @@ export default class Info extends BaseCommand {
     const kit = await this.getKit()
     const res = await this.parse(Info)
     const isL2 = await isCel2(kit.connection.web3)
+    let latestEpochNumber: number
+    let epochSize: number
 
     const blockNumber = await kit.connection.getBlockNumber()
 
     if (isL2) {
-      ux.info('Celo no longer has epochs')
-      printValueMapRecursive({
-        blockNumber,
-      })
-      return
+      const epochManagerWrapper = await kit.contracts.getEpochManager()
+
+      latestEpochNumber = await epochManagerWrapper.getCurrentEpochNumber()
+      epochSize = await epochManagerWrapper.epochDuration()
+    } else {
+      latestEpochNumber = await kit.getEpochNumberOfBlock(blockNumber)
+      epochSize = await kit.getEpochSize()
     }
 
-    const latestEpochNumber = await kit.getEpochNumberOfBlock(blockNumber)
-    const epochSize = await kit.getEpochSize()
+    const fetchEpochInfo = async (epochNumber: number) => {
+      if (isL2) {
+        const epochManagerWrapper = await kit.contracts.getEpochManager()
 
-    const fetchEpochInfo = async (epochNumber: number) => ({
-      number: epochNumber,
-      start: await kit.getFirstBlockNumberForEpoch(epochNumber),
-      end: await kit.getLastBlockNumberForEpoch(epochNumber),
-    })
+        const epochData: Record<string, number> = {
+          number: epochNumber,
+          start: await epochManagerWrapper.getFirstBlockAtEpoch(epochNumber),
+        }
+
+        // for L2 we cannot fetch the end block of the current epoch
+        if (epochNumber < latestEpochNumber) {
+          epochData.end = await epochManagerWrapper.getLastBlockAtEpoch(epochNumber)
+        }
+
+        return epochData
+      }
+
+      return {
+        number: epochNumber,
+        start: await kit.getFirstBlockNumberForEpoch(epochNumber),
+        end: await kit.getLastBlockNumberForEpoch(epochNumber),
+      }
+    }
 
     const n = res.flags.lastN
+    const minEpoch = isL2 ? await (await kit.contracts.getEpochManager()).firstKnownEpoch() : 1
     const epochs = []
-    for (let i = latestEpochNumber; i > latestEpochNumber - n; i--) {
+    for (let i = latestEpochNumber; i > latestEpochNumber - n && i >= minEpoch; i--) {
       epochs.push(await fetchEpochInfo(i))
     }
 

--- a/packages/sdk/contractkit/src/test-utils/utils.ts
+++ b/packages/sdk/contractkit/src/test-utils/utils.ts
@@ -40,6 +40,21 @@ export const mineToNextEpoch = async (web3: Web3, epochSize: number = GANACHE_EP
   await mineBlocks(blocksUntilNextEpoch, web3)
 }
 
+export const startAndFinishEpochProcess = async (kit: ContractKit) => {
+  const accounts = await kit.web3.eth.getAccounts()
+  const epochManagerWrapper = await kit.contracts.getEpochManager()
+
+  await epochManagerWrapper.startNextEpochProcess().sendAndWaitForReceipt({
+    from: accounts[0],
+  })
+
+  await (
+    await epochManagerWrapper.finishNextEpochProcessTx()
+  ).sendAndWaitForReceipt({
+    from: accounts[0],
+  })
+}
+
 export const topUpWithToken = async (
   kit: ContractKit,
   stableToken: StableToken,

--- a/packages/sdk/contractkit/src/wrappers/EpochManager.ts
+++ b/packages/sdk/contractkit/src/wrappers/EpochManager.ts
@@ -28,11 +28,18 @@ export interface EpochManagerConfig {
  */
 export class EpochManagerWrapper extends BaseWrapperForGoverning<EpochManager> {
   epochDuration = proxyCall(this.contract.methods.epochDuration, undefined, valueToInt)
+  firstKnownEpoch = proxyCall(this.contract.methods.firstKnownEpoch, undefined, valueToInt)
   getCurrentEpochNumber = proxyCall(
     this.contract.methods.getCurrentEpochNumber,
     undefined,
     valueToInt
   )
+  getFirstBlockAtEpoch = proxyCall(
+    this.contract.methods.getFirstBlockAtEpoch,
+    undefined,
+    valueToInt
+  )
+  getLastBlockAtEpoch = proxyCall(this.contract.methods.getLastBlockAtEpoch, undefined, valueToInt)
   isOnEpochProcess = proxyCall(this.contract.methods.isOnEpochProcess)
   isTimeForNextEpoch = proxyCall(this.contract.methods.isTimeForNextEpoch)
   getElected = proxyCall(this.contract.methods.getElected)


### PR DESCRIPTION
### Description

Refactors celocli `network:info` command to include L2 epoch data.

### Other changes

Added needed proxy calls to `EpochManager` wrapper.

### Tested

Ran tests locally. Ran command against devchain and alfajores/mainnet with different params.

### Related issues

- Fixes https://github.com/celo-org/developer-tooling/issues/347

### Backwards compatibility

Backwards compatible.

### Documentation

None.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `EpochManagerWrapper` in the `@celo/contractkit` by adding new functionalities for epoch handling and improving the `network:info` command in the CLI.

### Detailed summary
- Fixed `network:info` command for L2.
- Added `firstKnownEpoch`, `getFirstBlockAtEpoch`, and `getLastBlockAtEpoch` methods in `EpochManagerWrapper`.
- Implemented `startAndFinishEpochProcess` utility function for epoch management.
- Updated documentation for new methods and CLI flags. 
- Enhanced tests for epoch functionalities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->