### PR TITLE
Bump ABIS /devchain

### DIFF
--- a/.changeset/loud-kids-dress.md
+++ b/.changeset/loud-kids-dress.md
@@ -1,0 +1,7 @@
+---
+'@celo/contractkit': patch
+'@celo/governance': patch
+'@celo/dev-utils': patch
+---
+
+Bump @celo/abis-12

--- a/packages/cli/src/commands/network/__snapshots__/contracts-l2.test.ts.snap
+++ b/packages/cli/src/commands/network/__snapshots__/contracts-l2.test.ts.snap
@@ -85,7 +85,7 @@ exports[`network:contracts runs 1`] = `
   {
     "contract": "FeeHandler",
     "proxy": "0xeaEEC408eCbCdF9CDF21d0B1880419dF7290E2c9",
-    "implementation": "0x82106CcC8feAE0bEc797281ae4dDf5F77E3E6156",
+    "implementation": "0x2e647D9D128c89D7239fdF47ca290453ad5869df",
     "version": "1.2.0.0"
   },
   {

--- a/packages/cli/src/commands/network/__snapshots__/contracts.test.ts.snap
+++ b/packages/cli/src/commands/network/__snapshots__/contracts.test.ts.snap
@@ -85,7 +85,7 @@ exports[`network:contracts runs 1`] = `
   {
     "contract": "FeeHandler",
     "proxy": "0xeaEEC408eCbCdF9CDF21d0B1880419dF7290E2c9",
-    "implementation": "0x82106CcC8feAE0bEc797281ae4dDf5F77E3E6156",
+    "implementation": "0x2e647D9D128c89D7239fdF47ca290453ad5869df",
     "version": "1.2.0.0"
   },
   {

--- a/packages/cli/src/commands/network/parameters-l2.test.ts
+++ b/packages/cli/src/commands/network/parameters-l2.test.ts
@@ -52,7 +52,7 @@ testWithAnvilL2('network:parameters', (web3) => {
       Reserve: 
         frozenReserveGoldDays: 0 
         frozenReserveGoldStartBalance: 0 
-        frozenReserveGoldStartDay: 20013 (~2.001e+4)
+        frozenReserveGoldStartDay: 20042 (~2.004e+4)
         otherReserveAddresses: 
 
         tobinTaxStalenessThreshold: 3153600000 (~3.154e+9)

--- a/packages/cli/src/commands/network/parameters.test.ts
+++ b/packages/cli/src/commands/network/parameters.test.ts
@@ -67,7 +67,7 @@ testWithAnvilL1('network:parameters', (web3: Web3) => {
       Reserve: 
         frozenReserveGoldDays: 0 
         frozenReserveGoldStartBalance: 0 
-        frozenReserveGoldStartDay: 20013 (~2.001e+4)
+        frozenReserveGoldStartDay: 20042 (~2.004e+4)
         otherReserveAddresses: 
 
         tobinTaxStalenessThreshold: 3153600000 (~3.154e+9)

--- a/packages/cli/src/commands/validatorgroup/member.test.ts
+++ b/packages/cli/src/commands/validatorgroup/member.test.ts
@@ -30,7 +30,7 @@ testWithAnvilL2('validatorgroup:member cmd', (web3: Web3) => {
             "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
             "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
           ],
-          "membersUpdated": 1729165064,
+          "membersUpdated": 1731689623,
           "name": "cLabs",
           "nextCommission": "0",
           "nextCommissionBlock": "0",

--- a/packages/cli/src/commands/validatorgroup/show.test.ts
+++ b/packages/cli/src/commands/validatorgroup/show.test.ts
@@ -35,7 +35,7 @@ testWithAnvilL2('validatorgroup:show cmd', (web3: Web3) => {
       commission: 0.1
       nextCommission: 0
       nextCommissionBlock: 0
-      membersUpdated: 1729165064
+      membersUpdated: 1731689623
       affiliates: 
       slashingMultiplier: 1
       lastSlashed: 0",

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -32,7 +32,7 @@
     "web3-core-helpers": "1.10.4"
   },
   "devDependencies": {
-    "@celo/devchain-anvil": "12.0.0-canary.33",
+    "@celo/devchain-anvil": "12.0.0-canary.39",
     "@celo/typescript": "workspace:^",
     "@tsconfig/recommended": "^1.0.3",
     "@types/fs-extra": "^8.1.0",

--- a/packages/sdk/contractkit/package.json
+++ b/packages/sdk/contractkit/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@celo/abis": "11.0.0",
-    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.60",
+    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.66",
     "@celo/base": "^7.0.0-beta.0",
     "@celo/connect": "^6.1.0-beta.1",
     "@celo/utils": "^8.0.0-beta.0",

--- a/packages/sdk/governance/package.json
+++ b/packages/sdk/governance/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@celo/abis": "11.0.0",
-    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.60",
+    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.66",
     "@celo/base": "^7.0.0-beta.0",
     "@celo/connect": "^6.1.0-beta.1",
     "@celo/contractkit": "^9.0.0-beta.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,10 +1631,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@celo/abis-12@npm:@celo/abis@12.0.0-canary.60":
-  version: 12.0.0-canary.60
-  resolution: "@celo/abis@npm:12.0.0-canary.60"
-  checksum: 605aa68b6d7e2cd43b6a0d8115a44e3ace8416c49401c6559f173461c873ce2a8a1867c0a5dab5be05549f6a7e1d2249c57506a4633643a90694c0a011cf638d
+"@celo/abis-12@npm:@celo/abis@12.0.0-canary.66":
+  version: 12.0.0-canary.66
+  resolution: "@celo/abis@npm:12.0.0-canary.66"
+  checksum: 71f85edda338c651e214e77d983a9fb644cdc2f5bb0fe6bc471d73e3a8f87256dc4dc6e966e79d7b239fd5729d4862606c384a8f601e030829111e32b0824279
   languageName: node
   linkType: hard
 
@@ -1856,7 +1856,7 @@ __metadata:
   resolution: "@celo/contractkit@workspace:packages/sdk/contractkit"
   dependencies:
     "@celo/abis": "npm:11.0.0"
-    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.60"
+    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.66"
     "@celo/base": "npm:^7.0.0-beta.0"
     "@celo/celo-devchain": "npm:^7.0.0"
     "@celo/connect": "npm:^6.1.0-beta.1"
@@ -1909,7 +1909,7 @@ __metadata:
   dependencies:
     "@celo/abis": "npm:^11.0.0"
     "@celo/connect": "npm:^6.1.0-beta.1"
-    "@celo/devchain-anvil": "npm:12.0.0-canary.33"
+    "@celo/devchain-anvil": "npm:12.0.0-canary.39"
     "@celo/typescript": "workspace:^"
     "@tsconfig/recommended": "npm:^1.0.3"
     "@types/fs-extra": "npm:^8.1.0"
@@ -1925,10 +1925,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@celo/devchain-anvil@npm:12.0.0-canary.33":
-  version: 12.0.0-canary.33
-  resolution: "@celo/devchain-anvil@npm:12.0.0-canary.33"
-  checksum: 010b061f3c43b959f201b7aaf56e0d8c1d7558d341e4b5f905a1d445cefc8f8acc1f667d536aa2de40f7f1d850d5af611184e9740c31ff32a8c76266946834f3
+"@celo/devchain-anvil@npm:12.0.0-canary.39":
+  version: 12.0.0-canary.39
+  resolution: "@celo/devchain-anvil@npm:12.0.0-canary.39"
+  checksum: 12e04bd2bb81acf43987b390e9ffe329445d72299651509a02f4a20dda86041910f167f59e2203c11e0633b02b668d50ef78c0866904193662f95127616e55be
   languageName: node
   linkType: hard
 
@@ -1956,7 +1956,7 @@ __metadata:
   resolution: "@celo/governance@workspace:packages/sdk/governance"
   dependencies:
     "@celo/abis": "npm:11.0.0"
-    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.60"
+    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.66"
     "@celo/base": "npm:^7.0.0-beta.0"
     "@celo/connect": "npm:^6.1.0-beta.1"
     "@celo/contractkit": "npm:^9.0.0-beta.2"


### PR DESCRIPTION

### Description

bump abis and devchain and therefore update snapshots due to changes in generated addresses.

There is no official pre-audit release so basing on the last published release

#### Other changes

n/a
### Tested

n/a
### Related issues

- Fixes #445 


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating dependencies and making adjustments to various test files and snapshots related to the `@celo` packages, specifically addressing version bumps and changes in member updates.

### Detailed summary
- Bumped `@celo/abis-12` from `12.0.0-canary.60` to `12.0.0-canary.66`.
- Updated `@celo/devchain-anvil` from `12.0.0-canary.33` to `12.0.0-canary.39`.
- Changed `membersUpdated` value from `1729165064` to `1731689623` in test files.
- Adjusted `frozenReserveGoldStartDay` from `20013` to `20042` in multiple test files.
- Updated implementation addresses in snapshots for `FeeHandler` in `contracts.test.ts.snap` and `contracts-l2.test.ts.snap`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->