### PR TITLE
Derivation Warnings

### DIFF
--- a/.changeset/fifty-roses-explain.md
+++ b/.changeset/fifty-roses-explain.md
@@ -1,0 +1,6 @@
+---
+'@celo/cryptographic-utils': patch
+'@celo/celocli': patch
+---
+
+Add warning that ETH derivation path will be the default in a future major breaking change.

--- a/.changeset/polite-pets-push.md
+++ b/.changeset/polite-pets-push.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Fix: account:new can now be called without a node

--- a/docs/command-line-interface/account.md
+++ b/docs/command-line-interface/account.md
@@ -642,6 +642,9 @@ DESCRIPTION
   command has been tested swapping mnemonics with the Ledger successfully (only supports
   english)
 
+  WARN: In 7.0 the default derivation path will be Eth ("m/44'/60'/0'")
+  forum.celo.org/t/deprecating-the-celo-derivation-path/9229
+
 EXAMPLES
   new
 

--- a/docs/sdk/cryptographic-utils/modules/account.md
+++ b/docs/sdk/cryptographic-utils/modules/account.md
@@ -86,7 +86,7 @@ base/lib/account.d.ts:18
 
 #### Defined in
 
-[cryptographic-utils/src/account.ts:455](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/cryptographic-utils/src/account.ts#L455)
+[cryptographic-utils/src/account.ts:468](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/cryptographic-utils/src/account.ts#L468)
 
 ___
 
@@ -179,7 +179,7 @@ ___
 
 #### Defined in
 
-[cryptographic-utils/src/account.ts:403](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/cryptographic-utils/src/account.ts#L403)
+[cryptographic-utils/src/account.ts:410](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/cryptographic-utils/src/account.ts#L410)
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 #### Defined in
 
-[cryptographic-utils/src/account.ts:390](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/cryptographic-utils/src/account.ts#L390)
+[cryptographic-utils/src/account.ts:397](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/cryptographic-utils/src/account.ts#L397)
 
 ___
 
@@ -233,7 +233,7 @@ ___
 
 #### Defined in
 
-[cryptographic-utils/src/account.ts:431](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/cryptographic-utils/src/account.ts#L431)
+[cryptographic-utils/src/account.ts:444](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/cryptographic-utils/src/account.ts#L444)
 
 ___
 
@@ -278,7 +278,7 @@ ___
 
 #### Defined in
 
-[cryptographic-utils/src/account.ts:416](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/cryptographic-utils/src/account.ts#L416)
+[cryptographic-utils/src/account.ts:423](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/cryptographic-utils/src/account.ts#L423)
 
 ___
 

--- a/packages/cli/src/commands/account/new.test.ts
+++ b/packages/cli/src/commands/account/new.test.ts
@@ -1,0 +1,20 @@
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import { ux } from '@oclif/core'
+import Web3 from 'web3'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import NewAccount from './new'
+
+process.env.NO_SYNCCHECK = 'true'
+
+testWithAnvilL2('account:set-name cmd', (web3: Web3) => {
+  const writeMock = jest.spyOn(ux, 'info')
+
+  beforeEach(() => {
+    writeMock.mockClear()
+  })
+  it('generates mneumonic when called with no flags', async () => {
+    await testLocallyWithWeb3Node(NewAccount, [], web3)
+
+    expect(writeMock.mock.calls).toMatchInlineSnapshot()
+  })
+})

--- a/packages/cli/src/commands/account/new.test.ts
+++ b/packages/cli/src/commands/account/new.test.ts
@@ -19,7 +19,7 @@ testWithAnvilL2('account:set-name cmd', (web3: Web3) => {
     writeMock.mockClear()
     consoleMock.mockClear()
   })
-  it('generates mneumonic and lets people know which derivation path is being used when called with no flags', async () => {
+  it('generates mnemonic and lets people know which derivation path is being used when called with no flags', async () => {
     await testLocallyWithWeb3Node(NewAccount, [], web3)
 
     expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
@@ -46,7 +46,7 @@ testWithAnvilL2('account:set-name cmd', (web3: Web3) => {
       address: ADDRESS"
     `)
   })
-  it("when called with --derivationPath eth flag generates mneumonic using m/44'/60'/0'", async () => {
+  it("when called with --derivationPath eth flag generates mnemonic using m/44'/60'/0'", async () => {
     await testLocallyWithWeb3Node(NewAccount, ['--derivationPath', 'eth'], web3)
 
     expect(deRandomize(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
@@ -60,20 +60,20 @@ testWithAnvilL2('account:set-name cmd', (web3: Web3) => {
   })
 
   describe('when called with --mnemonicPath', () => {
-    const MNEUMONIC_PATH = path.join(__dirname, 'public_mneumonic')
-    const TEST_MNEUMONIC =
+    const MNEMONIC_PATH = path.join(__dirname, 'public_mnemonic')
+    const TEST_mnemonic =
       'hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue'
     beforeEach(() => {
-      fs.writeFileSync(MNEUMONIC_PATH, TEST_MNEUMONIC, {
+      fs.writeFileSync(MNEMONIC_PATH, TEST_mnemonic, {
         flag: 'w',
       })
     })
     afterEach(async () => {
-      fs.rmSync(MNEUMONIC_PATH)
+      fs.rmSync(MNEMONIC_PATH)
     })
 
     it('generates using celo derivation path', async () => {
-      await testLocallyWithWeb3Node(NewAccount, [`--mnemonicPath`, MNEUMONIC_PATH], web3)
+      await testLocallyWithWeb3Node(NewAccount, [`--mnemonicPath`, MNEMONIC_PATH], web3)
 
       expect(stripAnsiCodesAndTxHashes(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
         "mnemonic: hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue
@@ -88,7 +88,7 @@ testWithAnvilL2('account:set-name cmd', (web3: Web3) => {
     it("and --derivationPath m/44'/60'/0' generates using eth derivation path", async () => {
       await testLocallyWithWeb3Node(
         NewAccount,
-        [`--mnemonicPath`, MNEUMONIC_PATH, '--derivationPath', "m/44'/60'/0'"],
+        [`--mnemonicPath`, MNEMONIC_PATH, '--derivationPath', "m/44'/60'/0'"],
         web3
       )
 
@@ -104,7 +104,7 @@ testWithAnvilL2('account:set-name cmd', (web3: Web3) => {
     it("and --derivationPath m/44'/60'/0' and --changeIndex generates using eth derivation path", async () => {
       await testLocallyWithWeb3Node(
         NewAccount,
-        [`--mnemonicPath`, MNEUMONIC_PATH, '--derivationPath', 'eth', '--changeIndex', '2'],
+        [`--mnemonicPath`, MNEMONIC_PATH, '--derivationPath', 'eth', '--changeIndex', '2'],
         web3
       )
 
@@ -120,7 +120,7 @@ testWithAnvilL2('account:set-name cmd', (web3: Web3) => {
     it('and --derivationPath eth and --addressIndex generates using eth derivation path', async () => {
       await testLocallyWithWeb3Node(
         NewAccount,
-        [`--mnemonicPath`, MNEUMONIC_PATH, '--derivationPath', 'eth', '--addressIndex', '3'],
+        [`--mnemonicPath`, MNEMONIC_PATH, '--derivationPath', 'eth', '--addressIndex', '3'],
         web3
       )
 

--- a/packages/cli/src/commands/account/new.test.ts
+++ b/packages/cli/src/commands/account/new.test.ts
@@ -1,20 +1,145 @@
 import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
-import { ux } from '@oclif/core'
+import fs from 'node:fs'
+import path from 'node:path'
 import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import {
+  stripAnsiCodesAndTxHashes,
+  stripAnsiCodesFromNestedArray,
+  testLocallyWithWeb3Node,
+} from '../../test-utils/cliUtils'
 import NewAccount from './new'
 
 process.env.NO_SYNCCHECK = 'true'
 
 testWithAnvilL2('account:set-name cmd', (web3: Web3) => {
-  const writeMock = jest.spyOn(ux, 'info')
+  const writeMock = jest.spyOn(NewAccount.prototype, 'log')
+  const consoleMock = jest.spyOn(console, 'log')
 
   beforeEach(() => {
     writeMock.mockClear()
+    consoleMock.mockClear()
   })
-  it('generates mneumonic when called with no flags', async () => {
+  it('generates mneumonic and lets people know which derivation path is being used when called with no flags', async () => {
     await testLocallyWithWeb3Node(NewAccount, [], web3)
 
-    expect(writeMock.mock.calls).toMatchInlineSnapshot()
+    expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "
+      Using celo-legacy path (m/44'/52752'/0') for derivation. This will be switched to eth derivation path (m/44'/60'/0') next major version.
+      ",
+        ],
+        [
+          "
+      This is not being stored anywhere. Save the mnemonic somewhere to use this account at a later point.
+      ",
+        ],
+      ]
+    `)
+
+    expect(deRandomize(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
+      "mnemonic: *** *** 
+      derivationPath: m/44'/52752'/0'
+      accountAddress: ADDRESS
+      privateKey: PUBLIC_KEY
+      publicKey: PRIVATE_KEY
+      address: ADDRESS"
+    `)
+  })
+  it("when called with --derivationPath eth flag generates mneumonic using m/44'/60'/0'", async () => {
+    await testLocallyWithWeb3Node(NewAccount, ['--derivationPath', 'eth'], web3)
+
+    expect(deRandomize(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
+      "mnemonic: *** *** 
+      derivationPath: m/44'/60'/0'
+      accountAddress: ADDRESS
+      privateKey: PUBLIC_KEY
+      publicKey: PRIVATE_KEY
+      address: ADDRESS"
+    `)
+  })
+
+  describe('when called with --mnemonicPath', () => {
+    const MNEUMONIC_PATH = path.join(__dirname, 'public_mneumonic')
+    const TEST_MNEUMONIC =
+      'hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue'
+    beforeEach(() => {
+      fs.writeFileSync(MNEUMONIC_PATH, TEST_MNEUMONIC, {
+        flag: 'w',
+      })
+    })
+    afterEach(async () => {
+      fs.rmSync(MNEUMONIC_PATH)
+    })
+
+    it('generates using celo derivation path', async () => {
+      await testLocallyWithWeb3Node(NewAccount, [`--mnemonicPath`, MNEUMONIC_PATH], web3)
+
+      expect(stripAnsiCodesAndTxHashes(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
+        "mnemonic: hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue
+        derivationPath: m/44'/52752'/0'
+        accountAddress: 0x0a85BeCD036C86faD4Db5519634904be2021fb7d
+        privateKey: 6346d0cd7cfdb7904f08df48e442169d3333643de0351682f8b79cf714395471
+        publicKey: 02269b3efc9c4c6b81037d06e73e936078e625fb0f12b9ea1e0fd14d2cd45775f2
+        address: 0x0a85BeCD036C86faD4Db5519634904be2021fb7d"
+      `)
+    })
+
+    it("and --derivationPath m/44'/60'/0' generates using eth derivation path", async () => {
+      await testLocallyWithWeb3Node(
+        NewAccount,
+        [`--mnemonicPath`, MNEUMONIC_PATH, '--derivationPath', "m/44'/60'/0'"],
+        web3
+      )
+
+      expect(stripAnsiCodesAndTxHashes(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
+        "mnemonic: hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue
+        derivationPath: m/44'/60'/0'
+        accountAddress: 0x35A4d54B541fc7b2047fb5357cC706191E105cd3
+        privateKey: e4816cbb93346760921264ea38a7fc54903f4dd688ae0923fefd89a43c5f58cc
+        publicKey: 034b3036d657a6dc2f322db52cca29ae72101a9cf56de4765d17b0507ea1e87b7c
+        address: 0x35A4d54B541fc7b2047fb5357cC706191E105cd3"
+      `)
+    })
+    it("and --derivationPath m/44'/60'/0' and --changeIndex generates using eth derivation path", async () => {
+      await testLocallyWithWeb3Node(
+        NewAccount,
+        [`--mnemonicPath`, MNEUMONIC_PATH, '--derivationPath', 'eth', '--changeIndex', '2'],
+        web3
+      )
+
+      expect(stripAnsiCodesAndTxHashes(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
+        "mnemonic: hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue
+        derivationPath: m/44'/60'/0'
+        accountAddress: 0xb3492799c55141e0B3507302F241f1c34c08E1e2
+        privateKey: 3abc861ef3e9e31a6a7dc23e5903e41b3fe4a381d4fbb8f9db14e6730abd1c43
+        publicKey: 0280df4d09cf8ebcad418327287be3f4ba0054112544ffa290ab3cc0a87949b32a
+        address: 0xb3492799c55141e0B3507302F241f1c34c08E1e2"
+      `)
+    })
+    it('and --derivationPath eth and --addressIndex generates using eth derivation path', async () => {
+      await testLocallyWithWeb3Node(
+        NewAccount,
+        [`--mnemonicPath`, MNEUMONIC_PATH, '--derivationPath', 'eth', '--addressIndex', '3'],
+        web3
+      )
+
+      expect(stripAnsiCodesAndTxHashes(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
+        "mnemonic: hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue
+        derivationPath: m/44'/60'/0'
+        accountAddress: 0x336E523118B6091e033F9715257e2E793002964c
+        privateKey: aa324b2efd0ebe6387c3bcf03387c78047d82a1d2e8b4e132e9e1b9fb93529d0
+        publicKey: 0394cc7cc524079c545aef2067c9ea7e69decb4815004afecf215ea1e6f370ce6c
+        address: 0x336E523118B6091e033F9715257e2E793002964c"
+      `)
+    })
   })
 })
+
+function deRandomize(rawOutput: string) {
+  return stripAnsiCodesAndTxHashes(rawOutput)
+    .replace(/0x[A-Fa-f0-9]{40}/g, 'ADDRESS')
+    .replace(/ [A-Fa-f0-9]{66}/g, ' PRIVATE_KEY')
+    .replace(/ [A-Fa-f0-9]{64}/g, ' PUBLIC_KEY')
+    .replace(/mnemonic: ([a-z]+\s)+/, 'mnemonic: *** *** \n')
+}

--- a/packages/cli/src/commands/account/new.ts
+++ b/packages/cli/src/commands/account/new.ts
@@ -86,7 +86,7 @@ export default class NewAccount extends BaseCommand {
     if (derivationPath) {
       derivationPath = derivationPath.endsWith('/') ? derivationPath.slice(0, -1) : derivationPath
     }
-    return derivationPath !== 'eth' ? derivationPath : ETHEREUM_DERIVATION_PATH
+    return derivationPath === 'eth' ? ETHEREUM_DERIVATION_PATH : derivationPath
   }
 
   static readFile(file?: string): string | undefined {

--- a/packages/cli/src/commands/account/new.ts
+++ b/packages/cli/src/commands/account/new.ts
@@ -17,7 +17,8 @@ const ETHEREUM_DERIVATION_PATH = "m/44'/60'/0'"
 
 export default class NewAccount extends BaseCommand {
   static description =
-    "Creates a new account locally using the Celo Derivation Path (m/44'/52752'/0/changeIndex/addressIndex) and print out the key information. Save this information for local transaction signing or import into a Celo node. Ledger: this command has been tested swapping mnemonics with the Ledger successfully (only supports english)"
+    "Creates a new account locally using the Celo Derivation Path (m/44'/52752'/0/changeIndex/addressIndex) and print out the key information. Save this information for local transaction signing or import into a Celo node. Ledger: this command has been tested swapping mnemonics with the Ledger successfully (only supports english)" +
+    "\n\nWARN: In 7.0 the default derivation path will be Eth (\"m/44'/60'/0'\") forum.celo.org/t/deprecating-the-celo-derivation-path/9229"
 
   static flags = {
     ...BaseCommand.flags,

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -35,7 +35,7 @@ for detail info see [#9127](https://github.com/celo-org/celo-monorepo/pull/9127)
 
   - Removes phone and country related functions from utils. Now in [phone-utils](https://github.com/celo-org/celo-monorepo/pull/8987)
 
-  - comment encryption, bls and mneumonic functions moved to @celo/cryptographic-utils
+  - comment encryption, bls and mnemonic functions moved to @celo/cryptographic-utils
 
 
 Features

--- a/packages/sdk/cryptographic-utils/src/account.ts
+++ b/packages/sdk/cryptographic-utils/src/account.ts
@@ -387,7 +387,7 @@ function wordSuggestions(typo: string, language: MnemonicLanguages): Suggestions
     }, new Map<number, string[]>())
 }
 /*
- * @param mneumonic 12 or 12 BIP39 words
+ * @param mnemonic 12 or 12 BIP39 words
  * @param password
  * @param changeIndex postion 4 from https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
  * @param addressIndex postion 5 from https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
@@ -436,7 +436,7 @@ export async function generateSeed(
 }
 
 /*
- * @param seed - Buffer created from mneumonic
+ * @param seed - Buffer created from mnemonic
  * @param changeIndex postion 4 from https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
  * @param addressIndex postion 5 from https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
  * @param derivationPath - This will default to ETH_DERIVATION_PATH in 7.0 forum.celo.org/t/deprecating-the-celo-derivation-path/9229

--- a/packages/sdk/cryptographic-utils/src/account.ts
+++ b/packages/sdk/cryptographic-utils/src/account.ts
@@ -68,7 +68,7 @@ export async function generateMnemonic(
 
 export function validateMnemonic(
   mnemonic: string,
-  bip39ToUse = bip39Wrapper,
+  bip39ToUse: Bip39 = bip39Wrapper,
   language?: MnemonicLanguages
 ) {
   if (language !== undefined) {
@@ -386,13 +386,20 @@ function wordSuggestions(typo: string, language: MnemonicLanguages): Suggestions
       return map
     }, new Map<number, string[]>())
 }
-
+/*
+ * @param mneumonic 12 or 12 BIP39 words
+ * @param password
+ * @param changeIndex postion 4 from https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+ * @param addressIndex postion 5 from https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+ * bip39ToUse - bip39 library
+ * @param derivationPath - This will default to ETH_DERIVATION_PATH in 7.0 forum.celo.org/t/deprecating-the-celo-derivation-path/9229
+ */
 export async function generateKeys(
   mnemonic: string,
   password?: string,
   changeIndex: number = 0,
   addressIndex: number = 0,
-  bip39ToUse = bip39Wrapper,
+  bip39ToUse: Bip39 = bip39Wrapper,
   derivationPath: string = CELO_DERIVATION_PATH_BASE
 ): Promise<{ privateKey: string; publicKey: string; address: string }> {
   const seed: Buffer = await generateSeed(mnemonic, password, bip39ToUse)
@@ -410,13 +417,13 @@ export function generateDeterministicInviteCode(
   const seed = Buffer.from(keccak_256(utf8ToBytes(recipientPhoneHash + recipientPepper)))
   return generateKeysFromSeed(seed, changeIndex, addressIndex, derivationPath)
 }
-
-// keyByteLength truncates the seed. *Avoid its use*
-// It was added only because a backwards compatibility bug
+/*
+ * @param keyByteLength truncates the seed. *Avoid its use* It was added only because a backwards compatibility bug
+ */
 export async function generateSeed(
   mnemonic: string,
   password?: string,
-  bip39ToUse = bip39Wrapper,
+  bip39ToUse: Bip39 = bip39Wrapper,
   keyByteLength: number = 64
 ): Promise<Buffer> {
   let seed = Buffer.from(await bip39ToUse.mnemonicToSeed(mnemonic, password))
@@ -428,6 +435,12 @@ export async function generateSeed(
   return seed
 }
 
+/*
+ * @param seed - Buffer created from mneumonic
+ * @param changeIndex postion 4 from https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+ * @param addressIndex postion 5 from https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+ * @param derivationPath - This will default to ETH_DERIVATION_PATH in 7.0 forum.celo.org/t/deprecating-the-celo-derivation-path/9229
+ */
 export function generateKeysFromSeed(
   seed: Buffer,
   changeIndex: number = 0,


### PR DESCRIPTION
### Description

Add warnings about the derivation path default changing in the future. as per https://forum.celo.org/t/deprecating-the-celo-derivation-path/9229


### Other changes

add derivationPath to the output

### Tested

yes new `account:new` tests

https://app.warp.dev/block/bYdy5uQ3WsAUT7rj1bT19l

### Related issues

Prework for #352  

### Backwards compatibility

yes unless you count the output of the command which we do not as it is designed for humans to read.

### Documentation

improved!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updates to the `@celo/celocli` and `@celo/cryptographic-utils` packages, including the addition of a warning about the new default ETH derivation path, improvements to the `NewAccount` command, and modifications to key generation functions.

### Detailed summary
- `@celo/celocli`: Allow `account:new` command to run without a node.
- Added warning about default ETH derivation path in future versions.
- Updated `generateKeys`, `generateSeed`, and related functions with parameter documentation.
- Adjusted `NewAccount` command to reflect new derivation path logic.
- Updated test cases to verify new behavior with derivation paths.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->