### PR TITLE
Remove L2 BLS keys support for account:authorize

### DIFF
--- a/.changeset/orange-penguins-sneeze.md
+++ b/.changeset/orange-penguins-sneeze.md
@@ -1,5 +1,5 @@
 ---
-'@celo/celocli': major
+'@celo/celocli': minor
 ---
 
 Removes L2 BLS keys support for account:authorize

--- a/.changeset/orange-penguins-sneeze.md
+++ b/.changeset/orange-penguins-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': major
+---
+
+Removes L2 BLS keys support for account:authorize

--- a/packages/cli/src/commands/account/authorize-l2.test.ts
+++ b/packages/cli/src/commands/account/authorize-l2.test.ts
@@ -28,6 +28,8 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
 
     await testLocallyWithWeb3Node(Register, ['--from', notRegisteredAccount], web3)
 
+    logMock.mockClear()
+
     await testLocallyWithWeb3Node(
       Authorize,
       [
@@ -42,23 +44,9 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
       ],
       web3
     )
+
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
       [
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is not a registered Account ",
-        ],
-        [
-          "All checks passed",
-        ],
-        [
-          "SendTransaction: register",
-        ],
-        [
-          "txHash: 0xtxhash",
-        ],
         [
           "Running Checks:",
         ],
@@ -84,6 +72,9 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
     const signerNotRegisteredAccount = accounts[1]
 
     await testLocallyWithWeb3Node(Register, ['--from', notRegisteredAccount], web3)
+
+    logMock.mockClear()
+
     await testLocallyWithWeb3Node(
       Authorize,
       [
@@ -98,23 +89,9 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
       ],
       web3
     )
+
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
       [
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is not a registered Account ",
-        ],
-        [
-          "All checks passed",
-        ],
-        [
-          "SendTransaction: register",
-        ],
-        [
-          "txHash: 0xtxhash",
-        ],
         [
           "Running Checks:",
         ],
@@ -140,6 +117,9 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
     const signerNotRegisteredAccount = accounts[1]
 
     await testLocallyWithWeb3Node(Register, ['--from', notRegisteredAccount], web3)
+
+    logMock.mockClear()
+
     await testLocallyWithWeb3Node(
       Authorize,
       [
@@ -154,31 +134,14 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
       ],
       web3
     )
+
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
       [
         [
           "Running Checks:",
         ],
         [
-          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is not a registered Account ",
-        ],
-        [
-          "All checks passed",
-        ],
-        [
-          "SendTransaction: register",
-        ],
-        [
-          "txHash: 0xtxhash",
-        ],
-        [
-          "Running Checks:",
-        ],
-        [
           "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is a registered Account ",
-        ],
-        [
-          "   ✔  undefined is not a registered Validator ",
         ],
         [
           "All checks passed",
@@ -194,13 +157,10 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
     expect(stripAnsiCodesFromNestedArray(errorMock.mock.calls)).toMatchInlineSnapshot(`[]`)
   })
 
