### PR TITLE
chore: enter beta

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,31 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@celo/celocli": "5.2.1",
+    "@celo/dev-utils": "0.0.5",
+    "@celo/base": "6.1.0",
+    "@celo/connect": "6.0.2",
+    "@celo/contractkit": "8.3.0",
+    "@celo/cryptographic-utils": "5.1.0",
+    "@celo/explorer": "5.0.12",
+    "@celo/governance": "5.1.3",
+    "@celo/keystores": "5.0.11",
+    "@celo/metadata-claims": "0.0.1",
+    "@celo/network-utils": "5.0.6",
+    "@celo/phone-utils": "6.0.3",
+    "@celo/transactions-uri": "5.0.11",
+    "@celo/utils": "7.0.0",
+    "@celo/wallet-base": "6.0.1",
+    "@celo/wallet-hsm": "6.0.1",
+    "@celo/wallet-hsm-aws": "6.0.1",
+    "@celo/wallet-hsm-azure": "6.0.1",
+    "@celo/wallet-hsm-gcp": "6.0.1",
+    "@celo/wallet-ledger": "6.0.1",
+    "@celo/wallet-local": "6.0.1",
+    "@celo/wallet-remote": "6.0.1",
+    "@celo/typescript": "0.0.1",
+    "@celo/viem-account-ledger": "0.0.1"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
Enter beta mode

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new configuration file, `.changeset/pre.json`, which defines the pre-release mode and specifies version information for various `@celo` packages.

### Detailed summary
- Added `.changeset/pre.json` file.
- Set `mode` to `"pre"` and `tag` to `"beta"`.
- Defined `initialVersions` for multiple `@celo` packages with specified version numbers.
- Included an empty `changesets` array.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->