### PR TITLE
Typo Update commands.md

### DIFF
--- a/docs/command-line-interface/commands.md
+++ b/docs/command-line-interface/commands.md
@@ -13,7 +13,7 @@ list all the commands
 USAGE
   $ celocli commands [--json] [--deprecated] [-h] [--hidden] [--tree]
     [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
-    [--output csv|json|yaml |  | ] [--sort <value>]
+   [--output csv|json|yaml] [--sort <value>]
 
 FLAGS
   -h, --help             Show CLI help.


### PR DESCRIPTION
**Description:**

This pull request addresses a typo in the `commands.md` file, located under `docs/command-line-interface/commands.md`.

**Issue:**
In the FLAGS section, the usage description for the `--output` flag contains unnecessary and incorrect placeholders:  
`"[--output csv|json|yaml | | ]"`.  
The repeated `| |` is invalid and causes confusion for users reading the documentation.

**Fix:**
I have corrected this by removing the unnecessary placeholders and ensuring the usage line is properly formatted as:  
`"[--output csv|json|yaml]"`.  

**Importance:**
This fix is important because the incorrect formatting could mislead users on how to use the `--output` flag correctly, potentially causing confusion during the configuration of command-line operations. Properly formatted documentation helps ensure clarity and prevent errors when executing commands.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for the `celocli commands` command, specifically refining the options available for the `--output` flag.

### Detailed summary
- Modified the `--output` flag options from `[--output csv|json|yaml |  | ]` to `[--output csv|json|yaml]`, removing the extra spaces and clarifying the valid output formats.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->