### PR TITLE
port fixes from l2 investigation back. allow a validator reg without bls

### DIFF
--- a/.changeset/flat-readers-pull.md
+++ b/.changeset/flat-readers-pull.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Deprecate validator:force-deaffiliate

--- a/.changeset/wise-dodos-poke.md
+++ b/.changeset/wise-dodos-poke.md
@@ -1,0 +1,6 @@
+---
+'@celo/contractkit': patch
+'@celo/celocli': patch
+---
+
+Allow validator registration without bls as its not used after L2 hardfork

--- a/packages/cli/src/commands/validator/force-deaffiliate.ts
+++ b/packages/cli/src/commands/validator/force-deaffiliate.ts
@@ -17,6 +17,9 @@ export default class ValidatorForceDeaffiliate extends BaseCommand {
     'force-deaffiliate --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95 --validator 0xb7ef0985bdb4f19460A29d9829aA1514B181C4CD',
   ]
 
+  /*
+   * @deprecated this method is only callable by approved slasher contracts so AFAIKT it this command is not usable
+   */
   async run() {
     const kit = await this.getKit()
     const res = await this.parse(ValidatorForceDeaffiliate)

--- a/packages/cli/src/commands/validator/register.ts
+++ b/packages/cli/src/commands/validator/register.ts
@@ -13,8 +13,8 @@ export default class ValidatorRegister extends BaseCommand {
     ...BaseCommand.flags,
     from: CustomFlags.address({ required: true, description: 'Address for the Validator' }),
     ecdsaKey: CustomFlags.ecdsaPublicKey({ required: true }),
-    blsKey: CustomFlags.blsPublicKey({ required: true }),
-    blsSignature: CustomFlags.blsProofOfPossession({ required: true }),
+    blsKey: CustomFlags.blsPublicKey({ required: false }),
+    blsSignature: CustomFlags.blsProofOfPossession({ required: false }),
     yes: Flags.boolean({ description: 'Answer yes to prompt' }),
   }
 
@@ -52,15 +52,21 @@ export default class ValidatorRegister extends BaseCommand {
       .signerMeetsValidatorBalanceRequirements()
       .runChecks()
 
-    await displaySendTx(
-      'registerValidator',
-      validators.registerValidator(
-        // @ts-ignore incorrect typing for bytes type
-        res.flags.ecdsaKey,
-        res.flags.blsKey,
-        res.flags.blsSignature
+    if (await this.isCel2()) {
+      await displaySendTx(
+        'registerValidator',
+        validators.registerValidatorNoBls(res.flags.ecdsaKey)
       )
-    )
+    } else {
+      await displaySendTx(
+        'registerValidator',
+        validators.registerValidator(
+          res.flags.ecdsaKey,
+          res.flags.blsKey as string,
+          res.flags.blsSignature as string
+        )
+      )
+    }
 
     // register encryption key on accounts contract
     // TODO: Use a different key data encryption

--- a/packages/sdk/contractkit/src/wrappers/Validators.ts
+++ b/packages/sdk/contractkit/src/wrappers/Validators.ts
@@ -433,6 +433,12 @@ export class ValidatorsWrapper extends BaseWrapperForGoverning<Validators> {
     tupleParser(stringToSolidityBytes, stringToSolidityBytes, stringToSolidityBytes)
   )
 
+  registerValidatorNoBls: (ecdsaPublicKey: string) => CeloTransactionObject<boolean> = proxySend(
+    this.connection,
+    this.contract.methods.registerValidatorNoBls,
+    tupleParser(stringToSolidityBytes)
+  )
+
   getEpochNumber = proxyCall(this.contract.methods.getEpochNumber, undefined, valueToBigNumber)
 
   getEpochSize = proxyCall(this.contract.methods.getEpochSize, undefined, valueToBigNumber)


### PR DESCRIPTION
### Description

removed bls requirement for validator registration

#### Other changes

mark force-deaffiliate as deprecated. 
### Tested


### Related issues

inspired by #401 