### PR TITLE
Validator L2 command fixes

### DIFF
--- a/.changeset/fifty-dots-travel.md
+++ b/.changeset/fifty-dots-travel.md
@@ -1,0 +1,5 @@
+---
+'@celo/contractkit': minor
+---
+
+Exposes EpochManager.getElectedSigners contract method

--- a/.changeset/seven-pets-buy.md
+++ b/.changeset/seven-pets-buy.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+validator:signed-blocks not supported on L2 anymore, fixes validator:status L2

--- a/docs/command-line-interface/validator.md
+++ b/docs/command-line-interface/validator.md
@@ -467,7 +467,7 @@ FLAGS
       <options: csv|json|yaml>
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-      address of the signer to check if elected and validating
+      address of the signer to check if elected (and validating)
 
   --sort=<value>
       property to sort by (prepend '-' for descending)
@@ -477,7 +477,7 @@ FLAGS
       the last 100 blocks
 
   --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-      address of the validator to check if elected and validating
+      address of the validator to check if elected (and validating)
 
 DESCRIPTION
   Shows the consensus status of a validator. This command will show whether a validator

--- a/docs/sdk/contractkit/classes/wrappers_EpochManager.EpochManagerWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_EpochManager.EpochManagerWrapper.md
@@ -27,6 +27,7 @@ Contract handling epoch management.
 - [firstKnownEpoch](wrappers_EpochManager.EpochManagerWrapper.md#firstknownepoch)
 - [getCurrentEpochNumber](wrappers_EpochManager.EpochManagerWrapper.md#getcurrentepochnumber)
 - [getElectedAccounts](wrappers_EpochManager.EpochManagerWrapper.md#getelectedaccounts)
+- [getElectedSigners](wrappers_EpochManager.EpochManagerWrapper.md#getelectedsigners)
 - [getEpochNumberOfBlock](wrappers_EpochManager.EpochManagerWrapper.md#getepochnumberofblock)
 - [getEpochProcessingStatus](wrappers_EpochManager.EpochManagerWrapper.md#getepochprocessingstatus)
 - [getFirstBlockAtEpoch](wrappers_EpochManager.EpochManagerWrapper.md#getfirstblockatepoch)
@@ -161,7 +162,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:66](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L66)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:67](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L67)
 
 ___
 
@@ -237,6 +238,30 @@ ___
 
 ___
 
+### getElectedSigners
+
+• **getElectedSigners**: (...`args`: []) => `Promise`\<`string`[]\>
+
+#### Type declaration
+
+▸ (`...args`): `Promise`\<`string`[]\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [] |
+
+##### Returns
+
+`Promise`\<`string`[]\>
+
+#### Defined in
+
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:51](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L51)
+
+___
+
 ### getEpochNumberOfBlock
 
 • **getEpochNumberOfBlock**: (...`args`: [\_blockNumber: string \| number]) => `Promise`\<`number`\>
@@ -281,7 +306,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:51](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L51)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:52](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L52)
 
 ___
 
@@ -415,7 +440,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:65](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L65)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:66](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L66)
 
 ## Accessors
 
@@ -449,7 +474,7 @@ BaseWrapperForGoverning.address
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:68](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L68)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:69](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L69)
 
 ___
 
@@ -463,7 +488,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:130](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L130)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:131](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L131)
 
 ___
 
@@ -483,7 +508,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:81](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L81)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:82](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L82)
 
 ___
 

--- a/docs/sdk/contractkit/modules/wrappers_EpochManager.md
+++ b/docs/sdk/contractkit/modules/wrappers_EpochManager.md
@@ -29,4 +29,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:143](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L143)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:144](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L144)

--- a/packages/cli/src/commands/validator/signed-blocks-l2.test.ts
+++ b/packages/cli/src/commands/validator/signed-blocks-l2.test.ts
@@ -1,0 +1,18 @@
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import Web3 from 'web3'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import ValidatorSignedBlocks from './signed-blocks'
+
+process.env.NO_SYNCCHECK = 'true'
+
+const KNOWN_DEVCHAIN_VALIDATOR = '0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f'
+
+testWithAnvilL2('validator:signed-blocks', (web3: Web3) => {
+  it('shows unsupported message ', async () => {
+    await expect(
+      testLocallyWithWeb3Node(ValidatorSignedBlocks, ['--signer', KNOWN_DEVCHAIN_VALIDATOR], web3)
+    ).rejects.toMatchInlineSnapshot(
+      `[Error: This command is not available on L2 and might be removed in the future]`
+    )
+  })
+})

--- a/packages/cli/src/commands/validator/signed-blocks-l2.test.ts
+++ b/packages/cli/src/commands/validator/signed-blocks-l2.test.ts
@@ -12,7 +12,7 @@ testWithAnvilL2('validator:signed-blocks', (web3: Web3) => {
     await expect(
       testLocallyWithWeb3Node(ValidatorSignedBlocks, ['--signer', KNOWN_DEVCHAIN_VALIDATOR], web3)
     ).rejects.toMatchInlineSnapshot(
-      `[Error: This command is not available on L2 and might be removed in the future]`
+      `[Error: This command is not supported after CEL2 hardfork as the BFT consensus has been removed, see https://docs.celo.org/cel2/whats-changed/l1-l2 for more details]`
     )
   })
 })

