### PR TITLE
fix: force delete tsbuildinfo

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "node": ">=16"
   },
   "scripts": {
-    "clean": "rm tsconfig.tsbuildinfo && yarn run --top-level tsc -b . --clean",
+    "clean": "rm -f tsconfig.tsbuildinfo && yarn run --top-level tsc -b . --clean",
     "dev": "yarn build && ts-node ./bin/dev.js",
     "build": "yarn run --top-level tsc -b .",
     "docs": "./generate_docs.sh",


### PR DESCRIPTION
Fixes the release process failing like here: https://github.com/celo-org/developer-tooling/actions/runs/11813422762/job/32910435812

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `clean` script in the `packages/cli/package.json` file to ensure it forcefully removes the `tsconfig.tsbuildinfo` file by adding the `-f` flag to the `rm` command.

### Detailed summary
- Modified the `clean` script:
  - Changed `rm tsconfig.tsbuildinfo` to `rm -f tsconfig.tsbuildinfo` to force the removal of the file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->