-  // TODO figure out how we tackle this failure
-  test.failing('can authorize validator signer after validator is registered', async () => {
+  it('can authorize validator signer after validator is registered', async () => {
     const accounts = await web3.eth.getAccounts()
     const notRegisteredAccount = accounts[0]
     const signerNotRegisteredAccount = accounts[1]
-    const newBlsPublicKey = web3.utils.randomHex(96)
-    const newBlsPoP = web3.utils.randomHex(48)
     const ecdsaPublicKey = await addressToPublicKey(notRegisteredAccount, web3.eth.sign)
     await testLocallyWithWeb3Node(Register, ['--from', notRegisteredAccount], web3)
     await testLocallyWithWeb3Node(
@@ -210,19 +170,11 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
     )
     await testLocallyWithWeb3Node(
       ValidatorRegister,
-      [
-        '--from',
-        notRegisteredAccount,
-        '--ecdsaKey',
-        ecdsaPublicKey,
-        '--blsKey',
-        '0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00',
-        '--blsSignature',
-        '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
-        '--yes',
-      ],
+      ['--from', notRegisteredAccount, '--ecdsaKey', ecdsaPublicKey, '--yes'],
       web3
     )
+
+    logMock.mockClear()
 
     await testLocallyWithWeb3Node(
       Authorize,
@@ -235,17 +187,32 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
         signerNotRegisteredAccount,
         '--signature',
         PROOF_OF_POSSESSION_SIGNATURE,
-        '--blsKey',
-        newBlsPublicKey,
-        '--blsPop',
-        newBlsPoP,
       ],
       web3
     )
-    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot()
+
+    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "Running Checks:",
+        ],
+        [
+          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is a registered Account ",
+        ],
+        [
+          "All checks passed",
+        ],
+        [
+          "SendTransaction: authorizeTx",
+        ],
+        [
+          "txHash: 0xtxhash",
+        ],
+      ]
+    `)
   })
 
-  test('cannot authorize validator signer without BLS after validator is registered', async () => {
+  it('fails when using BLS keys on L2', async () => {
     const accounts = await web3.eth.getAccounts()
     const notRegisteredAccount = accounts[0]
     const signerNotRegisteredAccount = accounts[1]
@@ -258,19 +225,12 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
     )
     await testLocallyWithWeb3Node(
       ValidatorRegister,
-      [
-        '--from',
-        notRegisteredAccount,
-        '--ecdsaKey',
-        ecdsaPublicKey,
-        '--blsKey',
-        '0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00',
-        '--blsSignature',
-        '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
-        '--yes',
-      ],
+      ['--from', notRegisteredAccount, '--ecdsaKey', ecdsaPublicKey, '--yes'],
       web3
     )
+
+    logMock.mockClear()
+
     await expect(
       testLocallyWithWeb3Node(
         Authorize,
@@ -283,97 +243,17 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
           signerNotRegisteredAccount,
           '--signature',
           PROOF_OF_POSSESSION_SIGNATURE,
+          '--blsKey',
+          '0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00',
+          '--blsPop',
+          '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
         ],
 
         web3
       )
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
-    expect(stripAnsiCodesFromNestedArray(errorMock.mock.calls)).toMatchInlineSnapshot(`[]`)
-    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
-      [
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is not a registered Account ",
-        ],
-        [
-          "All checks passed",
-        ],
-        [
-          "SendTransaction: register",
-        ],
-        [
-          "txHash: 0xtxhash",
-        ],
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✔  Value [10000000000000000000000] is > 0 ",
-        ],
-        [
-          "All checks passed",
-        ],
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✔  Account has at least 10000 CELO ",
-        ],
-        [
-          "All checks passed",
-        ],
-        [
-          "SendTransaction: lock",
-        ],
-        [
-          "txHash: 0xtxhash",
-        ],
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is Signer or registered Account ",
-        ],
-        [
-          "   ✔  Signer can sign Validator Txs ",
-        ],
-        [
-          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is not a registered Validator ",
-        ],
-        [
-          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is not a registered ValidatorGroup ",
-        ],
-        [
-          "   ✔  Signer's account has enough locked celo for registration ",
-        ],
-        [
-          "All checks passed",
-        ],
-        [
-          "SendTransaction: registerValidator",
-        ],
-        [
-          "txHash: 0xtxhash",
-        ],
-        [
-          "SendTransaction: Set encryption key",
-        ],
-        [
-          "txHash: 0xtxhash",
-        ],
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is a registered Account ",
-        ],
-        [
-          "   ✘  undefined is not a registered Validator ",
-        ],
-      ]
-    `)
+    ).rejects.toMatchInlineSnapshot(`[Error: BLS keys are not supported on L2]`)
+
+    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`[]`)
   })
 
   test('can force authorize validator signer without BLS after validator is registered', async () => {
@@ -389,19 +269,12 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
     )
     await testLocallyWithWeb3Node(
       ValidatorRegister,
-      [
-        '--from',
-        notRegisteredAccount,
-        '--ecdsaKey',
-        ecdsaPublicKey,
-        '--blsKey',
-        '0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00',
-        '--blsSignature',
-        '0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900',
-        '--yes',
-      ],
+      ['--from', notRegisteredAccount, '--ecdsaKey', ecdsaPublicKey, '--yes'],
       web3
     )
+
+    logMock.mockClear()
+
     await testLocallyWithWeb3Node(
       Authorize,
       [
@@ -420,78 +293,6 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
     expect(stripAnsiCodesFromNestedArray(errorMock.mock.calls)).toMatchInlineSnapshot(`[]`)
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
       [
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is not a registered Account ",
-        ],
-        [
-          "All checks passed",
-        ],
-        [
-          "SendTransaction: register",
-        ],
-        [
-          "txHash: 0xtxhash",
-        ],
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✔  Value [10000000000000000000000] is > 0 ",
-        ],
-        [
-          "All checks passed",
-        ],
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✔  Account has at least 10000 CELO ",
-        ],
-        [
-          "All checks passed",
-        ],
-        [
-          "SendTransaction: lock",
-        ],
-        [
-          "txHash: 0xtxhash",
-        ],
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is Signer or registered Account ",
-        ],
-        [
-          "   ✔  Signer can sign Validator Txs ",
-        ],
-        [
-          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is not a registered Validator ",
-        ],
-        [
-          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is not a registered ValidatorGroup ",
-        ],
-        [
-          "   ✔  Signer's account has enough locked celo for registration ",
-        ],
-        [
-          "All checks passed",
-        ],
-        [
-          "SendTransaction: registerValidator",
-        ],
-        [
-          "txHash: 0xtxhash",
-        ],
-        [
-          "SendTransaction: Set encryption key",
-        ],
-        [
-          "txHash: 0xtxhash",
-        ],
         [
           "Running Checks:",
         ],
@@ -515,6 +316,9 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
     const accounts = await web3.eth.getAccounts()
     const notRegisteredAccount = accounts[0]
     const signerNotRegisteredAccount = accounts[1]
+
+    logMock.mockClear()
+
     await expect(
       testLocallyWithWeb3Node(
         Authorize,
@@ -540,9 +344,6 @@ testWithAnvilL2('account:authorize cmd', (web3: Web3) => {
         ],
         [
           "   ✘  0x5409ED021D9299bf6814279A6A1411A7e866A631 is a registered Account 0x5409ED021D9299bf6814279A6A1411A7e866A631 is not registered as an account. Try running account:register",
-        ],
-        [
-          "   ✔  undefined is not a registered Validator ",
         ],
       ]
     `)


### PR DESCRIPTION
### Description

BLS keys are no longer supported on L2, this PR removes the requirement for those in `account:authorize validator` command.

#### Other changes

Improves snapshot readability by clearing log mock right before calling the actual method we're testing.

### Tested

Ran tests locally.

### Related issues

- Fixes https://github.com/celo-org/developer-tooling/issues/417

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing support for L2 BLS keys in the `account:authorize` command, ensuring that users cannot use BLS keys on L2.

### Detailed summary
- Removed L2 BLS keys support for `account:authorize`.
- Added checks to prevent using BLS keys when the role is `validator` on L2.
- Updated tests to verify the removal of BLS key support on L2.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->