### PR TITLE
chore: update codecov.ymal with modern options

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,17 +1,47 @@
 coverage:
   status:
-    project:
+    patch:
       default:
+        # basic
         target: auto
-        threshold: null
-        removed_code_behavior: adjust_base
-      celotool:
-        paths:
-          - packages/celotool
-      celocli:
-        paths:
-          - packages/cli
-      sdk:
-        paths:
-          - packages/sdk
-    patch: off
+        threshold: 0%
+        base: auto
+        only_pulls: true
+comment:
+  layout: 'header, diff, flags, components'
+
+ignore:
+  - "packages/typescript"
+  - "docs"
+  - ".github"
+  - ".changeset"
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        branches:
+          - '!master'
+  individual_components:
+    - component_id: celocli
+      name: celocli
+      paths:
+        - packages/cli
+    - component_id: dev-utils
+      name: dev-utils
+      paths:
+        - packages/dev-utils
+    - component_id: sdks
+      name: sdk
+      paths:
+        - '!packages/sdk/wallets'
+        - packages/sdk/*
+    - component_id: wallets
+      name: wallets
+      paths:
+        - 'packages/sdk/wallets/*'
+    - component_id: viem-sdks
+      name: viem-sdks
+      paths:
+        - 'packages/viem-*

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,10 +11,10 @@ comment:
   layout: 'header, diff, flags, components'
 
 ignore:
-  - "packages/typescript"
-  - "docs"
-  - ".github"
-  - ".changeset"
+  - 'packages/typescript'
+  - 'docs'
+  - '.github'
+  - '.changeset'
 
 component_management:
   default_rules:
@@ -36,7 +36,7 @@ component_management:
       name: sdk
       paths:
         - '!packages/sdk/wallets'
-        - packages/sdk/*
+        - 'packages/sdk/*'
     - component_id: wallets
       name: wallets
       paths:
@@ -44,4 +44,4 @@ component_management:
     - component_id: viem-sdks
       name: viem-sdks
       paths:
-        - 'packages/viem-*
+        - 'packages/viem-*'

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/semver": "7.3.8",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "@typescript-eslint/parser": "^6.17.0",
-    "codecov": "^3.6.5",
+    "codecov": "^3.8.3",
     "colors": "1.4.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",

--- a/packages/cli/src/commands/account/balance.test.ts
+++ b/packages/cli/src/commands/account/balance.test.ts
@@ -1,0 +1,75 @@
+import { ContractKit, newKitFromWeb3, StableToken } from '@celo/contractkit'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import BigNumber from 'bignumber.js'
+import Web3 from 'web3'
+import { topUpWithToken } from '../../test-utils/chain-setup'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import Balance from './balance'
+
+process.env.NO_SYNCCHECK = 'true'
+
+testWithAnvilL2('account:set-name cmd', (web3: Web3) => {
+  const consoleMock = jest.spyOn(console, 'log')
+  let accounts: string[] = []
+  let kit: ContractKit
+
+  beforeEach(async () => {
+    kit = newKitFromWeb3(web3)
+    accounts = await web3.eth.getAccounts()
+    consoleMock.mockClear()
+  })
+
+  it('shows the balance of the account in several currencies', async () => {
+    await testLocallyWithWeb3Node(Balance, [accounts[0]], web3)
+
+    expect(stripAnsiCodesFromNestedArray(consoleMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "All balances expressed in units of 10^-18.",
+        ],
+        [
+          "lockedCELO: 0
+      pending: 0
+      CELO: 1e+24
+      cUSD: 0
+      cEUR: 0
+      cREAL: 0",
+        ],
+      ]
+    `)
+  })
+
+  it('shows the balance of the account in given currency', async () => {
+    const amount = new BigNumber('1234567890000000000000')
+    await topUpWithToken(kit, StableToken.cUSD, accounts[0], amount)
+
+    await testLocallyWithWeb3Node(
+      Balance,
+      [
+        accounts[0],
+        '--erc20Address',
+        (await kit.contracts.getStableToken(StableToken.cUSD)).address,
+      ],
+      web3
+    )
+
+    expect(stripAnsiCodesFromNestedArray(consoleMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "All balances expressed in units of 10^-18.",
+        ],
+        [
+          "lockedCELO: 0
+      pending: 0
+      CELO: 1e+24
+      cUSD: ${amount.toExponential()}
+      cEUR: 0
+      cREAL: 0",
+        ],
+        [
+          "erc20: ${amount.toExponential()}",
+        ],
+      ]
+    `)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -8673,7 +8673,7 @@ __metadata:
     "@types/semver": "npm:7.3.8"
     "@typescript-eslint/eslint-plugin": "npm:^6.17.0"
     "@typescript-eslint/parser": "npm:^6.17.0"
-    codecov: "npm:^3.6.5"
+    codecov: "npm:^3.8.3"
     colors: "npm:1.4.0"
     eslint: "npm:^8.56.0"
     eslint-config-prettier: "npm:^9.1.0"
@@ -9090,7 +9090,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"codecov@npm:^3.6.5":
+"codecov@npm:^3.8.3":
   version: 3.8.3
   resolution: "codecov@npm:3.8.3"
   dependencies:


### PR DESCRIPTION
### Description

Various coverage improvements

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `codecov` dependency version, modifies the `codecov.yml` configuration, and adds tests for the `Balance` command in the `packages/cli/src/commands/account/balance.test.ts` file.

### Detailed summary
- Updated `codecov` version from `3.6.5` to `3.8.3` in `package.json` and `yarn.lock`.
- Changed `codecov.yml` configuration settings, including:
  - Updated `threshold` to `0%` and set `base` to `auto`.
  - Added `only_pulls` option and modified `comment` layout.
  - Introduced component management rules for various components.
- Added tests for the `Balance` command, covering:
  - Displaying account balances in multiple currencies.
  - Displaying account balances in a specified currency after topping up.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->