--- a/packages/cli/src/commands/validator/signed-blocks.ts
+++ b/packages/cli/src/commands/validator/signed-blocks.ts
@@ -63,7 +63,9 @@ export default class ValidatorSignedBlocks extends BaseCommand {
     const isCel2 = await this.isCel2()
 
     if (isCel2) {
-      this.error('This command is not available on L2 and might be removed in the future')
+      this.error(
+        'This command is not supported after CEL2 hardfork as the BFT consensus has been removed, see https://docs.celo.org/cel2/whats-changed/l1-l2 for more details'
+      )
     }
 
     const kit = await this.getKit()

--- a/packages/cli/src/commands/validator/signed-blocks.ts
+++ b/packages/cli/src/commands/validator/signed-blocks.ts
@@ -70,7 +70,7 @@ export default class ValidatorSignedBlocks extends BaseCommand {
     const res = await this.parse(ValidatorSignedBlocks)
     const web3 = await this.getWeb3()
     const election = await kit.contracts.getElection()
-    const electionCache = new ElectionResultsCache(kit, isCel2, election)
+    const electionCache = new ElectionResultsCache(kit, election, isCel2)
 
     if (res.flags.follow) {
       console.info('Follow mode, press q or ctrl-c to quit')

--- a/packages/cli/src/commands/validator/signed-blocks.ts
+++ b/packages/cli/src/commands/validator/signed-blocks.ts
@@ -60,13 +60,17 @@ export default class ValidatorSignedBlocks extends BaseCommand {
   ]
 
   async run() {
+    const isCel2 = await this.isCel2()
+
+    if (isCel2) {
+      this.error('This command is not available on L2 and might be removed in the future')
+    }
+
     const kit = await this.getKit()
     const res = await this.parse(ValidatorSignedBlocks)
     const web3 = await this.getWeb3()
     const election = await kit.contracts.getElection()
-    const validators = await kit.contracts.getValidators()
-    const epochSize = await validators.getEpochSize()
-    const electionCache = new ElectionResultsCache(election, epochSize.toNumber())
+    const electionCache = new ElectionResultsCache(kit, isCel2, election)
 
     if (res.flags.follow) {
       console.info('Follow mode, press q or ctrl-c to quit')

--- a/packages/cli/src/commands/validator/status-l2.test.ts
+++ b/packages/cli/src/commands/validator/status-l2.test.ts
@@ -1,30 +1,17 @@
-import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
-import { IstanbulUtils } from '@celo/utils/lib/istanbul'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
-import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import Switch from '../epochs/switch'
 import Status from './status'
 
 process.env.NO_SYNCCHECK = 'true'
 
 const KNOWN_DEVCHAIN_VALIDATOR = '0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f'
 
-testWithAnvilL1('validator:status', (web3: Web3) => {
+testWithAnvilL2('validator:status', (web3: Web3) => {
   const writeMock = jest.spyOn(ux.write, 'stdout')
   const logMock = jest.spyOn(console, 'log')
-
-  // In anvil the blocks don't have any extraData on them
-  // This is a bare minimum needed by status command to work
-  jest.spyOn(IstanbulUtils, 'parseBlockExtraData').mockImplementation(() => {
-    return {
-      parentAggregatedSeal: {
-        bitmap: new BigNumber(0),
-      },
-    } as any
-  })
-
-  jest.spyOn(IstanbulUtils, 'bitIsSet').mockImplementation(() => false)
 
   afterEach(() => {
     jest.clearAllMocks()
@@ -52,16 +39,17 @@ testWithAnvilL1('validator:status', (web3: Web3) => {
     expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
         [
           [
-            "Address,Signer,Elected,Frontrunner,Signatures
+            "Address,Signer,Elected,Frontrunner
         ",
           ],
           [
-            "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,true,true,0.00%
+            "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,true,true
         ",
           ],
         ]
       `)
   })
+
   it('displays status for all validators', async () => {
     await testLocallyWithWeb3Node(Status, ['--all', '--csv'], web3)
 
@@ -69,34 +57,50 @@ testWithAnvilL1('validator:status', (web3: Web3) => {
     expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
         [
           [
-            "Address,Signer,Elected,Frontrunner,Signatures
+            "Address,Signer,Elected,Frontrunner
         ",
           ],
           [
-            "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65,0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65,true,true,0.00%
+            "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65,0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65,true,true
         ",
           ],
           [
-            "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc,0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc,true,true,0.00%
+            "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc,0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc,true,true
         ",
           ],
           [
-            "0x976EA74026E726554dB657fA54763abd0C3a0aa9,0x976EA74026E726554dB657fA54763abd0C3a0aa9,true,true,0.00%
+            "0x976EA74026E726554dB657fA54763abd0C3a0aa9,0x976EA74026E726554dB657fA54763abd0C3a0aa9,true,true
         ",
           ],
           [
-            "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955,0x14dC79964da2C08b23698B3D3cc7Ca32193d9955,true,true,0.00%
+            "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955,0x14dC79964da2C08b23698B3D3cc7Ca32193d9955,true,true
         ",
           ],
           [
-            "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,true,true,0.00%
+            "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,true,true
         ",
           ],
           [
-            "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720,0xa0Ee7A142d267C1f36714E4a8F75612F20a79720,true,true,0.00%
+            "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720,0xa0Ee7A142d267C1f36714E4a8F75612F20a79720,true,true
         ",
           ],
         ]
       `)
+  })
+
+  it('fails if start and end are in different epochs', async () => {
+    const [account] = await web3.eth.getAccounts()
+
+    await testLocallyWithWeb3Node(Switch, ['--from', account], web3)
+
+    await expect(
+      testLocallyWithWeb3Node(
+        Status,
+        ['--validator', KNOWN_DEVCHAIN_VALIDATOR, '--start', '349'],
+        web3
+      )
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Start and end blocks must be in the current epoch"`
+    )
   })
 })

--- a/packages/cli/src/commands/validator/status-l2.test.ts
+++ b/packages/cli/src/commands/validator/status-l2.test.ts
@@ -18,7 +18,11 @@ testWithAnvilL2('validator:status', (web3: Web3) => {
   })
 
   it('displays status of the validator', async () => {
-    await testLocallyWithWeb3Node(Status, ['--validator', KNOWN_DEVCHAIN_VALIDATOR, '--csv'], web3)
+    await testLocallyWithWeb3Node(
+      Status,
+      ['--validator', KNOWN_DEVCHAIN_VALIDATOR, '--csv', '--start', '349'],
+      web3
+    )
 
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [
@@ -51,7 +55,7 @@ testWithAnvilL2('validator:status', (web3: Web3) => {
   })
 
   it('displays status for all validators', async () => {
-    await testLocallyWithWeb3Node(Status, ['--all', '--csv'], web3)
+    await testLocallyWithWeb3Node(Status, ['--all', '--csv', '--start', '349'], web3)
 
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`[]`)
     expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`

--- a/packages/cli/src/commands/validator/status.test.ts
+++ b/packages/cli/src/commands/validator/status.test.ts
@@ -1,5 +1,5 @@
 import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
-import { IstanbulUtils } from '@celo/utils/lib/istanbul'
+import { IstanbulUtils } from '@celo/utils'
 import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'

--- a/packages/cli/src/commands/validator/status.ts
+++ b/packages/cli/src/commands/validator/status.ts
@@ -119,8 +119,8 @@ export default class ValidatorStatus extends BaseCommand {
     const epochSize = await kit.getEpochSize()
     const electionCache = new ElectionResultsCache(
       kit,
-      isCel2,
       election,
+      isCel2,
       isCel2 ? await kit.contracts.getEpochManager() : undefined
     )
     let frontRunnerSigners: string[] = []

--- a/packages/cli/src/utils/election.ts
+++ b/packages/cli/src/utils/election.ts
@@ -13,12 +13,12 @@ export class ElectionResultsCache {
 
   constructor(
     private readonly kit: ContractKit,
-    private readonly isCel2: boolean,
     private readonly electionWrapper: ElectionWrapper,
+    private readonly isCel2: boolean,
     private readonly epochManagerWrapper?: EpochManagerWrapper
   ) {
     if (isCel2 && !epochManagerWrapper) {
-      throw new Error('EpochManagerWrapper is required for L2')
+      throw new Error('EpochManagerWrapper is required')
     }
   }
 

--- a/packages/sdk/contractkit/src/wrappers/EpochManager.ts
+++ b/packages/sdk/contractkit/src/wrappers/EpochManager.ts
@@ -48,6 +48,7 @@ export class EpochManagerWrapper extends BaseWrapperForGoverning<EpochManager> {
   isOnEpochProcess = proxyCall(this.contract.methods.isOnEpochProcess)
   isTimeForNextEpoch = proxyCall(this.contract.methods.isTimeForNextEpoch)
   getElectedAccounts = proxyCall(this.contract.methods.getElectedAccounts)
+  getElectedSigners = proxyCall(this.contract.methods.getElectedSigners)
   getEpochProcessingStatus = proxyCall(
     this.contract.methods.epochProcessing,
     undefined,


### PR DESCRIPTION
### Description

This PR fixes/improves 

- `validator:signed-blocks`
- `validator:status`

commands in L2 context.

#### Other changes

Exposes new command in `EpochManager` contract.

### Tested

Ran tests locally and ran commands versus a local node.

### Related issues

- Fixes https://github.com/celo-org/developer-tooling/issues/416

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `EpochManager` and `Validator` functionalities in the Celo ecosystem, particularly addressing L2 support and improving the command-line interface for validators.

### Detailed summary
- Added `getElectedSigners` method to the `EpochManager`.
- Updated validator commands to reflect L2 support.
- Adjusted descriptions in CLI for clarity.
- Enhanced tests for `validator:signed-blocks` and `validator:status`.
- Modified `ElectionResultsCache` to handle L2 specifics.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->