### PR TITLE
fix #357 show node flag aliases in help

### DIFF
--- a/.changeset/purple-phones-try.md
+++ b/.changeset/purple-phones-try.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Show --node and --useLedger flags when --help is called. Show aliases for networks in --node help

--- a/docs/command-line-interface/account.md
+++ b/docs/command-line-interface/account.md
@@ -41,10 +41,17 @@ Keep your locked Gold more secure by authorizing alternative keys to be used for
 USAGE
   $ celocli account:authorize --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d -r
     vote|validator|attestation --signature 0x --signer
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--blsKey 0x --blsPop 0x]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp] [--blsKey 0x --blsPop 0x]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -r, --role=<option>
       (required) Role to delegate
       <options: vote|validator|attestation>
@@ -67,11 +74,18 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --signature=0x
       (required) Signature (a.k.a proof-of-possession) of the signer key
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Account Address
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Keep your locked Gold more secure by authorizing alternative keys to be used for
@@ -84,6 +98,16 @@ EXAMPLES
   authorize --from 0x5409ED021D9299bf6814279A6A1411A7e866A631 --role vote --signer 0x6ecbe1db9ef729cbe972c83fb886247691fb6beb --signature 0x1b9fca4bbb5bfb1dbe69ef1cddbd9b4202dcb6b134c5170611e1e36ecfa468d7b46c85328d504934fce6c2a1571603a50ae224d2b32685e84d4d1a1eebad8452eb
 
   authorize --from 0x5409ED021D9299bf6814279A6A1411A7e866A631 --role validator --signer 0x6ecbe1db9ef729cbe972c83fb886247691fb6beb --signature 0x1b9fca4bbb5bfb1dbe69ef1cddbd9b4202dcb6b134c5170611e1e36ecfa468d7b46c85328d504934fce6c2a1571603a50ae224d2b32685e84d4d1a1eebad8452eb --blsKey 0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00 --blsPop 0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/authorize.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/authorize.ts)_
@@ -94,11 +118,17 @@ View Celo Stables and CELO balances for an address
 
 ```
 USAGE
-  $ celocli account:balance ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--erc20Address
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
+  $ celocli account:balance ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp] [--erc20Address 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   --erc20Address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       Address of generic ERC-20 token to also check balance for
 
@@ -109,6 +139,13 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   View Celo Stables and CELO balances for an address
 
@@ -116,6 +153,16 @@ EXAMPLES
   balance 0x5409ed021d9299bf6814279a6a1411a7e866a631
 
   balance 0x5409ed021d9299bf6814279a6a1411a7e866a631 --erc20Address 0x765DE816845861e75A25fCA122bb6898B8B1282a
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/balance.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/balance.ts)_
@@ -127,31 +174,43 @@ Claim another account, and optionally its public key, and add the claim to a loc
 ```
 USAGE
   $ celocli account:claim-account ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --address <value> [--gasCurrency 0x1234567890123456789012345678901234567890]
+    --address <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp] [--publicKey <value>]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
-  --address=<value>                                         (required) The address of
-                                                            the account you want to
-                                                            claim
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            account to set metadata for
-                                                            or an authorized signer for
-                                                            the address in the metadata
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --publicKey=<value>                                       The public key of the
-                                                            account that others may use
-                                                            to send you encrypted
-                                                            messages
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --address=<value>
+      (required) The address of the account you want to claim
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the account to set metadata for or an authorized signer for
+      the address in the metadata
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --publicKey=<value>
+      The public key of the account that others may use to send you encrypted messages
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Claim another account, and optionally its public key, and add the claim to a local
@@ -159,6 +218,16 @@ DESCRIPTION
 
 EXAMPLES
   claim-account ~/metadata.json --address 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/claim-account.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/claim-account.ts)_
@@ -170,32 +239,56 @@ Claim a domain and add the claim to a local metadata file
 ```
 USAGE
   $ celocli account:claim-domain ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --domain <value> [--gasCurrency 0x1234567890123456789012345678901234567890]
+    --domain <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
-  --domain=<value>                                          (required) The domain you
-                                                            want to claim
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            account to set metadata for
-                                                            or an authorized signer for
-                                                            the address in the metadata
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --domain=<value>
+      (required) The domain you want to claim
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the account to set metadata for or an authorized signer for
+      the address in the metadata
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Claim a domain and add the claim to a local metadata file
 
 EXAMPLES
   claim-domain ~/metadata.json --domain example.com --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/claim-domain.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/claim-domain.ts)_
@@ -207,32 +300,56 @@ Claim a keybase username and add the claim to a local metadata file
 ```
 USAGE
   $ celocli account:claim-keybase ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --username <value> [--gasCurrency 0x1234567890123456789012345678901234567890]
+    --username <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            account to set metadata for
-                                                            or an authorized signer for
-                                                            the address in the metadata
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --username=<value>                                        (required) The keybase
-                                                            username you want to claim
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the account to set metadata for or an authorized signer for
+      the address in the metadata
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --username=<value>
+      (required) The keybase username you want to claim
 
 DESCRIPTION
   Claim a keybase username and add the claim to a local metadata file
 
 EXAMPLES
   claim-keybase ~/metadata.json --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --username myusername
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/claim-keybase.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/claim-keybase.ts)_
@@ -244,32 +361,56 @@ Claim a name and add the claim to a local metadata file
 ```
 USAGE
   $ celocli account:claim-name ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --name <value> [--gasCurrency 0x1234567890123456789012345678901234567890]
+    --name <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            account to set metadata for
-                                                            or an authorized signer for
-                                                            the address in the metadata
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --name=<value>                                            (required) The name you want
-                                                            to claim
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the account to set metadata for or an authorized signer for
+      the address in the metadata
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --name=<value>
+      (required) The name you want to claim
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Claim a name and add the claim to a local metadata file
 
 EXAMPLES
   claim-name ~/metadata.json --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --name myname
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/claim-name.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/claim-name.ts)_
@@ -281,33 +422,56 @@ Claim a storage root and add the claim to a local metadata file
 ```
 USAGE
   $ celocli account:claim-storage ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --url https://www.celo.org [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    --url https://www.celo.org [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            account to set metadata for
-                                                            or an authorized signer for
-                                                            the address in the metadata
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --url=https://www.celo.org                                (required) The URL of the
-                                                            storage root you want to
-                                                            claim
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the account to set metadata for or an authorized signer for
+      the address in the metadata
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --url=https://www.celo.org
+      (required) The URL of the storage root you want to claim
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Claim a storage root and add the claim to a local metadata file
 
 EXAMPLES
   claim-storage ~/metadata.json --url http://example.com/myurl --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/claim-storage.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/claim-storage.ts)_
@@ -319,23 +483,37 @@ Create an empty identity metadata file. Use this metadata file to store claims a
 ```
 USAGE
   $ celocli account:create-metadata ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+    [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 ARGUMENTS
   ARG1  Path where the metadata should be saved
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            account to set metadata for
-                                                            or an authorized signer for
-                                                            the address in the metadata
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the account to set metadata for or an authorized signer for
+      the address in the metadata
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Create an empty identity metadata file. Use this metadata file to store claims
@@ -344,6 +522,16 @@ DESCRIPTION
 
 EXAMPLES
   create-metadata ~/metadata.json --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/create-metadata.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/create-metadata.ts)_
@@ -355,10 +543,18 @@ Remove an account's authorized attestation signer role.
 ```
 USAGE
   $ celocli account:deauthorize --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d -r
-    attestation --signer 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    attestation --signer 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> |
+    --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -r, --role=<option>
       (required) Role to remove
       <options: attestation>
@@ -373,14 +569,31 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Account Address
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Remove an account's authorized attestation signer role.
 
 EXAMPLES
   deauthorize --from 0x5409ED021D9299bf6814279A6A1411A7e866A631 --role attestation --signer 0x6ecbe1db9ef729cbe972c83fb886247691fb6beb
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/deauthorize.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/deauthorize.ts)_
@@ -391,24 +604,50 @@ Removes a validator's payment delegation by setting beneficiary and fraction to 
 
 ```
 USAGE
-  $ celocli account:delete-payment-delegation --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli account:delete-payment-delegation --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Removes a validator's payment delegation by setting beneficiary and fraction to 0.
 
 EXAMPLES
   delete-payment-delegation --account 0x5409ED021D9299bf6814279A6A1411A7e866A631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/delete-payment-delegation.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/delete-payment-delegation.ts)_
@@ -419,15 +658,21 @@ Show information about an address. Retrieves the metadata URL for an account fro
 
 ```
 USAGE
-  $ celocli account:get-metadata ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli account:get-metadata ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header |
+    [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 ARGUMENTS
   ARG1  Address to get metadata for
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -447,6 +692,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -460,12 +709,25 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   Show information about an address. Retrieves the metadata URL for an account from the
   on-chain, then fetches the metadata file off-chain and verifies proofs as able.
 
 EXAMPLES
   get-metadata 0x97f7333c51897469E8D98E7af8653aAb468050a3
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/get-metadata.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/get-metadata.ts)_
@@ -476,12 +738,19 @@ Get the payment delegation account beneficiary and fraction allocated from a val
 
 ```
 USAGE
-  $ celocli account:get-payment-delegation --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp] [--columns
-    <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ celocli account:get-payment-delegation --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
+    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -504,6 +773,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -517,12 +790,25 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   Get the payment delegation account beneficiary and fraction allocated from a
   validator's payment each epoch. The fraction cannot be greater than 1.
 
 EXAMPLES
   get-payment-delegation --account 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/get-payment-delegation.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/get-payment-delegation.ts)_
@@ -533,24 +819,47 @@ List the addresses from the node and the local instance
 
 ```
 USAGE
-  $ celocli account:list [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--local]
+  $ celocli account:list [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--local]
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --[no-]local                                              If set, only show local and
-                                                            hardware wallet accounts.
-                                                            Use no-local to only show
-                                                            keystore addresses.
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --[no-]local
+      If set, only show local and hardware wallet accounts. Use no-local to only show
+      keystore addresses.
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   List the addresses from the node and the local instance
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/list.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/list.ts)_
@@ -561,26 +870,49 @@ Lock an account which was previously unlocked
 
 ```
 USAGE
-  $ celocli account:lock ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli account:lock ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp]
 
 ARGUMENTS
   ARG1  Account address
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Lock an account which was previously unlocked
 
 EXAMPLES
   lock 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/lock.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/lock.ts)_
@@ -591,13 +923,16 @@ Creates a new account locally using the Celo Derivation Path (m/44'/52752'/0/cha
 
 ```
 USAGE
-  $ celocli account:new [--gasCurrency
+  $ celocli account:new [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--globalHelp] [--passphrasePath
     <value>] [--changeIndex <value>] [--addressIndex <value>] [--language chinese_simpli
     fied|chinese_traditional|english|french|italian|japanese|korean|spanish]
     [--mnemonicPath <value>] [--derivationPath <value>]
 
 FLAGS
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   --addressIndex=<value>
       Choose the address index for the derivation path
 
@@ -654,6 +989,16 @@ EXAMPLES
   new --passphrasePath some_folder/my_passphrase_file --language japanese --addressIndex 5
 
   new --passphrasePath some_folder/my_passphrase_file --mnemonicPath some_folder/my_mnemonic_file --addressIndex 5
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/new.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/new.ts)_
@@ -664,30 +1009,47 @@ DEV: Reads the name from offchain storage
 
 ```
 USAGE
-  $ celocli account:offchain-read ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--directory <value>]
-    [--bucket <value> --provider git|aws|gcp] [--from
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--privateDEK <value>]
+  $ celocli account:offchain-read ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp] [--directory <value>] [--bucket <value> --provider
+    git|aws|gcp] [--from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--privateDEK
+    <value>]
 
 FLAGS
-  --bucket=<value>                                          If using a GCP or AWS
-                                                            storage bucket this
-                                                            parameter is required
-  --directory=<value>                                       [default: .] To which
-                                                            directory data should be
-                                                            written
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --bucket=<value>
+      If using a GCP or AWS storage bucket this parameter is required
+
+  --directory=<value>
+      [default: .] To which directory data should be written
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --privateDEK=<value>
-  --provider=<option>                                       If the CLI should attempt to
-                                                            push to the cloud
-                                                            <options: git|aws|gcp>
+
+  --provider=<option>
+      If the CLI should attempt to push to the cloud
+      <options: git|aws|gcp>
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   DEV: Reads the name from offchain storage
@@ -696,6 +1058,16 @@ EXAMPLES
   offchain-read 0x...
 
   offchain-read 0x... --from 0x... --privateKey 0x...
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/offchain-read.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/offchain-read.ts)_
@@ -706,32 +1078,48 @@ DEV: Writes a name to offchain storage
 
 ```
 USAGE
-  $ celocli account:offchain-write --name <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--directory <value>]
-    [--bucket <value> --provider git|aws|gcp] (--privateDEK <value> --privateKey <value>
-    --encryptTo <value>)
+  $ celocli account:offchain-write --name <value> [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> (--useLedger
+    | --privateKey <value>)] [--globalHelp] [--directory <value>] [--bucket <value>
+    --provider git|aws|gcp] [--privateDEK <value>  --encryptTo <value>]
 
 FLAGS
-  --bucket=<value>                                          If using a GCP or AWS
-                                                            storage bucket this
-                                                            parameter is required
-  --directory=<value>                                       [default: .] To which
-                                                            directory data should be
-                                                            written
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --bucket=<value>
+      If using a GCP or AWS storage bucket this parameter is required
+
+  --directory=<value>
+      [default: .] To which directory data should be written
+
   --encryptTo=<value>
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --name=<value>                                            (required)
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --name=<value>
+      (required)
+
   --privateDEK=<value>
-  --privateKey=<value>                                      (required)
-  --provider=<option>                                       If the CLI should attempt to
-                                                            push to the cloud
-                                                            <options: git|aws|gcp>
+
+  --privateKey=<value>
+      (required)
+
+  --provider=<option>
+      If the CLI should attempt to push to the cloud
+      <options: git|aws|gcp>
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   DEV: Writes a name to offchain storage
@@ -740,6 +1128,16 @@ EXAMPLES
   offchain-write --name test-account --privateKey 0x...
 
   offchain-write --name test-account --privateKey 0x...  privateDEK 0x... --encryptTo 0x...
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/offchain-write.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/offchain-write.ts)_
@@ -751,24 +1149,36 @@ Generate proof-of-possession to be used to authorize a signer. See the "account:
 ```
 USAGE
   $ celocli account:proof-of-possession --signer 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ]
+    [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Address of the
-                                                            account that needs to prove
-                                                            possession of the signer
-                                                            key.
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Address of the
-                                                            signer key to prove
-                                                            possession of.
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the account that needs to prove possession of the signer key.
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the signer key to prove possession of.
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Generate proof-of-possession to be used to authorize a signer. See the
@@ -776,6 +1186,16 @@ DESCRIPTION
 
 EXAMPLES
   proof-of-possession --account 0x5409ed021d9299bf6814279a6a1411a7e866a631 --signer 0x6ecbe1db9ef729cbe972c83fb886247691fb6beb
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/proof-of-possession.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/proof-of-possession.ts)_
@@ -786,20 +1206,36 @@ Register an account on-chain. This allows you to lock Gold, which is a pre-requi
 
 ```
 USAGE
-  $ celocli account:register --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp] [--name
-    <value>]
+  $ celocli account:register --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--name <value>]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --name=<value>
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Register an account on-chain. This allows you to lock Gold, which is a pre-requisite
@@ -810,6 +1246,16 @@ EXAMPLES
   register --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
 
   register --from 0x5409ed021d9299bf6814279a6a1411a7e866a631 --name test-account
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/register.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/register.ts)_
@@ -821,22 +1267,36 @@ Register a data encryption key for an account on chain. This key can be used to 
 ```
 USAGE
   $ celocli account:register-data-encryption-key --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --publicKey <value> [--gasCurrency 0x1234567890123456789012345678901234567890]
+    --publicKey <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            account to set the data
-                                                            encryption key for
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --publicKey=<value>                                       (required) The public key
-                                                            you want to register
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the account to set the data encryption key for
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --publicKey=<value>
+      (required) The public key you want to register
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Register a data encryption key for an account on chain. This key can be used to
@@ -844,6 +1304,16 @@ DESCRIPTION
 
 EXAMPLES
   register-data-encryption-key --publicKey 0x...  --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/register-data-encryption-key.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/register-data-encryption-key.ts)_
@@ -855,11 +1325,18 @@ Register metadata URL for an account where users will be able to retrieve the me
 ```
 USAGE
   $ celocli account:register-metadata --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --url
-    <value> [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
-    [--force] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+    <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--force] [--columns <value> | -x] [--filter <value>] [--no-header |
+    [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -885,6 +1362,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -901,12 +1382,25 @@ FLAGS
   --url=<value>
       (required) The url to the metadata you want to register
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   Register metadata URL for an account where users will be able to retrieve the metadata
   file and verify your claims
 
 EXAMPLES
   register-metadata --url https://www.mywebsite.com/celo-metadata --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/register-metadata.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/register-metadata.ts)_
@@ -918,19 +1412,36 @@ Sets the name of a registered account on-chain. An account's name is an optional
 ```
 USAGE
   $ celocli account:set-name --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --name <value> [--gasCurrency 0x1234567890123456789012345678901234567890]
+    --name <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --name=<value>                                            (required)
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --name=<value>
+      (required)
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Sets the name of a registered account on-chain. An account's name is an optional human
@@ -938,6 +1449,16 @@ DESCRIPTION
 
 EXAMPLES
   set-name --account 0x5409ed021d9299bf6814279a6a1411a7e866a631 --name test-account
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/set-name.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/set-name.ts)_
@@ -949,20 +1470,40 @@ Sets a payment delegation beneficiary, an account address to receive a fraction 
 ```
 USAGE
   $ celocli account:set-payment-delegation --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --beneficiary 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --fraction <value>
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+    --beneficiary 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --fraction <value> [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Account Address
-  --beneficiary=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Account Address
-  --fraction=<value>                                        (required)
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --beneficiary=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --fraction=<value>
+      (required)
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Sets a payment delegation beneficiary, an account address to receive a fraction of the
@@ -970,6 +1511,16 @@ DESCRIPTION
 
 EXAMPLES
   set-payment-delegation --account 0x5409ed021d9299bf6814279a6a1411a7e866a631 --beneficiary 0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb --fraction 0.1
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/set-payment-delegation.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/set-payment-delegation.ts)_
@@ -981,25 +1532,43 @@ Sets the wallet of a registered account on-chain. An account's wallet is an opti
 ```
 USAGE
   $ celocli account:set-wallet --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --wallet 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--signature 0x]
-    [--signer 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
+    --wallet 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ]
+    [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp] [--signature 0x] [--signer
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --signature=0x                                            Signature (a.k.a.
-                                                            proof-of-possession) of the
-                                                            signer key
-  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       Address of the signer key to
-                                                            verify proof of possession.
-  --wallet=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Account Address
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --signature=0x
+      Signature (a.k.a. proof-of-possession) of the signer key
+
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Address of the signer key to verify proof of possession.
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --wallet=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
 
 DESCRIPTION
   Sets the wallet of a registered account on-chain. An account's wallet is an optional
@@ -1009,6 +1578,16 @@ EXAMPLES
   set-wallet --account 0x5409ed021d9299bf6814279a6a1411a7e866a631 --wallet 0x5409ed021d9299bf6814279a6a1411a7e866a631
 
   set-wallet --account 0x5409ed021d9299bf6814279a6a1411a7e866a631 --wallet 0x5409ed021d9299bf6814279a6a1411a7e866a631 --signer 0x0EdeDF7B1287f07db348997663EeEb283D70aBE7 --signature 0x1c5efaa1f7ca6484d49ccce76217e2fba0552c0b23462cff7ba646473bc2717ffc4ce45be89bd5be9b5d23305e87fc2896808467c4081d9524a84c01b89ec91ca3
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/set-wallet.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/set-wallet.ts)_
@@ -1019,17 +1598,30 @@ Show information for an account, including name, authorized vote, validator, and
 
 ```
 USAGE
-  $ celocli account:show ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli account:show ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp]
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Show information for an account, including name, authorized vote, validator, and
@@ -1039,6 +1631,16 @@ DESCRIPTION
 
 EXAMPLES
   show 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/show.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/show.ts)_
@@ -1049,23 +1651,46 @@ Show information about claimed accounts
 
 ```
 USAGE
-  $ celocli account:show-claimed-accounts ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli account:show-claimed-accounts ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp]
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Show information about claimed accounts
 
 EXAMPLES
   show-claimed-accounts 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/show-claimed-accounts.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/show-claimed-accounts.ts)_
@@ -1076,15 +1701,21 @@ Show the data in a local metadata file
 
 ```
 USAGE
-  $ celocli account:show-metadata ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli account:show-metadata ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header |
+    [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -1104,6 +1735,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -1117,11 +1752,24 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   Show the data in a local metadata file
 
 EXAMPLES
   show-metadata ~/metadata.json
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/show-metadata.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/show-metadata.ts)_
@@ -1132,29 +1780,41 @@ Unlock an account address to send transactions or validate blocks
 
 ```
 USAGE
-  $ celocli account:unlock ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--password <value>]
-    [--duration <value>]
+  $ celocli account:unlock ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp] [--password <value>] [--duration <value>]
 
 ARGUMENTS
   ARG1  Account address
 
 FLAGS
-  --duration=<value>                                        Duration in seconds to leave
-                                                            the account unlocked.
-                                                            Unlocks until the node exits
-                                                            by default.
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --password=<value>                                        Password used to unlock the
-                                                            account. If not specified,
-                                                            you will be prompted for a
-                                                            password.
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --duration=<value>
+      Duration in seconds to leave the account unlocked. Unlocks until the node exits by
+      default.
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --password=<value>
+      Password used to unlock the account. If not specified, you will be prompted for a
+      password.
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Unlock an account address to send transactions or validate blocks
@@ -1163,6 +1823,16 @@ EXAMPLES
   unlock 0x5409ed021d9299bf6814279a6a1411a7e866a631
 
   unlock 0x5409ed021d9299bf6814279a6a1411a7e866a631 --duration 600
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/unlock.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/unlock.ts)_
@@ -1174,27 +1844,40 @@ Verify a proof-of-possession. See the "account:proof-of-possession" command for 
 ```
 USAGE
   $ celocli account:verify-proof-of-possession --signer 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --signature 0x [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --signature 0x [-k <value> |
+    --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Address of the
-                                                            account that needs to prove
-                                                            possession of the signer
-                                                            key.
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --signature=0x                                            (required) Signature (a.k.a.
-                                                            proof-of-possession) of the
-                                                            signer key
-  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) Address of the
-                                                            signer key to verify proof
-                                                            of possession.
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the account that needs to prove possession of the signer key.
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --signature=0x
+      (required) Signature (a.k.a. proof-of-possession) of the signer key
+
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the signer key to verify proof of possession.
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Verify a proof-of-possession. See the "account:proof-of-possession" command for more
@@ -1202,6 +1885,16 @@ DESCRIPTION
 
 EXAMPLES
   verify-proof-of-possession --account 0x199eDF79ABCa29A2Fa4014882d3C13dC191A5B58 --signer 0x0EdeDF7B1287f07db348997663EeEb283D70aBE7 --signature 0x1c5efaa1f7ca6484d49ccce76217e2fba0552c0b23462cff7ba646473bc2717ffc4ce45be89bd5be9b5d23305e87fc2896808467c4081d9524a84c01b89ec91ca3
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/account/verify-proof-of-possession.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/account/verify-proof-of-possession.ts)_

--- a/docs/command-line-interface/config.md
+++ b/docs/command-line-interface/config.md
@@ -12,20 +12,43 @@ Output network node configuration
 
 ```
 USAGE
-  $ celocli config:get [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli config:get [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Output network node configuration
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/config/get.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/config/get.ts)_
@@ -36,12 +59,16 @@ Configure running node information for propagating transactions to network
 
 ```
 USAGE
-  $ celocli config:set [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli config:set [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
   -n, --node=<value>
-      URL of the node to run commands against (defaults to 'http://localhost:8545')
+      URL of the node to run commands against or an alias
 
   --gasCurrency=0x1234567890123456789012345678901234567890
       Use a specific gas currency for transaction fees (defaults to CELO if no gas
@@ -49,6 +76,13 @@ FLAGS
 
   --globalHelp
       View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Configure running node information for propagating transactions to network
@@ -69,6 +103,16 @@ EXAMPLES
   set --node ws://localhost:2500
 
   set --node <geth-location>/geth.ipc
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/config/set.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/config/set.ts)_

--- a/docs/command-line-interface/dkg.md
+++ b/docs/command-line-interface/dkg.md
@@ -18,26 +18,52 @@ Allowlist an address in the DKG
 USAGE
   $ celocli dkg:allowlist --participantAddress <value> --address
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --from
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) DKG Contract
-                                                            Address
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            sender
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --participantAddress=<value>                              (required) Address of the
-                                                            participant to allowlist
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) DKG Contract Address
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the sender
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --participantAddress=<value>
+      (required) Address of the participant to allowlist
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Allowlist an address in the DKG
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/dkg/allowlist.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/dkg/allowlist.ts)_
@@ -49,26 +75,52 @@ Deploys the DKG smart contract
 ```
 USAGE
   $ celocli dkg:deploy --phaseDuration <value> --threshold <value> --from
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            sender
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --phaseDuration=<value>                                   (required) Duration of each
-                                                            DKG phase in blocks
-  --threshold=<value>                                       (required) The threshold to
-                                                            use for the DKG
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the sender
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --phaseDuration=<value>
+      (required) Duration of each DKG phase in blocks
+
+  --threshold=<value>
+      (required) The threshold to use for the DKG
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Deploys the DKG smart contract
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/dkg/deploy.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/dkg/deploy.ts)_
@@ -81,27 +133,50 @@ Gets data from the contract to run the next phase
 USAGE
   $ celocli dkg:get --method
     shares|responses|justifications|participants|phase|group --address
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) DKG Contract
-                                                            Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --method=<option>                                         (required) Getter method to
-                                                            call
-                                                            <options: shares|responses|j
-                                                            ustifications|participants|p
-                                                            hase|group>
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) DKG Contract Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --method=<option>
+      (required) Getter method to call
+      <options: shares|responses|justifications|participants|phase|group>
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Gets data from the contract to run the next phase
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/dkg/get.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/dkg/get.ts)_
@@ -114,26 +189,52 @@ Publishes data for each phase of the DKG
 USAGE
   $ celocli dkg:publish --data <value> --address
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --from
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) DKG Contract
-                                                            Address
-  --data=<value>                                            (required) Path to the data
-                                                            being published
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            sender
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) DKG Contract Address
+
+  --data=<value>
+      (required) Path to the data being published
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the sender
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Publishes data for each phase of the DKG
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/dkg/publish.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/dkg/publish.ts)_
@@ -146,25 +247,52 @@ Register a public key in the DKG
 USAGE
   $ celocli dkg:register --blsKey <value> --address
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --from
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) DKG Contract
-                                                            Address
-  --blsKey=<value>                                          (required)
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            sender
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) DKG Contract Address
+
+  --blsKey=<value>
+      (required)
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the sender
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Register a public key in the DKG
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/dkg/register.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/dkg/register.ts)_
@@ -176,24 +304,49 @@ Starts the DKG
 ```
 USAGE
   $ celocli dkg:start --address 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) DKG Contract
-                                                            Address
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            sender
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) DKG Contract Address
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the sender
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Starts the DKG
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/dkg/start.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/dkg/start.ts)_

--- a/docs/command-line-interface/election.md
+++ b/docs/command-line-interface/election.md
@@ -17,27 +17,40 @@ Activate pending votes in validator elections to begin earning rewards. To earn 
 
 ```
 USAGE
-  $ celocli election:activate --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp] [--for
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--wait]
+  $ celocli election:activate --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--for 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--wait]
 
 FLAGS
-  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d          Optional: use this to
-                                                            activate votes for another
-                                                            address
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address sending
-                                                            transaction (and voter's
-                                                            address if --for not
-                                                            specified)
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --wait                                                    Wait until all pending votes
-                                                            can be activated
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Optional: use this to activate votes for another address
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address sending transaction (and voter's address if --for not specified)
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --wait
+      Wait until all pending votes can be activated
 
 DESCRIPTION
   Activate pending votes in validator elections to begin earning rewards. To earn
@@ -50,6 +63,16 @@ EXAMPLES
   activate --from 0x4443d0349e8b3075cba511a0a87796597602a0f1 --for 0x5409ed021d9299bf6814279a6a1411a7e866a631
 
   activate --from 0x4443d0349e8b3075cba511a0a87796597602a0f1 --wait
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/election/activate.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/election/activate.ts)_
@@ -60,12 +83,18 @@ Outputs the set of validators currently participating in BFT to create blocks. A
 
 ```
 USAGE
-  $ celocli election:current [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--valset] [--columns
-    <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ celocli election:current [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--valset] [--columns <value> | -x] [--filter <value>] [--no-header |
+    [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -85,6 +114,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -98,6 +131,9 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
   --valset
       Show currently used signers from valset (by default the authorized validator signers
       are shown). Useful for checking if keys have been rotated.
@@ -105,6 +141,16 @@ FLAGS
 DESCRIPTION
   Outputs the set of validators currently participating in BFT to create blocks. An
   election is run to select the validator set at the end of every epoch.
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/election/current.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/election/current.ts)_
@@ -115,12 +161,18 @@ Prints the list of validator groups, the number of votes they have received, the
 
 ```
 USAGE
-  $ celocli election:list [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli election:list [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
+    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -140,6 +192,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -153,6 +209,9 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   Prints the list of validator groups, the number of votes they have received, the
   number of additional votes they are able to receive, and whether or not they are
@@ -160,6 +219,16 @@ DESCRIPTION
 
 EXAMPLES
   list
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/election/list.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/election/list.ts)_
@@ -171,28 +240,55 @@ Revoke votes for a Validator Group in validator elections.
 ```
 USAGE
   $ celocli election:revoke --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --for
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
+    | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d          (required) ValidatorGroup's
-                                                            address
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Voter's address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --value=<value>                                           (required) Value of votes to
-                                                            revoke
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) ValidatorGroup's address
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Voter's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=<value>
+      (required) Value of votes to revoke
 
 DESCRIPTION
   Revoke votes for a Validator Group in validator elections.
 
 EXAMPLES
   revoke --from 0x4443d0349e8b3075cba511a0a87796597602a0f1 --for 0x932fee04521f5fcb21949041bf161917da3f588b, --value 1000000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/election/revoke.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/election/revoke.ts)_
@@ -203,12 +299,18 @@ Runs a "mock" election and prints out the validators that would be elected if th
 
 ```
 USAGE
-  $ celocli election:run [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli election:run [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
+    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -228,6 +330,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -241,9 +347,22 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   Runs a "mock" election and prints out the validators that would be elected if the
   epoch ended right now.
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/election/run.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/election/run.ts)_
@@ -254,26 +373,39 @@ Show election information about a voter or registered Validator Group
 
 ```
 USAGE
-  $ celocli election:show ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--voter | --group]
+  $ celocli election:show ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp] [--voter | --group]
 
 ARGUMENTS
   ARG1  Voter or Validator Groups's address
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --group                                                   Show information about a
-                                                            group running in Validator
-                                                            elections
-  --voter                                                   Show information about an
-                                                            account voting in Validator
-                                                            elections
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --group
+      Show information about a group running in Validator elections
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --voter
+      Show information about an account voting in Validator elections
 
 DESCRIPTION
   Show election information about a voter or registered Validator Group
@@ -282,6 +414,16 @@ EXAMPLES
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3 --voter
 
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3 --group
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/election/show.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/election/show.ts)_
@@ -293,28 +435,55 @@ Vote for a Validator Group in validator elections.
 ```
 USAGE
   $ celocli election:vote --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --for
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
+    | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d          (required) ValidatorGroup's
-                                                            address
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Voter's address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --value=<value>                                           (required) Amount of Gold
-                                                            used to vote for group
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) ValidatorGroup's address
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Voter's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=<value>
+      (required) Amount of Gold used to vote for group
 
 DESCRIPTION
   Vote for a Validator Group in validator elections.
 
 EXAMPLES
   vote --from 0x4443d0349e8b3075cba511a0a87796597602a0f1 --for 0x932fee04521f5fcb21949041bf161917da3f588b, --value 1000000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/election/vote.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/election/vote.ts)_

--- a/docs/command-line-interface/epochs.md
+++ b/docs/command-line-interface/epochs.md
@@ -13,24 +13,50 @@ Finishes next epoch process.
 
 ```
 USAGE
-  $ celocli epochs:finish --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli epochs:finish --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Finishes next epoch process.
 
 EXAMPLES
   finish --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/epochs/finish.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/epochs/finish.ts)_
@@ -41,24 +67,50 @@ Starts next epoch process.
 
 ```
 USAGE
-  $ celocli epochs:start --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli epochs:start --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Starts next epoch process.
 
 EXAMPLES
   start --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/epochs/start.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/epochs/start.ts)_
@@ -69,24 +121,50 @@ Finishes current epoch and starts a new one.
 
 ```
 USAGE
-  $ celocli epochs:switch --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli epochs:switch --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Finishes current epoch and starts a new one.
 
 EXAMPLES
   switch --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/epochs/switch.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/epochs/switch.ts)_

--- a/docs/command-line-interface/exchange.md
+++ b/docs/command-line-interface/exchange.md
@@ -17,31 +17,44 @@ Exchange CELO for StableTokens via Mento. (Note: this is the equivalent of the o
 ```
 USAGE
   $ celocli exchange:celo --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
-    10000000000000000000000 [--gasCurrency 0x1234567890123456789012345678901234567890]
+    10000000000000000000000 [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp] [--forAtLeast 10000000000000000000000] [--stableToken
     cUSD|cusd|cEUR|ceur|cREAL|creal]
 
 FLAGS
-  --forAtLeast=10000000000000000000000                      [default: 0] Optional, the
-                                                            minimum value of
-                                                            StableTokens to receive in
-                                                            return
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
-                                                            CELO to exchange
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --stableToken=<option>                                    [default: cusd] Name of the
-                                                            stable to receive
-                                                            <options: cUSD|cusd|cEUR|ceu
-                                                            r|cREAL|creal>
-  --value=10000000000000000000000                           (required) The value of CELO
-                                                            to exchange for a
-                                                            StableToken
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --forAtLeast=10000000000000000000000
+      [default: 0] Optional, the minimum value of StableTokens to receive in return
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) The address with CELO to exchange
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --stableToken=<option>
+      [default: cusd] Name of the stable to receive
+      <options: cUSD|cusd|cEUR|ceur|cREAL|creal>
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=10000000000000000000000
+      (required) The value of CELO to exchange for a StableToken
 
 DESCRIPTION
   Exchange CELO for StableTokens via Mento. (Note: this is the equivalent of the old
@@ -51,6 +64,16 @@ EXAMPLES
   celo --value 5000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
 
   celo --value 5000000000000 --forAtLeast 100000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --stableToken cStableTokenSymbol
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/exchange/celo.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/exchange/celo.ts)_
@@ -62,24 +85,39 @@ Exchange Celo Dollars for CELO via Mento
 ```
 USAGE
   $ celocli exchange:dollars --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
-    10000000000000000000000 [--gasCurrency 0x1234567890123456789012345678901234567890]
+    10000000000000000000000 [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp] [--forAtLeast 10000000000000000000000]
 
 FLAGS
-  --forAtLeast=10000000000000000000000                      [default: 0] Optional, the
-                                                            minimum value of CELO to
-                                                            receive in return
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
-                                                            Celo Dollars to exchange
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --value=10000000000000000000000                           (required) The value of Celo
-                                                            Dollars to exchange for CELO
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --forAtLeast=10000000000000000000000
+      [default: 0] Optional, the minimum value of CELO to receive in return
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) The address with Celo Dollars to exchange
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=10000000000000000000000
+      (required) The value of Celo Dollars to exchange for CELO
 
 DESCRIPTION
   Exchange Celo Dollars for CELO via Mento
@@ -88,6 +126,16 @@ EXAMPLES
   dollars --value 10000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
 
   dollars --value 10000000000000 --forAtLeast 50000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/exchange/dollars.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/exchange/dollars.ts)_
@@ -99,24 +147,39 @@ Exchange Celo Euros for CELO via Mento
 ```
 USAGE
   $ celocli exchange:euros --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
-    10000000000000000000000 [--gasCurrency 0x1234567890123456789012345678901234567890]
+    10000000000000000000000 [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp] [--forAtLeast 10000000000000000000000]
 
 FLAGS
-  --forAtLeast=10000000000000000000000                      [default: 0] Optional, the
-                                                            minimum value of CELO to
-                                                            receive in return
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
-                                                            Celo Euros to exchange
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --value=10000000000000000000000                           (required) The value of Celo
-                                                            Euros to exchange for CELO
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --forAtLeast=10000000000000000000000
+      [default: 0] Optional, the minimum value of CELO to receive in return
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) The address with Celo Euros to exchange
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=10000000000000000000000
+      (required) The value of Celo Euros to exchange for CELO
 
 DESCRIPTION
   Exchange Celo Euros for CELO via Mento
@@ -125,6 +188,16 @@ EXAMPLES
   euros --value 10000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
 
   euros --value 10000000000000 --forAtLeast 50000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/exchange/euros.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/exchange/euros.ts)_
@@ -136,26 +209,39 @@ Exchange Celo Brazilian Real (cREAL) for CELO via Mento
 ```
 USAGE
   $ celocli exchange:reals --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
-    10000000000000000000000 [--gasCurrency 0x1234567890123456789012345678901234567890]
+    10000000000000000000000 [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp] [--forAtLeast 10000000000000000000000]
 
 FLAGS
-  --forAtLeast=10000000000000000000000                      [default: 0] Optional, the
-                                                            minimum value of CELO to
-                                                            receive in return
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
-                                                            Celo Brazilian Real to
-                                                            exchange
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --value=10000000000000000000000                           (required) The value of Celo
-                                                            Brazilian Real to exchange
-                                                            for CELO
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --forAtLeast=10000000000000000000000
+      [default: 0] Optional, the minimum value of CELO to receive in return
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) The address with Celo Brazilian Real to exchange
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=10000000000000000000000
+      (required) The value of Celo Brazilian Real to exchange for CELO
 
 DESCRIPTION
   Exchange Celo Brazilian Real (cREAL) for CELO via Mento
@@ -164,6 +250,16 @@ EXAMPLES
   reals --value 10000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
 
   reals --value 10000000000000 --forAtLeast 50000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/exchange/reals.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/exchange/reals.ts)_
@@ -174,27 +270,50 @@ Show the current exchange rates offered by the Broker
 
 ```
 USAGE
-  $ celocli exchange:show [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--amount <value>]
+  $ celocli exchange:show [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--amount <value>]
 
 FLAGS
-  --amount=<value>                                          [default:
-                                                            1000000000000000000] Amount
-                                                            of the token being exchanged
-                                                            to report rates for
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --amount=<value>
+      [default: 1000000000000000000] Amount of the token being exchanged to report rates
+      for
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Show the current exchange rates offered by the Broker
 
 EXAMPLES
   list
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/exchange/show.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/exchange/show.ts)_
@@ -206,30 +325,44 @@ Exchange Stable Token for CELO via Mento
 ```
 USAGE
   $ celocli exchange:stable --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
-    10000000000000000000000 [--gasCurrency 0x1234567890123456789012345678901234567890]
+    10000000000000000000000 [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp] [--forAtLeast 10000000000000000000000] [--stableToken
     cUSD|cusd|cEUR|ceur|cREAL|creal]
 
 FLAGS
-  --forAtLeast=10000000000000000000000                      [default: 0] Optional, the
-                                                            minimum value of CELO to
-                                                            receive in return
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
-                                                            the Stable Token to exchange
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --stableToken=<option>                                    Name of the stable token to
-                                                            be transferred
-                                                            <options: cUSD|cusd|cEUR|ceu
-                                                            r|cREAL|creal>
-  --value=10000000000000000000000                           (required) The value of
-                                                            Stable Tokens to exchange
-                                                            for CELO
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --forAtLeast=10000000000000000000000
+      [default: 0] Optional, the minimum value of CELO to receive in return
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) The address with the Stable Token to exchange
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --stableToken=<option>
+      Name of the stable token to be transferred
+      <options: cUSD|cusd|cEUR|ceur|cREAL|creal>
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=10000000000000000000000
+      (required) The value of Stable Tokens to exchange for CELO
 
 DESCRIPTION
   Exchange Stable Token for CELO via Mento
@@ -238,6 +371,16 @@ EXAMPLES
   stable --value 10000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --stableToken cStableTokenSymbol
 
   stable --value 10000000000000 --forAtLeast 50000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --stableToken cStableTokenSymbol
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/exchange/stable.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/exchange/stable.ts)_

--- a/docs/command-line-interface/governance.md
+++ b/docs/command-line-interface/governance.md
@@ -31,32 +31,51 @@ Approve a dequeued governance proposal (or hotfix)
 
 ```
 USAGE
-  $ celocli governance:approvehotfix --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
-    [--proposalID <value> | --hotfix <value>] [--useMultiSig | --useSafe] [--type
-    approver|securityCouncil ]
+  $ celocli governance:approvehotfix --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--proposalID <value> | --hotfix <value>] [--useMultiSig | --useSafe]
+    [--type approver|securityCouncil ]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Approver's
-                                                            address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --hotfix=<value>                                          Hash of hotfix proposal
-  --proposalID=<value>                                      UUID of proposal to approve
-  --type=<option>                                           Determines which type of
-                                                            hotfix approval (approver or
-                                                            security council) to use.
-                                                            <options:
-                                                            approver|securityCouncil>
-  --useMultiSig                                             True means the request will
-                                                            be sent through multisig.
-  --useSafe                                                 True means the request will
-                                                            be sent through safe.
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Approver's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --hotfix=<value>
+      Hash of hotfix proposal
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --proposalID=<value>
+      UUID of proposal to approve
+
+  --type=<option>
+      Determines which type of hotfix approval (approver or security council) to use.
+      <options: approver|securityCouncil>
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --useMultiSig
+      True means the request will be sent through multisig.
+
+  --useSafe
+      True means the request will be sent through safe.
 
 DESCRIPTION
   Approve a dequeued governance proposal (or hotfix)
@@ -73,6 +92,16 @@ EXAMPLES
   approve --hotfix 0xfcfc98ec3db7c56f0866a7149e811bf7f9e30c9d40008b0def497fcc6fe90649 --from 0xCc50EaC48bA71343dC76852FAE1892c6Bd2971DA --useMultiSig
 
   approve --hotfix 0xfcfc98ec3db7c56f0866a7149e811bf7f9e30c9d40008b0def497fcc6fe90649 --from 0xCc50EaC48bA71343dC76852FAE1892c6Bd2971DA --useMultiSig --type securityCouncil
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 ## `celocli governance:build-proposal`
@@ -81,34 +110,56 @@ Interactively build a governance proposal
 
 ```
 USAGE
-  $ celocli governance:build-proposal [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--output <value>]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:build-proposal [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--output <value>] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
-  --afterExecutingID=<value>                                Governance proposal
-                                                            identifier which will be
-                                                            executed prior to proposal
-                                                            being built
-  --afterExecutingProposal=<value>                          Path to proposal which will
-                                                            be executed prior to
-                                                            proposal being built
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --output=<value>                                          [default:
-                                                            proposalTransactions.json]
-                                                            Path to output
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --afterExecutingID=<value>
+      Governance proposal identifier which will be executed prior to proposal being built
+
+  --afterExecutingProposal=<value>
+      Path to proposal which will be executed prior to proposal being built
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --output=<value>
+      [default: proposalTransactions.json] Path to output
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Interactively build a governance proposal
 
 EXAMPLES
   build-proposal --output ./transactions.json
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/build-proposal.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/build-proposal.ts)_
@@ -119,24 +170,50 @@ Try to dequeue governance proposal
 
 ```
 USAGE
-  $ celocli governance:dequeue --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli governance:dequeue --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) From address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) From address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Try to dequeue governance proposal
 
 EXAMPLES
   dequeue --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/dequeue.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/dequeue.ts)_
@@ -148,27 +225,52 @@ Execute a passing governance proposal
 ```
 USAGE
   $ celocli governance:execute --proposalID <value> --from
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Executor's
-                                                            address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --proposalID=<value>                                      (required) UUID of proposal
-                                                            to execute
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Executor's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --proposalID=<value>
+      (required) UUID of proposal to execute
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Execute a passing governance proposal
 
 EXAMPLES
   execute --proposalID 99 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/execute.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/execute.ts)_
@@ -180,29 +282,55 @@ Execute a governance hotfix prepared for the current epoch
 ```
 USAGE
   $ celocli governance:executehotfix --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --jsonTransactions <value> --salt <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    --jsonTransactions <value> --salt <value> [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Executors's
-                                                            address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --jsonTransactions=<value>                                (required) Path to json
-                                                            transactions
-  --salt=<value>                                            (required) Secret salt
-                                                            associated with hotfix
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Executors's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --jsonTransactions=<value>
+      (required) Path to json transactions
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --salt=<value>
+      (required) Secret salt associated with hotfix
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Execute a governance hotfix prepared for the current epoch
 
 EXAMPLES
   executehotfix --jsonTransactions ./transactions.json --salt 0x614dccb5ac13cba47c2430bdee7829bb8c8f3603a8ace22e7680d317b39e3658 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/executehotfix.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/executehotfix.ts)_
@@ -213,28 +341,56 @@ Hash a governance hotfix specified by JSON and a salt
 
 ```
 USAGE
-  $ celocli governance:hashhotfix --jsonTransactions <value> --salt <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--force]
+  $ celocli governance:hashhotfix --jsonTransactions <value> --salt <value> [-k <value> |
+    --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--force]
 
 FLAGS
-  --force                                                   Skip execution check
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --jsonTransactions=<value>                                (required) Path to json
-                                                            transactions of the hotfix
-  --salt=<value>                                            (required) Secret salt
-                                                            associated with hotfix
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --force
+      Skip execution check
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --jsonTransactions=<value>
+      (required) Path to json transactions of the hotfix
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --salt=<value>
+      (required) Secret salt associated with hotfix
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Hash a governance hotfix specified by JSON and a salt
 
 EXAMPLES
   hashhotfix --jsonTransactions ./transactions.json --salt 0x614dccb5ac13cba47c2430bdee7829bb8c8f3603a8ace22e7680d317b39e3658
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/hashhotfix.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/hashhotfix.ts)_
@@ -245,12 +401,18 @@ List live governance proposals (queued and ongoing)
 
 ```
 USAGE
-  $ celocli governance:list [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli governance:list [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
+    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -270,6 +432,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -283,11 +449,24 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   List live governance proposals (queued and ongoing)
 
 EXAMPLES
   list
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/list.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/list.ts)_
@@ -299,26 +478,52 @@ Prepare a governance hotfix for execution in the current epoch
 ```
 USAGE
   $ celocli governance:preparehotfix --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --hash
-    <value> [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+    <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Preparer's
-                                                            address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --hash=<value>                                            (required) Hash of hotfix
-                                                            transactions
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Preparer's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --hash=<value>
+      (required) Hash of hotfix transactions
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Prepare a governance hotfix for execution in the current epoch
 
 EXAMPLES
   preparehotfix --hash 0x614dccb5ac13cba47c2430bdee7829bb8c8f3603a8ace22e7680d317b39e3658 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/preparehotfix.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/preparehotfix.ts)_
@@ -330,41 +535,62 @@ Submit a governance proposal
 ```
 USAGE
   $ celocli governance:propose --jsonTransactions <value> --deposit <value> --from
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --descriptionURL <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--for
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --useMultiSig] [--force] [--noInfo]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --descriptionURL <value> [-k <value> |
+    --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--for 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --useMultiSig]
+    [--force] [--noInfo] [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --afterExecutingID=<value>                                Governance proposal
-                                                            identifier which will be
-                                                            executed prior to proposal
-  --afterExecutingProposal=<value>                          Path to proposal which will
-                                                            be executed prior to
-                                                            proposal
-  --deposit=<value>                                         (required) Amount of Celo to
-                                                            attach to proposal
-  --descriptionURL=<value>                                  (required) A URL where
-                                                            further information about
-                                                            the proposal can be viewed
-  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d          Address of the multi-sig
-                                                            contract
-  --force                                                   Skip execution check
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Proposer's
-                                                            address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --jsonTransactions=<value>                                (required) Path to json
-                                                            transactions
-  --noInfo                                                  Skip printing the proposal
-                                                            info
-  --useMultiSig                                             True means the request will
-                                                            be sent through multisig.
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --afterExecutingID=<value>
+      Governance proposal identifier which will be executed prior to proposal
+
+  --afterExecutingProposal=<value>
+      Path to proposal which will be executed prior to proposal
+
+  --deposit=<value>
+      (required) Amount of Celo to attach to proposal
+
+  --descriptionURL=<value>
+      (required) A URL where further information about the proposal can be viewed
+
+  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Address of the multi-sig contract
+
+  --force
+      Skip execution check
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Proposer's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --jsonTransactions=<value>
+      (required) Path to json transactions
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --noInfo
+      Skip printing the proposal info
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --useMultiSig
+      True means the request will be sent through multisig.
 
 DESCRIPTION
   Submit a governance proposal
@@ -373,6 +599,16 @@ EXAMPLES
   propose --jsonTransactions ./transactions.json --deposit 10000e18 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631 --descriptionURL https://gist.github.com/yorhodes/46430eacb8ed2f73f7bf79bef9d58a33
 
   propose --jsonTransactions ./transactions.json --deposit 10000e18 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631  --useMultiSig --for 0x6c3dDFB1A9e73B5F49eDD46624F4954Bf66CAe93 --descriptionURL https://gist.github.com/yorhodes/46430eacb8ed2f73f7bf79bef9d58a33
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/propose.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/propose.ts)_
@@ -383,24 +619,50 @@ Revoke upvotes for queued governance proposals
 
 ```
 USAGE
-  $ celocli governance:revokeupvote --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli governance:revokeupvote --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Upvoter's address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Upvoter's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Revoke upvotes for queued governance proposals
 
 EXAMPLES
   revokeupvote --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/revokeupvote.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/revokeupvote.ts)_
@@ -411,45 +673,65 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:show [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--raw]
-    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
-    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:show [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--raw] [--jsonTransactions <value>] [--notwhitelisted]
+    [--whitelisters | --nonwhitelisters |  | [--proposalID <value> | --account <value> |
+    --hotfix <value>]] [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --account=<value>                                         Address of account or voter
-  --afterExecutingID=<value>                                Governance proposal
-                                                            identifier which will be
-                                                            executed prior to proposal
-  --afterExecutingProposal=<value>                          Path to proposal which will
-                                                            be executed prior to
-                                                            proposal
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --hotfix=<value>                                          Hash of hotfix proposal
-  --jsonTransactions=<value>                                Output proposal JSON to
-                                                            provided file
-  --nonwhitelisters                                         If set, displays validators
-                                                            that have not whitelisted
-                                                            the hotfix.(will be removed
-                                                            when L2 launches
-  --notwhitelisted                                          List validators who have not
-                                                            whitelisted the specified
-                                                            hotfix (will be removed when
-                                                            L2 launches
-  --proposalID=<value>                                      UUID of proposal to view
-  --raw                                                     Display proposal in raw
-                                                            bytes format
-  --whitelisters                                            If set, displays validators
-                                                            that have whitelisted the
-                                                            hotfix.(will be removed when
-                                                            L2 launches
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=<value>
+      Address of account or voter
+
+  --afterExecutingID=<value>
+      Governance proposal identifier which will be executed prior to proposal
+
+  --afterExecutingProposal=<value>
+      Path to proposal which will be executed prior to proposal
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --hotfix=<value>
+      Hash of hotfix proposal
+
+  --jsonTransactions=<value>
+      Output proposal JSON to provided file
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --nonwhitelisters
+      If set, displays validators that have not whitelisted the hotfix.(will be removed
+      when L2 launches
+
+  --notwhitelisted
+      List validators who have not whitelisted the specified hotfix (will be removed when
+      L2 launches
+
+  --proposalID=<value>
+      UUID of proposal to view
+
+  --raw
+      Display proposal in raw bytes format
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --whitelisters
+      If set, displays validators that have whitelisted the hotfix.(will be removed when
+      L2 launches
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -474,6 +756,16 @@ EXAMPLES
   show --hotfix 0x614dccb5ac13cba47c2430bdee7829bb8c8f3603a8ace22e7680d317b39e3658 --nonwhitelisters
 
   show --account 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/show.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/show.ts)_
@@ -484,45 +776,65 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:showaccount [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--raw]
-    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
-    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:showaccount [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--raw] [--jsonTransactions <value>] [--notwhitelisted]
+    [--whitelisters | --nonwhitelisters |  | [--proposalID <value> | --account <value> |
+    --hotfix <value>]] [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --account=<value>                                         Address of account or voter
-  --afterExecutingID=<value>                                Governance proposal
-                                                            identifier which will be
-                                                            executed prior to proposal
-  --afterExecutingProposal=<value>                          Path to proposal which will
-                                                            be executed prior to
-                                                            proposal
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --hotfix=<value>                                          Hash of hotfix proposal
-  --jsonTransactions=<value>                                Output proposal JSON to
-                                                            provided file
-  --nonwhitelisters                                         If set, displays validators
-                                                            that have not whitelisted
-                                                            the hotfix.(will be removed
-                                                            when L2 launches
-  --notwhitelisted                                          List validators who have not
-                                                            whitelisted the specified
-                                                            hotfix (will be removed when
-                                                            L2 launches
-  --proposalID=<value>                                      UUID of proposal to view
-  --raw                                                     Display proposal in raw
-                                                            bytes format
-  --whitelisters                                            If set, displays validators
-                                                            that have whitelisted the
-                                                            hotfix.(will be removed when
-                                                            L2 launches
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=<value>
+      Address of account or voter
+
+  --afterExecutingID=<value>
+      Governance proposal identifier which will be executed prior to proposal
+
+  --afterExecutingProposal=<value>
+      Path to proposal which will be executed prior to proposal
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --hotfix=<value>
+      Hash of hotfix proposal
+
+  --jsonTransactions=<value>
+      Output proposal JSON to provided file
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --nonwhitelisters
+      If set, displays validators that have not whitelisted the hotfix.(will be removed
+      when L2 launches
+
+  --notwhitelisted
+      List validators who have not whitelisted the specified hotfix (will be removed when
+      L2 launches
+
+  --proposalID=<value>
+      UUID of proposal to view
+
+  --raw
+      Display proposal in raw bytes format
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --whitelisters
+      If set, displays validators that have whitelisted the hotfix.(will be removed when
+      L2 launches
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -547,6 +859,16 @@ EXAMPLES
   show --hotfix 0x614dccb5ac13cba47c2430bdee7829bb8c8f3603a8ace22e7680d317b39e3658 --nonwhitelisters
 
   show --account 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 ## `celocli governance:showhotfix`
@@ -555,45 +877,65 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:showhotfix [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--raw]
-    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
-    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:showhotfix [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--raw] [--jsonTransactions <value>] [--notwhitelisted]
+    [--whitelisters | --nonwhitelisters |  | [--proposalID <value> | --account <value> |
+    --hotfix <value>]] [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --account=<value>                                         Address of account or voter
-  --afterExecutingID=<value>                                Governance proposal
-                                                            identifier which will be
-                                                            executed prior to proposal
-  --afterExecutingProposal=<value>                          Path to proposal which will
-                                                            be executed prior to
-                                                            proposal
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --hotfix=<value>                                          Hash of hotfix proposal
-  --jsonTransactions=<value>                                Output proposal JSON to
-                                                            provided file
-  --nonwhitelisters                                         If set, displays validators
-                                                            that have not whitelisted
-                                                            the hotfix.(will be removed
-                                                            when L2 launches
-  --notwhitelisted                                          List validators who have not
-                                                            whitelisted the specified
-                                                            hotfix (will be removed when
-                                                            L2 launches
-  --proposalID=<value>                                      UUID of proposal to view
-  --raw                                                     Display proposal in raw
-                                                            bytes format
-  --whitelisters                                            If set, displays validators
-                                                            that have whitelisted the
-                                                            hotfix.(will be removed when
-                                                            L2 launches
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=<value>
+      Address of account or voter
+
+  --afterExecutingID=<value>
+      Governance proposal identifier which will be executed prior to proposal
+
+  --afterExecutingProposal=<value>
+      Path to proposal which will be executed prior to proposal
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --hotfix=<value>
+      Hash of hotfix proposal
+
+  --jsonTransactions=<value>
+      Output proposal JSON to provided file
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --nonwhitelisters
+      If set, displays validators that have not whitelisted the hotfix.(will be removed
+      when L2 launches
+
+  --notwhitelisted
+      List validators who have not whitelisted the specified hotfix (will be removed when
+      L2 launches
+
+  --proposalID=<value>
+      UUID of proposal to view
+
+  --raw
+      Display proposal in raw bytes format
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --whitelisters
+      If set, displays validators that have whitelisted the hotfix.(will be removed when
+      L2 launches
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -618,6 +960,16 @@ EXAMPLES
   show --hotfix 0x614dccb5ac13cba47c2430bdee7829bb8c8f3603a8ace22e7680d317b39e3658 --nonwhitelisters
 
   show --account 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 ## `celocli governance:upvote`
@@ -627,26 +979,52 @@ Upvote a queued governance proposal
 ```
 USAGE
   $ celocli governance:upvote --proposalID <value> --from
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Upvoter's address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --proposalID=<value>                                      (required) UUID of proposal
-                                                            to upvote
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Upvoter's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --proposalID=<value>
+      (required) UUID of proposal to upvote
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Upvote a queued governance proposal
 
 EXAMPLES
   upvote --proposalID 99 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/upvote.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/upvote.ts)_
@@ -657,45 +1035,65 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:view [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--raw]
-    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
-    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:view [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--raw] [--jsonTransactions <value>] [--notwhitelisted]
+    [--whitelisters | --nonwhitelisters |  | [--proposalID <value> | --account <value> |
+    --hotfix <value>]] [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --account=<value>                                         Address of account or voter
-  --afterExecutingID=<value>                                Governance proposal
-                                                            identifier which will be
-                                                            executed prior to proposal
-  --afterExecutingProposal=<value>                          Path to proposal which will
-                                                            be executed prior to
-                                                            proposal
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --hotfix=<value>                                          Hash of hotfix proposal
-  --jsonTransactions=<value>                                Output proposal JSON to
-                                                            provided file
-  --nonwhitelisters                                         If set, displays validators
-                                                            that have not whitelisted
-                                                            the hotfix.(will be removed
-                                                            when L2 launches
-  --notwhitelisted                                          List validators who have not
-                                                            whitelisted the specified
-                                                            hotfix (will be removed when
-                                                            L2 launches
-  --proposalID=<value>                                      UUID of proposal to view
-  --raw                                                     Display proposal in raw
-                                                            bytes format
-  --whitelisters                                            If set, displays validators
-                                                            that have whitelisted the
-                                                            hotfix.(will be removed when
-                                                            L2 launches
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=<value>
+      Address of account or voter
+
+  --afterExecutingID=<value>
+      Governance proposal identifier which will be executed prior to proposal
+
+  --afterExecutingProposal=<value>
+      Path to proposal which will be executed prior to proposal
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --hotfix=<value>
+      Hash of hotfix proposal
+
+  --jsonTransactions=<value>
+      Output proposal JSON to provided file
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --nonwhitelisters
+      If set, displays validators that have not whitelisted the hotfix.(will be removed
+      when L2 launches
+
+  --notwhitelisted
+      List validators who have not whitelisted the specified hotfix (will be removed when
+      L2 launches
+
+  --proposalID=<value>
+      UUID of proposal to view
+
+  --raw
+      Display proposal in raw bytes format
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --whitelisters
+      If set, displays validators that have whitelisted the hotfix.(will be removed when
+      L2 launches
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -720,6 +1118,16 @@ EXAMPLES
   show --hotfix 0x614dccb5ac13cba47c2430bdee7829bb8c8f3603a8ace22e7680d317b39e3658 --nonwhitelisters
 
   show --account 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 ## `celocli governance:viewaccount`
@@ -728,45 +1136,65 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:viewaccount [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--raw]
-    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
-    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:viewaccount [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--raw] [--jsonTransactions <value>] [--notwhitelisted]
+    [--whitelisters | --nonwhitelisters |  | [--proposalID <value> | --account <value> |
+    --hotfix <value>]] [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --account=<value>                                         Address of account or voter
-  --afterExecutingID=<value>                                Governance proposal
-                                                            identifier which will be
-                                                            executed prior to proposal
-  --afterExecutingProposal=<value>                          Path to proposal which will
-                                                            be executed prior to
-                                                            proposal
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --hotfix=<value>                                          Hash of hotfix proposal
-  --jsonTransactions=<value>                                Output proposal JSON to
-                                                            provided file
-  --nonwhitelisters                                         If set, displays validators
-                                                            that have not whitelisted
-                                                            the hotfix.(will be removed
-                                                            when L2 launches
-  --notwhitelisted                                          List validators who have not
-                                                            whitelisted the specified
-                                                            hotfix (will be removed when
-                                                            L2 launches
-  --proposalID=<value>                                      UUID of proposal to view
-  --raw                                                     Display proposal in raw
-                                                            bytes format
-  --whitelisters                                            If set, displays validators
-                                                            that have whitelisted the
-                                                            hotfix.(will be removed when
-                                                            L2 launches
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=<value>
+      Address of account or voter
+
+  --afterExecutingID=<value>
+      Governance proposal identifier which will be executed prior to proposal
+
+  --afterExecutingProposal=<value>
+      Path to proposal which will be executed prior to proposal
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --hotfix=<value>
+      Hash of hotfix proposal
+
+  --jsonTransactions=<value>
+      Output proposal JSON to provided file
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --nonwhitelisters
+      If set, displays validators that have not whitelisted the hotfix.(will be removed
+      when L2 launches
+
+  --notwhitelisted
+      List validators who have not whitelisted the specified hotfix (will be removed when
+      L2 launches
+
+  --proposalID=<value>
+      UUID of proposal to view
+
+  --raw
+      Display proposal in raw bytes format
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --whitelisters
+      If set, displays validators that have whitelisted the hotfix.(will be removed when
+      L2 launches
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -791,6 +1219,16 @@ EXAMPLES
   show --hotfix 0x614dccb5ac13cba47c2430bdee7829bb8c8f3603a8ace22e7680d317b39e3658 --nonwhitelisters
 
   show --account 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 ## `celocli governance:viewhotfix`
@@ -799,45 +1237,65 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:viewhotfix [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--raw]
-    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
-    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:viewhotfix [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--raw] [--jsonTransactions <value>] [--notwhitelisted]
+    [--whitelisters | --nonwhitelisters |  | [--proposalID <value> | --account <value> |
+    --hotfix <value>]] [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
-  --account=<value>                                         Address of account or voter
-  --afterExecutingID=<value>                                Governance proposal
-                                                            identifier which will be
-                                                            executed prior to proposal
-  --afterExecutingProposal=<value>                          Path to proposal which will
-                                                            be executed prior to
-                                                            proposal
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --hotfix=<value>                                          Hash of hotfix proposal
-  --jsonTransactions=<value>                                Output proposal JSON to
-                                                            provided file
-  --nonwhitelisters                                         If set, displays validators
-                                                            that have not whitelisted
-                                                            the hotfix.(will be removed
-                                                            when L2 launches
-  --notwhitelisted                                          List validators who have not
-                                                            whitelisted the specified
-                                                            hotfix (will be removed when
-                                                            L2 launches
-  --proposalID=<value>                                      UUID of proposal to view
-  --raw                                                     Display proposal in raw
-                                                            bytes format
-  --whitelisters                                            If set, displays validators
-                                                            that have whitelisted the
-                                                            hotfix.(will be removed when
-                                                            L2 launches
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=<value>
+      Address of account or voter
+
+  --afterExecutingID=<value>
+      Governance proposal identifier which will be executed prior to proposal
+
+  --afterExecutingProposal=<value>
+      Path to proposal which will be executed prior to proposal
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --hotfix=<value>
+      Hash of hotfix proposal
+
+  --jsonTransactions=<value>
+      Output proposal JSON to provided file
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --nonwhitelisters
+      If set, displays validators that have not whitelisted the hotfix.(will be removed
+      when L2 launches
+
+  --notwhitelisted
+      List validators who have not whitelisted the specified hotfix (will be removed when
+      L2 launches
+
+  --proposalID=<value>
+      UUID of proposal to view
+
+  --raw
+      Display proposal in raw bytes format
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --whitelisters
+      If set, displays validators that have whitelisted the hotfix.(will be removed when
+      L2 launches
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -862,6 +1320,16 @@ EXAMPLES
   show --hotfix 0x614dccb5ac13cba47c2430bdee7829bb8c8f3603a8ace22e7680d317b39e3658 --nonwhitelisters
 
   show --account 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 ## `celocli governance:vote`
@@ -871,28 +1339,56 @@ Vote on an approved governance proposal
 ```
 USAGE
   $ celocli governance:vote --proposalID <value> --value Abstain|No|Yes --from
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Voter's address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --proposalID=<value>                                      (required) UUID of proposal
-                                                            to vote on
-  --value=<option>                                          (required) Vote
-                                                            <options: Abstain|No|Yes>
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Voter's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --proposalID=<value>
+      (required) UUID of proposal to vote on
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=<option>
+      (required) Vote
+      <options: Abstain|No|Yes>
 
 DESCRIPTION
   Vote on an approved governance proposal
 
 EXAMPLES
   vote --proposalID 99 --value Yes --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/vote.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/vote.ts)_
@@ -904,30 +1400,62 @@ Vote partially on an approved governance proposal
 ```
 USAGE
   $ celocli governance:votePartially --proposalID <value> --from
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--yes <value>] [--no
-    <value>] [--abstain <value>]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp] [--yes <value>] [--no <value>]
+    [--abstain <value>]
 
 FLAGS
-  --abstain=<value>                                         Abstain votes
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Voter's address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --no=<value>                                              No votes
-  --proposalID=<value>                                      (required) UUID of proposal
-                                                            to vote on
-  --yes=<value>                                             Yes votes
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --abstain=<value>
+      Abstain votes
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Voter's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --no=<value>
+      No votes
+
+  --proposalID=<value>
+      (required) UUID of proposal to vote on
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --yes=<value>
+      Yes votes
 
 DESCRIPTION
   Vote partially on an approved governance proposal
 
 EXAMPLES
   vote-partially --proposalID 99 --yes 10 --no 20 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/votePartially.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/votePartially.ts)_
@@ -939,26 +1467,52 @@ Whitelist a governance hotfix
 ```
 USAGE
   $ celocli governance:whitelisthotfix --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --hash
-    <value> [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+    <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Whitelister's
-                                                            address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --hash=<value>                                            (required) Hash of hotfix
-                                                            transactions
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Whitelister's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --hash=<value>
+      (required) Hash of hotfix transactions
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Whitelist a governance hotfix
 
 EXAMPLES
   whitelisthotfix --hash 0x614dccb5ac13cba47c2430bdee7829bb8c8f3603a8ace22e7680d317b39e3658 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/whitelisthotfix.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/whitelisthotfix.ts)_
@@ -969,25 +1523,50 @@ Withdraw refunded governance proposal deposits.
 
 ```
 USAGE
-  $ celocli governance:withdraw --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli governance:withdraw --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Proposer's
-                                                            address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Proposer's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Withdraw refunded governance proposal deposits.
 
 EXAMPLES
   withdraw --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/governance/withdraw.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/withdraw.ts)_

--- a/docs/command-line-interface/identity.md
+++ b/docs/command-line-interface/identity.md
@@ -11,11 +11,18 @@ Withdraw accumulated attestation rewards for a given currency
 
 ```
 USAGE
-  $ celocli identity:withdraw-attestation-rewards --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
-    [--tokenAddress 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
+  $ celocli identity:withdraw-attestation-rewards --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--tokenAddress 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address to withdraw from. Can be the attestation signer address or the
       underlying account address
@@ -27,11 +34,28 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --tokenAddress=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       The address of the token that will be withdrawn. Defaults to cUSD
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   Withdraw accumulated attestation rewards for a given currency
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/identity/withdraw-attestation-rewards.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/identity/withdraw-attestation-rewards.ts)_

--- a/docs/command-line-interface/lockedgold.md
+++ b/docs/command-line-interface/lockedgold.md
@@ -20,27 +20,56 @@ Delegate locked celo.
 ```
 USAGE
   $ celocli lockedgold:delegate --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --percent <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --percent <value> [-k <value> |
+    --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --percent=<value>                                         (required) 1-100% of locked
-                                                            celo to be delegated
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Account Address
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --percent=<value>
+      (required) 1-100% of locked celo to be delegated
+
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Delegate locked celo.
 
 EXAMPLES
   delegate --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --to 0xc0ffee254729296a45a3885639AC7E10F9d54979 --percent 100
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/lockedgold/delegate.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/lockedgold/delegate.ts)_
@@ -51,24 +80,50 @@ Delegate info about account.
 
 ```
 USAGE
-  $ celocli lockedgold:delegate-info --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli lockedgold:delegate-info --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --account=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Delegate info about account.
 
 EXAMPLES
   delegate-info --account 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/lockedgold/delegate-info.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/lockedgold/delegate-info.ts)_
@@ -80,25 +135,52 @@ Locks CELO to be used in governance and validator elections.
 ```
 USAGE
   $ celocli lockedgold:lock --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
-    <value> [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+    <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --value=<value>                                           (required) The unit amount
-                                                            of CELO
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=<value>
+      (required) The unit amount of CELO
 
 DESCRIPTION
   Locks CELO to be used in governance and validator elections.
 
 EXAMPLES
   lock --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --value 10000000000000000000000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/lockedgold/lock.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/lockedgold/lock.ts)_
@@ -109,23 +191,46 @@ Returns the maximum number of delegates allowed per account.
 
 ```
 USAGE
-  $ celocli lockedgold:max-delegatees-count [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli lockedgold:max-delegatees-count [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Returns the maximum number of delegates allowed per account.
 
 EXAMPLES
   max-delegatees-count
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/lockedgold/max-delegatees-count.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/lockedgold/max-delegatees-count.ts)_
@@ -137,28 +242,56 @@ Revoke delegated locked celo.
 ```
 USAGE
   $ celocli lockedgold:revoke-delegate --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --percent <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --percent <value> [-k <value> |
+    --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --percent=<value>                                         (required) 1-100% of locked
-                                                            celo to be revoked from
-                                                            currently delegated amount
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Account Address
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --percent=<value>
+      (required) 1-100% of locked celo to be revoked from currently delegated amount
+
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Revoke delegated locked celo.
 
 EXAMPLES
   revoke-delegate --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --to 0xc0ffee254729296a45a3885639AC7E10F9d54979 --percent 100
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/lockedgold/revoke-delegate.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/lockedgold/revoke-delegate.ts)_
@@ -169,17 +302,30 @@ Show Locked Gold information for a given account. This includes the total amount
 
 ```
 USAGE
-  $ celocli lockedgold:show ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli lockedgold:show ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp]
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Show Locked Gold information for a given account. This includes the total amount of
@@ -190,6 +336,16 @@ DESCRIPTION
 
 EXAMPLES
   show 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/lockedgold/show.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/lockedgold/show.ts)_
@@ -201,19 +357,36 @@ Unlocks CELO, which can be withdrawn after the unlocking period. Unlocked celo w
 ```
 USAGE
   $ celocli lockedgold:unlock --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
-    <value> [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+    <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --value=<value>                                           (required) The unit amount
-                                                            of CELO
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=<value>
+      (required) The unit amount of CELO
 
 DESCRIPTION
   Unlocks CELO, which can be withdrawn after the unlocking period. Unlocked celo will
@@ -222,6 +395,16 @@ DESCRIPTION
 
 EXAMPLES
   unlock --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --value 500000000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/lockedgold/unlock.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/lockedgold/unlock.ts)_
@@ -233,19 +416,36 @@ Updates the amount of delegated locked celo. There might be discrepancy between 
 ```
 USAGE
   $ celocli lockedgold:update-delegated-amount --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Account Address
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Updates the amount of delegated locked celo. There might be discrepancy between the
@@ -254,6 +454,16 @@ DESCRIPTION
 
 EXAMPLES
   update-delegated-amount --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --to 0xc0ffee254729296a45a3885639AC7E10F9d54979
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/lockedgold/update-delegated-amount.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/lockedgold/update-delegated-amount.ts)_
@@ -264,18 +474,34 @@ Withdraw any pending withdrawals created via "lockedgold:unlock" that have becom
 
 ```
 USAGE
-  $ celocli lockedgold:withdraw --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli lockedgold:withdraw --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account Address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account Address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Withdraw any pending withdrawals created via "lockedgold:unlock" that have become
@@ -283,6 +509,16 @@ DESCRIPTION
 
 EXAMPLES
   withdraw --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/lockedgold/withdraw.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/lockedgold/withdraw.ts)_

--- a/docs/command-line-interface/multisig.md
+++ b/docs/command-line-interface/multisig.md
@@ -14,29 +14,55 @@ Approves an existing transaction on a multi-sig contract
 ```
 USAGE
   $ celocli multisig:approve --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --for
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --tx <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --tx <value> [-k <value> | --useLedger |
+    ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
-  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d          (required) Address of the
-                                                            multi-sig contract
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account approving
-                                                            the multi-sig transaction
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --tx=<value>                                              (required) Transaction to
-                                                            approve
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the multi-sig contract
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account approving the multi-sig transaction
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --tx=<value>
+      (required) Transaction to approve
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Approves an existing transaction on a multi-sig contract
 
 EXAMPLES
   approve --from 0x6ecbe1db9ef729cbe972c83fb886247691fb6beb --for 0x5409ed021d9299bf6814279a6a1411a7e866a631 --tx 3
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/multisig/approve.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/multisig/approve.ts)_
@@ -47,23 +73,39 @@ Shows information about multi-sig contract
 
 ```
 USAGE
-  $ celocli multisig:show ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--tx <value>] [--all]
-    [--raw]
+  $ celocli multisig:show ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp] [--tx <value>] [--all] [--raw]
 
 FLAGS
-  --all                                                     Show info about all
-                                                            transactions
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --raw                                                     Do not attempt to parse
-                                                            transactions
-  --tx=<value>                                              Show info for a transaction
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --all
+      Show info about all transactions
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --raw
+      Do not attempt to parse transactions
+
+  --tx=<value>
+      Show info for a transaction
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Shows information about multi-sig contract
@@ -74,6 +116,16 @@ EXAMPLES
   show 0x5409ed021d9299bf6814279a6a1411a7e866a631 --tx 3
 
   show 0x5409ed021d9299bf6814279a6a1411a7e866a631 --all --raw
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/multisig/show.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/multisig/show.ts)_
@@ -85,30 +137,47 @@ Ability to approve CELO transfers to and from multisig. Submit transaction or ap
 ```
 USAGE
   $ celocli multisig:transfer ARG1 --to 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --amount <value> --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--transferFrom]
-    [--sender 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
+    --amount <value> --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> |
+    --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--transferFrom] [--sender
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
 
 FLAGS
-  --amount=<value>                                          (required) Amount to
-                                                            transfer, e.g. 10e18
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Account
-                                                            transferring value to the
-                                                            recipient
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --sender=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       Identify sender if
-                                                            performing transferFrom
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Recipient of
-                                                            transfer
-  --transferFrom                                            Perform transferFrom instead
-                                                            of transfer in the ERC-20
-                                                            interface
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --amount=<value>
+      (required) Amount to transfer, e.g. 10e18
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Account transferring value to the recipient
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --sender=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Identify sender if performing transferFrom
+
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Recipient of transfer
+
+  --transferFrom
+      Perform transferFrom instead of transfer in the ERC-20 interface
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Ability to approve CELO transfers to and from multisig. Submit transaction or approve
@@ -118,6 +187,16 @@ EXAMPLES
   transfer <multiSigAddr> --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount 200000e18 --from 0x123abc
 
   transfer <multiSigAddr> --transferFrom --sender 0x123abc --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --amount 200000e18 --from 0x123abc
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/multisig/transfer.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/multisig/transfer.ts)_

--- a/docs/command-line-interface/network.md
+++ b/docs/command-line-interface/network.md
@@ -14,12 +14,18 @@ Lists Celo core contracts and their addresses.
 
 ```
 USAGE
-  $ celocli network:contracts [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli network:contracts [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
+    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -39,6 +45,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -52,8 +62,21 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   Lists Celo core contracts and their addresses.
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/network/contracts.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/network/contracts.ts)_
@@ -64,22 +87,46 @@ View general network information such as the current block number
 
 ```
 USAGE
-  $ celocli network:info [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--lastN <value>]
+  $ celocli network:info [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--lastN <value>]
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --lastN=<value>                                           [default: 1] Fetch info
-                                                            about the last n epochs
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --lastN=<value>
+      [default: 1] Fetch info about the last n epochs
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   View general network information such as the current block number
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/network/info.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/network/info.ts)_
@@ -90,23 +137,47 @@ View parameters of the network, including but not limited to configuration for t
 
 ```
 USAGE
-  $ celocli network:parameters [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--raw]
+  $ celocli network:parameters [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--raw]
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --raw                                                     Display raw numerical
-                                                            configuration
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --raw
+      Display raw numerical configuration
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   View parameters of the network, including but not limited to configuration for the
   various Celo core smart contracts.
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/network/parameters.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/network/parameters.ts)_
@@ -117,12 +188,18 @@ List the whitelisted fee currencies
 
 ```
 USAGE
-  $ celocli network:whitelist [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli network:whitelist [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
+    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -142,6 +219,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -155,11 +236,24 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   List the whitelisted fee currencies
 
 EXAMPLES
   whitelist
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/network/whitelist.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/network/whitelist.ts)_

--- a/docs/command-line-interface/node.md
+++ b/docs/command-line-interface/node.md
@@ -12,20 +12,43 @@ List the addresses that this node has the private keys for.
 
 ```
 USAGE
-  $ celocli node:accounts [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli node:accounts [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   List the addresses that this node has the private keys for.
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/node/accounts.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/node/accounts.ts)_
@@ -36,22 +59,46 @@ Check if the node is synced
 
 ```
 USAGE
-  $ celocli node:synced [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--verbose]
+  $ celocli node:synced [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--verbose]
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --verbose                                                 output the full status if
-                                                            syncing
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --verbose
+      output the full status if syncing
 
 DESCRIPTION
   Check if the node is synced
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/node/synced.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/node/synced.ts)_

--- a/docs/command-line-interface/oracle.md
+++ b/docs/command-line-interface/oracle.md
@@ -14,20 +14,33 @@ List oracle addresses for a given token
 
 ```
 USAGE
-  $ celocli oracle:list ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli oracle:list ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to list the oracles for
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   List oracle addresses for a given token
@@ -38,6 +51,16 @@ EXAMPLES
   list
 
   list StableTokenEUR
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/oracle/list.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/oracle/list.ts)_
@@ -49,22 +72,36 @@ Remove expired oracle reports for a specified token
 ```
 USAGE
   $ celocli oracle:remove-expired-reports ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+    [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to remove expired reports for
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            account removing oracle
-                                                            reports
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the account removing oracle reports
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Remove expired oracle reports for a specified token
@@ -75,6 +112,16 @@ EXAMPLES
   remove-expired-reports --from 0x8c349AAc7065a35B7166f2659d6C35D75A3893C1
 
   remove-expired-reports StableTokenEUR --from 0x8c349AAc7065a35B7166f2659d6C35D75A3893C1
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/oracle/remove-expired-reports.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/oracle/remove-expired-reports.ts)_
@@ -86,25 +133,39 @@ Report the price of CELO in a specified token
 ```
 USAGE
   $ celocli oracle:report ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --value <value> [--gasCurrency 0x1234567890123456789012345678901234567890]
+    --value <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to report on
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            oracle account
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --value=<value>                                           (required) Amount of the
-                                                            specified token equal to 1
-                                                            CELO
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the oracle account
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=<value>
+      (required) Amount of the specified token equal to 1 CELO
 
 DESCRIPTION
   Report the price of CELO in a specified token
@@ -115,6 +176,16 @@ EXAMPLES
   report --value 0.99 --from 0x8c349AAc7065a35B7166f2659d6C35D75A3893C1
 
   report StableTokenEUR --value 1.02 --from 0x8c349AAc7065a35B7166f2659d6C35D75A3893C1
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/oracle/report.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/oracle/report.ts)_
@@ -125,15 +196,21 @@ List oracle reports for a given token
 
 ```
 USAGE
-  $ celocli oracle:reports ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli oracle:reports ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header |
+    [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to list the reports for
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -153,6 +230,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -166,6 +247,9 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   List oracle reports for a given token
 
@@ -175,6 +259,16 @@ EXAMPLES
   reports
 
   reports StableTokenEUR
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/oracle/reports.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/oracle/reports.ts)_

--- a/docs/command-line-interface/releasecelo.md
+++ b/docs/command-line-interface/releasecelo.md
@@ -27,38 +27,52 @@ Authorize an alternative key to be used for a given action (Vote, Validate, Atte
 USAGE
   $ celocli releasecelo:authorize --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --role vote|validator|attestation --signer
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --signature 0x [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--blsKey 0x --blsPop 0x]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --signature 0x [-k <value> | --useLedger
+    | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp] [--blsKey 0x --blsPop 0x]
 
 FLAGS
-  --blsKey=0x                                               The BLS public key that the
-                                                            validator is using for
-                                                            consensus, should pass proof
-                                                            of possession. 96 bytes.
-  --blsPop=0x                                               The BLS public key
-                                                            proof-of-possession, which
-                                                            consists of a signature on
-                                                            the account address. 48
-                                                            bytes.
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
-                                                            ReleaseGold Contract
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --role=<option>                                           (required)
-                                                            <options:
-                                                            vote|validator|attestation>
-  --signature=0x                                            (required) Signature (a.k.a.
-                                                            proof-of-possession) of the
-                                                            signer key
-  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d       (required) The signer key
-                                                            that is to be used for
-                                                            voting through the
-                                                            ReleaseGold instance
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --blsKey=0x
+      The BLS public key that the validator is using for consensus, should pass proof of
+      possession. 96 bytes.
+
+  --blsPop=0x
+      The BLS public key proof-of-possession, which consists of a signature on the account
+      address. 48 bytes.
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --role=<option>
+      (required)
+      <options: vote|validator|attestation>
+
+  --signature=0x
+      (required) Signature (a.k.a. proof-of-possession) of the signer key
+
+  --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) The signer key that is to be used for voting through the ReleaseGold
+      instance
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Authorize an alternative key to be used for a given action (Vote, Validate, Attest) on
@@ -70,6 +84,16 @@ EXAMPLES
   authorize --contract 0x5409ED021D9299bf6814279A6A1411A7e866A631 --role validator --signer 0x6ecbe1db9ef729cbe972c83fb886247691fb6beb --signature 0x1b9fca4bbb5bfb1dbe69ef1cddbd9b4202dcb6b134c5170611e1e36ecfa468d7b46c85328d504934fce6c2a1571603a50ae224d2b32685e84d4d1a1eebad8452eb --blsKey 0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00 --blsPop 0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900
 
   authorize --contract 0x5409ED021D9299bf6814279A6A1411A7e866A631 --role attestation --signer 0x6ecbe1db9ef729cbe972c83fb886247691fb6beb --signature 0x1b9fca4bbb5bfb1dbe69ef1cddbd9b4202dcb6b134c5170611e1e36ecfa468d7b46c85328d504934fce6c2a1571603a50ae224d2b32685e84d4d1a1eebad8452eb
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/authorize.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/authorize.ts)_
@@ -80,25 +104,50 @@ Creates a new account for the ReleaseGold instance
 
 ```
 USAGE
-  $ celocli releasecelo:create-account --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli releasecelo:create-account --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
-                                                            ReleaseGold Contract
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Creates a new account for the ReleaseGold instance
 
 EXAMPLES
   create-account --contract 0x5409ED021D9299bf6814279A6A1411A7e866A631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/create-account.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/create-account.ts)_
@@ -110,13 +159,20 @@ Perform actions [lock, unlock, withdraw] on CELO that has been locked via the pr
 ```
 USAGE
   $ celocli releasecelo:locked-gold --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d -a
-    lock|unlock|withdraw --value 10000000000000000000000 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--yes]
+    lock|unlock|withdraw --value 10000000000000000000000 [-k <value> | --useLedger | ]
+    [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp] [--yes]
 
 FLAGS
   -a, --action=<option>
       (required) Action to perform on contract's celo
       <options: lock|unlock|withdraw>
+
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
 
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address of the ReleaseGold Contract
@@ -127,6 +183,13 @@ FLAGS
 
   --globalHelp
       View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
   --value=10000000000000000000000
       (required) Amount of celo to perform `action` with
@@ -144,6 +207,16 @@ EXAMPLES
   locked-gold --contract 0xCcc8a47BE435F1590809337BB14081b256Ae26A8 --action unlock --value 10000000000000000000000
 
   locked-gold --contract 0xCcc8a47BE435F1590809337BB14081b256Ae26A8 --action withdraw --value 10000000000000000000000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/locked-gold.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/locked-gold.ts)_
@@ -154,19 +227,34 @@ Refund the given contract's balance to the appropriate parties and destroy the c
 
 ```
 USAGE
-  $ celocli releasecelo:refund-and-finalize --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli releasecelo:refund-and-finalize --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
-                                                            ReleaseGold Contract
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Refund the given contract's balance to the appropriate parties and destroy the
@@ -174,6 +262,16 @@ DESCRIPTION
 
 EXAMPLES
   refund-and-finalize --contract 0x5409ED021D9299bf6814279A6A1411A7e866A631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/refund-and-finalize.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/refund-and-finalize.ts)_
@@ -184,22 +282,37 @@ Revoke the given contract instance. Once revoked, any Locked Gold can be unlocke
 
 ```
 USAGE
-  $ celocli releasecelo:revoke --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
-    [--yesreally]
+  $ celocli releasecelo:revoke --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--yesreally]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
-                                                            ReleaseGold Contract
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --yesreally                                               Override prompt to set
-                                                            liquidity (be careful!)
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --yesreally
+      Override prompt to set liquidity (be careful!)
 
 DESCRIPTION
   Revoke the given contract instance. Once revoked, any Locked Gold can be unlocked by
@@ -209,6 +322,16 @@ DESCRIPTION
 
 EXAMPLES
   revoke --contract 0x5409ED021D9299bf6814279A6A1411A7e866A631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/revoke.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/revoke.ts)_
@@ -219,28 +342,47 @@ Revokes `votes` for the given contract's account from the given group's account
 
 ```
 USAGE
-  $ celocli releasecelo:revoke-votes --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp] [--group
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --allGroups] [--votes <value> |
-    --allVotes | ]
+  $ celocli releasecelo:revoke-votes --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--group 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --allGroups]
+    [--votes <value> | --allVotes | ]
 
 FLAGS
-  --allGroups                                               Revoke all votes from all
-                                                            groups
-  --allVotes                                                Revoke all votes
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
-                                                            ReleaseGold Contract
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d        Address of the group to
-                                                            revoke votes from
-  --votes=<value>                                           The number of votes to
-                                                            revoke
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --allGroups
+      Revoke all votes from all groups
+
+  --allVotes
+      Revoke all votes
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Address of the group to revoke votes from
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --votes=<value>
+      The number of votes to revoke
 
 DESCRIPTION
   Revokes `votes` for the given contract's account from the given group's account
@@ -249,6 +391,16 @@ EXAMPLES
   revoke-votes --contract 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --group 0x5409ED021D9299bf6814279A6A1411A7e866A631 --votes 100
 
   revoke-votes --contract 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --allVotes --allGroups
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/revoke-votes.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/revoke-votes.ts)_
@@ -260,10 +412,17 @@ Set account properties of the ReleaseGold instance account such as name, data en
 ```
 USAGE
   $ celocli releasecelo:set-account --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d -p
-    name|dataEncryptionKey|metaURL -v <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    name|dataEncryptionKey|metaURL -v <value> [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -p, --property=<option>
       (required) Property type to set
       <options: name|dataEncryptionKey|metaURL>
@@ -281,6 +440,13 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   Set account properties of the ReleaseGold instance account such as name, data
   encryption key, and the metadata URL
@@ -291,6 +457,16 @@ EXAMPLES
   set-account --contract 0x5719118266779B58D0f9519383A4A27aA7b829E5 --property dataEncryptionKey --value 0x041bb96e35f9f4b71ca8de561fff55a249ddf9d13ab582bdd09a09e75da68ae4cd0ab7038030f41b237498b4d76387ae878dc8d98fd6f6db2c15362d1a3bf11216
 
   set-account --contract 0x5719118266779B58D0f9519383A4A27aA7b829E5 --property metaURL --value www.example.com
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/set-account.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/set-account.ts)_
@@ -302,10 +478,17 @@ Set the ReleaseGold contract account's wallet address
 ```
 USAGE
   $ celocli releasecelo:set-account-wallet-address --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --walletAddress 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--pop <value>]
+    --walletAddress 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger
+    | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp] [--pop <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address of the ReleaseGold Contract
 
@@ -316,8 +499,15 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --pop=<value>
       ECDSA PoP for signer over contract's account
+
+  --useLedger
+      Set it to use a ledger wallet
 
   --walletAddress=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address of wallet to set for contract's account and signer of PoP. 0x0 if
@@ -328,6 +518,16 @@ DESCRIPTION
 
 EXAMPLES
   set-account-wallet-address --contract 0x5409ED021D9299bf6814279A6A1411A7e866A631 --walletAddress 0xE36Ea790bc9d7AB70C55260C66D52b1eca985f84 --pop 0x1b3e611d05e46753c43444cdc55c2cc3d95c54da0eba2464a8cc8cb01bd57ae8bb3d82a0e293ca97e5813e7fb9b624127f42ef0871d025d8a56fe2f8f08117e25b
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/set-account-wallet-address.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/set-account-wallet-address.ts)_
@@ -340,26 +540,42 @@ Set the beneficiary of the ReleaseGold contract. This command is gated via a mul
 USAGE
   $ celocli releasecelo:set-beneficiary --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --beneficiary
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--yesreally]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp] [--yesreally]
 
 FLAGS
-  --beneficiary=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                            new beneficiary
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
-                                                            ReleaseGold Contract
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address to submit
-                                                            multisig transaction from
-                                                            (one of the owners)
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --yesreally                                               Override prompt to set new
-                                                            beneficiary (be careful!)
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --beneficiary=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the new beneficiary
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address to submit multisig transaction from (one of the owners)
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --yesreally
+      Override prompt to set new beneficiary (be careful!)
 
 DESCRIPTION
   Set the beneficiary of the ReleaseGold contract. This command is gated via a
@@ -369,6 +585,16 @@ DESCRIPTION
 
 EXAMPLES
   set-beneficiary --contract 0x5409ED021D9299bf6814279A6A1411A7e866A631 --from 0xE36Ea790bc9d7AB70C55260C66D52b1eca985f84 --beneficiary 0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/set-beneficiary.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/set-beneficiary.ts)_
@@ -380,31 +606,56 @@ Set the canExpire flag for the given ReleaseGold contract
 ```
 USAGE
   $ celocli releasecelo:set-can-expire --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --value true|false|True|False [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--yesreally]
+    --value true|false|True|False [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp] [--yesreally]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
-                                                            ReleaseGold Contract
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --value=<option>                                          (required) canExpire value
-                                                            <options:
-                                                            true|false|True|False>
-  --yesreally                                               Override prompt to set
-                                                            expiration flag (be
-                                                            careful!)
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=<option>
+      (required) canExpire value
+      <options: true|false|True|False>
+
+  --yesreally
+      Override prompt to set expiration flag (be careful!)
 
 DESCRIPTION
   Set the canExpire flag for the given ReleaseGold contract
 
 EXAMPLES
   set-can-expire --contract 0x5409ED021D9299bf6814279A6A1411A7e866A631 --value true
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/set-can-expire.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/set-can-expire.ts)_
@@ -415,22 +666,37 @@ Set the liquidity provision to true, allowing the beneficiary to withdraw releas
 
 ```
 USAGE
-  $ celocli releasecelo:set-liquidity-provision --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
-    [--yesreally]
+  $ celocli releasecelo:set-liquidity-provision --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--yesreally]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
-                                                            ReleaseGold Contract
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --yesreally                                               Override prompt to set
-                                                            liquidity (be careful!)
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --yesreally
+      Override prompt to set liquidity (be careful!)
 
 DESCRIPTION
   Set the liquidity provision to true, allowing the beneficiary to withdraw released
@@ -438,6 +704,16 @@ DESCRIPTION
 
 EXAMPLES
   set-liquidity-provision --contract 0x5409ED021D9299bf6814279A6A1411A7e866A631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/set-liquidity-provision.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/set-liquidity-provision.ts)_
@@ -449,33 +725,56 @@ Set the maximum distribution of celo for the given contract
 ```
 USAGE
   $ celocli releasecelo:set-max-distribution --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --distributionRatio <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--yesreally]
+    --distributionRatio <value> [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp] [--yesreally]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
-                                                            ReleaseGold Contract
-  --distributionRatio=<value>                               (required) Amount in range
-                                                            [0, 1000] (3 significant
-                                                            figures) indicating % of
-                                                            total balance available for
-                                                            distribution.
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --yesreally                                               Override prompt to set new
-                                                            maximum distribution (be
-                                                            careful!)
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --distributionRatio=<value>
+      (required) Amount in range [0, 1000] (3 significant figures) indicating % of total
+      balance available for distribution.
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --yesreally
+      Override prompt to set new maximum distribution (be careful!)
 
 DESCRIPTION
   Set the maximum distribution of celo for the given contract
 
 EXAMPLES
   set-max-distribution --contract 0x5409ED021D9299bf6814279A6A1411A7e866A631 --distributionRatio 1000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/set-max-distribution.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/set-max-distribution.ts)_
@@ -486,25 +785,50 @@ Show info on a ReleaseGold instance contract.
 
 ```
 USAGE
-  $ celocli releasecelo:show --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli releasecelo:show --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
-                                                            ReleaseGold Contract
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Show info on a ReleaseGold instance contract.
 
 EXAMPLES
   show --contract 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/show.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/show.ts)_
@@ -516,24 +840,40 @@ Transfer Celo Dollars from the given contract address. Dollars may be accrued to
 ```
 USAGE
   $ celocli releasecelo:transfer-dollars --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --to 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value 10000000000000000000000
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+    --to 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value 10000000000000000000000 [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
-                                                            ReleaseGold Contract
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
-                                                            recipient of Celo Dollars
-                                                            transfer
-  --value=10000000000000000000000                           (required) Value (in Wei) of
-                                                            Celo Dollars to transfer
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the recipient of Celo Dollars transfer
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=10000000000000000000000
+      (required) Value (in Wei) of Celo Dollars to transfer
 
 DESCRIPTION
   Transfer Celo Dollars from the given contract address. Dollars may be accrued to the
@@ -541,6 +881,16 @@ DESCRIPTION
 
 EXAMPLES
   transfer-dollars --contract 0x5409ED021D9299bf6814279A6A1411A7e866A631 --to 0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb --value 10000000000000000000000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/transfer-dollars.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/transfer-dollars.ts)_
@@ -552,22 +902,36 @@ Withdraws `value` released celo to the beneficiary address. Fails if `value` wor
 ```
 USAGE
   $ celocli releasecelo:withdraw --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --value 10000000000000000000000 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    --value 10000000000000000000000 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp]
 
 FLAGS
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d     (required) Address of the
-                                                            ReleaseGold Contract
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --value=10000000000000000000000                           (required) Amount of
-                                                            released celo (in wei) to
-                                                            withdraw
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=10000000000000000000000
+      (required) Amount of released celo (in wei) to withdraw
 
 DESCRIPTION
   Withdraws `value` released celo to the beneficiary address. Fails if `value` worth of
@@ -575,6 +939,16 @@ DESCRIPTION
 
 EXAMPLES
   withdraw --contract 0x5409ED021D9299bf6814279A6A1411A7e866A631 --value 10000000000000000000000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/releasecelo/withdraw.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/releasecelo/withdraw.ts)_

--- a/docs/command-line-interface/rewards.md
+++ b/docs/command-line-interface/rewards.md
@@ -11,15 +11,21 @@ Show rewards information about a voter, registered Validator, or Validator Group
 
 ```
 USAGE
-  $ celocli rewards:show [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--estimate] [--voter
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--validator
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--group
+  $ celocli rewards:show [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--estimate] [--voter 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
+    [--validator 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--group
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--slashing] [--epochs <value>]
     [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
     [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -48,6 +54,10 @@ FLAGS
   --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       Validator Group to show rewards for
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -64,6 +74,9 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
   --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       Validator to show rewards for
 
@@ -75,6 +88,16 @@ DESCRIPTION
 
 EXAMPLES
   show --voter 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/rewards/show.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/rewards/show.ts)_

--- a/docs/command-line-interface/transfer.md
+++ b/docs/command-line-interface/transfer.md
@@ -17,24 +17,42 @@ Transfer CELO to a specified address. (Note: this is the equivalent of the old t
 ```
 USAGE
   $ celocli transfer:celo --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--comment <value>]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
+    | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp] [--comment <value>]
 
 FLAGS
-  --comment=<value>                                         Transfer comment
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            sender
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
-                                                            receiver
-  --value=<value>                                           (required) Amount to
-                                                            transfer (in wei)
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --comment=<value>
+      Transfer comment
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the sender
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the receiver
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=<value>
+      (required) Amount to transfer (in wei)
 
 DESCRIPTION
   Transfer CELO to a specified address. (Note: this is the equivalent of the old
@@ -42,6 +60,16 @@ DESCRIPTION
 
 EXAMPLES
   celo --from 0xa0Af2E71cECc248f4a7fD606F203467B500Dd53B --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --value 10000000000000000000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/transfer/celo.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/transfer/celo.ts)_
@@ -53,30 +81,58 @@ Transfer Celo Dollars (cUSD) to a specified address.
 ```
 USAGE
   $ celocli transfer:dollars --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--comment <value>]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
+    | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp] [--comment <value>]
 
 FLAGS
-  --comment=<value>                                         Transfer comment
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            sender
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
-                                                            receiver
-  --value=<value>                                           (required) Amount to
-                                                            transfer (in wei)
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --comment=<value>
+      Transfer comment
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the sender
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the receiver
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=<value>
+      (required) Amount to transfer (in wei)
 
 DESCRIPTION
   Transfer Celo Dollars (cUSD) to a specified address.
 
 EXAMPLES
   dollars --from 0xa0Af2E71cECc248f4a7fD606F203467B500Dd53B --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --value 1000000000000000000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/transfer/dollars.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/transfer/dollars.ts)_
@@ -89,10 +145,17 @@ Transfer ERC20 to a specified address
 USAGE
   $ celocli transfer:erc20 --erc20Address 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
+    | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   --erc20Address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Custom erc20 to check it's balance too
 
@@ -106,8 +169,15 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address of the receiver
+
+  --useLedger
+      Set it to use a ledger wallet
 
   --value=<value>
       (required) Amount to transfer (in wei)
@@ -117,6 +187,16 @@ DESCRIPTION
 
 EXAMPLES
   erc20 --erc20Address 0x765DE816845861e75A25fCA122bb6898B8B1282a --from 0xa0Af2E71cECc248f4a7fD606F203467B500Dd53B --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --value 10000000000000000000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/transfer/erc20.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/transfer/erc20.ts)_
@@ -128,30 +208,58 @@ Transfer Celo Euros (cEUR) to a specified address.
 ```
 USAGE
   $ celocli transfer:euros --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--comment <value>]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
+    | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp] [--comment <value>]
 
 FLAGS
-  --comment=<value>                                         Transfer comment
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            sender
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
-                                                            receiver
-  --value=<value>                                           (required) Amount to
-                                                            transfer (in wei)
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --comment=<value>
+      Transfer comment
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the sender
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the receiver
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=<value>
+      (required) Amount to transfer (in wei)
 
 DESCRIPTION
   Transfer Celo Euros (cEUR) to a specified address.
 
 EXAMPLES
   euros --from 0xa0Af2E71cECc248f4a7fD606F203467B500Dd53B --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --value 1000000000000000000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/transfer/euros.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/transfer/euros.ts)_
@@ -163,30 +271,58 @@ Transfer Celo Brazilian Real (cREAL) to a specified address.
 ```
 USAGE
   $ celocli transfer:reals --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--comment <value>]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
+    | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp] [--comment <value>]
 
 FLAGS
-  --comment=<value>                                         Transfer comment
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            sender
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
-                                                            receiver
-  --value=<value>                                           (required) Amount to
-                                                            transfer (in wei)
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --comment=<value>
+      Transfer comment
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the sender
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the receiver
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=<value>
+      (required) Amount to transfer (in wei)
 
 DESCRIPTION
   Transfer Celo Brazilian Real (cREAL) to a specified address.
 
 EXAMPLES
   reals --from 0xa0Af2E71cECc248f4a7fD606F203467B500Dd53B --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --value 1000000000000000000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/transfer/reals.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/transfer/reals.ts)_
@@ -198,35 +334,63 @@ Transfer a stable token to a specified address.
 ```
 USAGE
   $ celocli transfer:stable --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--comment <value>]
-    [--stableToken cUSD|cusd|cEUR|ceur|cREAL|creal]
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
+    | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--globalHelp] [--comment <value>] [--stableToken
+    cUSD|cusd|cEUR|ceur|cREAL|creal]
 
 FLAGS
-  --comment=<value>                                         Transfer comment
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address of the
-                                                            sender
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --stableToken=<option>                                    Name of the stable to be
-                                                            transferred
-                                                            <options: cUSD|cusd|cEUR|ceu
-                                                            r|cREAL|creal>
-  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the
-                                                            receiver
-  --value=<value>                                           (required) Amount to
-                                                            transfer (in wei)
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --comment=<value>
+      Transfer comment
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the sender
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --stableToken=<option>
+      Name of the stable to be transferred
+      <options: cUSD|cusd|cEUR|ceur|cREAL|creal>
+
+  --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the receiver
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --value=<value>
+      (required) Amount to transfer (in wei)
 
 DESCRIPTION
   Transfer a stable token to a specified address.
 
 EXAMPLES
   stable --from 0xa0Af2E71cECc248f4a7fD606F203467B500Dd53B --to 0x5409ed021d9299bf6814279a6a1411a7e866a631 --value 1000000000000000000 --stableToken cStableTokenSymbol
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/transfer/stable.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/transfer/stable.ts)_

--- a/docs/command-line-interface/validator.md
+++ b/docs/command-line-interface/validator.md
@@ -23,22 +23,39 @@ Affiliate a Validator with a Validator Group. This allows the Validator Group to
 ```
 USAGE
   $ celocli validator:affiliate ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp] [--yes]
+    [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--yes]
 
 ARGUMENTS
   ARG1  ValidatorGroup's address
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Signer or
-                                                            Validator's address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --yes                                                     Answer yes to prompt
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Signer or Validator's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --yes
+      Answer yes to prompt
 
 DESCRIPTION
   Affiliate a Validator with a Validator Group. This allows the Validator Group to add
@@ -48,6 +65,16 @@ DESCRIPTION
 
 EXAMPLES
   affiliate --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95 0x97f7333c51897469e8d98e7af8653aab468050a3
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validator/affiliate.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validator/affiliate.ts)_
@@ -58,19 +85,34 @@ Deaffiliate a Validator from a Validator Group, and remove it from the Group if 
 
 ```
 USAGE
-  $ celocli validator:deaffiliate --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli validator:deaffiliate --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Signer or
-                                                            Validator's address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Signer or Validator's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Deaffiliate a Validator from a Validator Group, and remove it from the Group if it is
@@ -78,6 +120,16 @@ DESCRIPTION
 
 EXAMPLES
   deaffiliate --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validator/deaffiliate.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validator/deaffiliate.ts)_
@@ -88,19 +140,34 @@ Deregister a Validator. Approximately 60 days after the validator is no longer p
 
 ```
 USAGE
-  $ celocli validator:deregister --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli validator:deregister --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Signer or
-                                                            Validator's address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Signer or Validator's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Deregister a Validator. Approximately 60 days after the validator is no longer part of
@@ -111,6 +178,16 @@ DESCRIPTION
 
 EXAMPLES
   deregister --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validator/deregister.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validator/deregister.ts)_
@@ -121,14 +198,21 @@ Downtime slash a validator
 
 ```
 USAGE
-  $ celocli validator:downtime-slash --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
-    [--validator 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --validators
-    '["0xb7ef0985bdb4f19460A29d9829aA1514B181C4CD",
+  $ celocli validator:downtime-slash --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--validator 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d |
+    --validators '["0xb7ef0985bdb4f19460A29d9829aA1514B181C4CD",
     "0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95"]'] [--intervals '[0:1], [1:2]' |
     --beforeBlock <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   --beforeBlock=<value>
       Slash for slashable downtime window before provided block
 
@@ -145,6 +229,13 @@ FLAGS
   --intervals='[0:1], [1:2]'
       Array of intervals, ordered by min start to max end
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
   --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       Validator (signer or account) address
 
@@ -159,6 +250,16 @@ EXAMPLES
   downtime-slash     --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95     --validator 0xb7ef0985bdb4f19460A29d9829aA1514B181C4CD     --intervals "[100:150), [150:200)"
 
   downtime-slash     --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95     --validator 0xb7ef0985bdb4f19460A29d9829aA1514B181C4CD     --slashableDowntimeBeforeBlock 200
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validator/downtime-slash.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validator/downtime-slash.ts)_
@@ -169,12 +270,18 @@ List registered Validators, their name (if provided), affiliation, uptime score,
 
 ```
 USAGE
-  $ celocli validator:list [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli validator:list [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
+    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -194,6 +301,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -207,12 +318,25 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   List registered Validators, their name (if provided), affiliation, uptime score, and
   public keys used for validating.
 
 EXAMPLES
   list
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validator/list.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validator/list.ts)_
@@ -224,29 +348,61 @@ Register a new Validator
 ```
 USAGE
   $ celocli validator:register --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --ecdsaKey 0x [--gasCurrency 0x1234567890123456789012345678901234567890]
+    --ecdsaKey 0x [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp] [--blsKey 0x] [--blsSignature 0x] [--yes]
 
 FLAGS
-  --blsKey=0x                                               BLS Public Key
-  --blsSignature=0x                                         BLS Proof-of-Possession
-  --ecdsaKey=0x                                             (required) ECDSA Public Key
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address for the
-                                                            Validator
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --yes                                                     Answer yes to prompt
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --blsKey=0x
+      BLS Public Key
+
+  --blsSignature=0x
+      BLS Proof-of-Possession
+
+  --ecdsaKey=0x
+      (required) ECDSA Public Key
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address for the Validator
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --yes
+      Answer yes to prompt
 
 DESCRIPTION
   Register a new Validator
 
 EXAMPLES
   register --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --ecdsaKey 0x049b7291ab8813a095d6b7913a7930ede5ea17466abd5e1a26c6c44f6df9a400a6f474080098b2c752c6c4871978ca977b90dcd3aed92bc9d564137c8dfa14ee72 --blsKey 0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00 --blsSignature 0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validator/register.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validator/register.ts)_
@@ -257,17 +413,30 @@ List the Locked Gold requirements for registering a Validator. This consists of 
 
 ```
 USAGE
-  $ celocli validator:requirements [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli validator:requirements [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   List the Locked Gold requirements for registering a Validator. This consists of a
@@ -277,6 +446,16 @@ DESCRIPTION
 
 EXAMPLES
   requirements
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validator/requirements.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validator/requirements.ts)_
@@ -287,29 +466,44 @@ Set validator signature bitmaps for provided intervals
 
 ```
 USAGE
-  $ celocli validator:set-bitmaps --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
-    [--slashableDowntimeBeforeBlock <value> | --intervals '[0:1], [1:2]' |
-    --slashableDowntimeBeforeLatest]
+  $ celocli validator:set-bitmaps --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--slashableDowntimeBeforeBlock <value> | --intervals '[0:1], [1:2]'
+    | --slashableDowntimeBeforeLatest]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) From address to
-                                                            sign set bitmap transactions
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --intervals='[0:1], [1:2]'                                Array of intervals, ordered
-                                                            by min start to max end
-  --slashableDowntimeBeforeBlock=<value>                    Set all bitmaps for
-                                                            slashable downtime window
-                                                            before provided block
-  --slashableDowntimeBeforeLatest                           Set all bitmaps for
-                                                            slashable downtime window
-                                                            before latest block
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) From address to sign set bitmap transactions
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --intervals='[0:1], [1:2]'
+      Array of intervals, ordered by min start to max end
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --slashableDowntimeBeforeBlock=<value>
+      Set all bitmaps for slashable downtime window before provided block
+
+  --slashableDowntimeBeforeLatest
+      Set all bitmaps for slashable downtime window before latest block
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Set validator signature bitmaps for provided intervals
@@ -318,6 +512,16 @@ EXAMPLES
   set-bitmaps --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95 --slashableDowntimeBeforeBlock 10000
 
   set-bitmaps --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95 --intervals "[0:100], (100:200]"
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validator/set-bitmaps.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validator/set-bitmaps.ts)_
@@ -328,26 +532,49 @@ Show information about a registered Validator.
 
 ```
 USAGE
-  $ celocli validator:show ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli validator:show ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp]
 
 ARGUMENTS
   ARG1  Validator's address
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Show information about a registered Validator.
 
 EXAMPLES
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validator/show.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validator/show.ts)_
@@ -358,15 +585,21 @@ Display a graph of blocks and whether the given signer's signature is included i
 
 ```
 USAGE
-  $ celocli validator:signed-blocks [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--signer
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --signers
+  $ celocli validator:signed-blocks [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--signer 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --signers
     '["0xb7ef0985bdb4f19460A29d9829aA1514B181C4CD",
     "0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95"]'] [--wasDownWhileElected] [--at-block
     <value> | ] [--slashableDowntimeLookback | [--lookback <value> | ]] [--width
     <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   --at-block=<value>
       latest block to examine for signer activity
 
@@ -376,6 +609,10 @@ FLAGS
 
   --globalHelp
       View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
 
   --lookback=<value>
       [default: 120] how many blocks to look back for signer activity
@@ -389,6 +626,9 @@ FLAGS
 
   --slashableDowntimeLookback
       lookback of slashableDowntime
+
+  --useLedger
+      Set it to use a ledger wallet
 
   --wasDownWhileElected
       indicate whether a validator was down while elected for range
@@ -412,6 +652,16 @@ EXAMPLES
   signed-blocks --lookback 500 --signer 0x5409ED021D9299bf6814279A6A1411A7e866A631
 
   signed-blocks --lookback 50 --width 10 --signer 0x5409ED021D9299bf6814279A6A1411A7e866A631
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validator/signed-blocks.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validator/signed-blocks.ts)_
@@ -422,14 +672,20 @@ Shows the consensus status of a validator. This command will show whether a vali
 
 ```
 USAGE
-  $ celocli validator:status [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--validator
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --all | --signer
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--start <value>] [--end <value>]
-    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
-    [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli validator:status [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--validator 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --all |
+    --signer 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--start <value>] [--end
+    <value>] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
+    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -456,6 +712,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -476,6 +736,9 @@ FLAGS
       [default: -1] what block to start at when looking at signer activity. defaults to
       the last 100 blocks
 
+  --useLedger
+      Set it to use a ledger wallet
+
   --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       address of the validator to check if elected and validating
 
@@ -491,6 +754,16 @@ EXAMPLES
   status --validator 0x5409ED021D9299bf6814279A6A1411A7e866A631 --start 1480000
 
   status --all --start 1480000 --end 1490000
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validator/status.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validator/status.ts)_
@@ -502,22 +775,39 @@ Update the BLS public key for a Validator to be used in consensus.
 ```
 USAGE
   $ celocli validator:update-bls-public-key --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --blsKey 0x --blsPop 0x [--gasCurrency 0x1234567890123456789012345678901234567890]
+    --blsKey 0x --blsPop 0x [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp]
 
 FLAGS
-  --blsKey=0x                                               (required) BLS Public Key
-  --blsPop=0x                                               (required) BLS
-                                                            Proof-of-Possession
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Validator's
-                                                            address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --blsKey=0x
+      (required) BLS Public Key
+
+  --blsPop=0x
+      (required) BLS Proof-of-Possession
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Validator's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Update the BLS public key for a Validator to be used in consensus.
@@ -532,6 +822,16 @@ DESCRIPTION
 
 EXAMPLES
   update-bls-key --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --blsKey 0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00 --blsPop 0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validator/update-bls-public-key.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validator/update-bls-public-key.ts)_

--- a/docs/command-line-interface/validatorgroup.md
+++ b/docs/command-line-interface/validatorgroup.md
@@ -17,28 +17,40 @@ Manage the commission for a registered Validator Group. This represents the shar
 
 ```
 USAGE
-  $ celocli validatorgroup:commission --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp] [--apply |
-    --queue-update <value>]
+  $ celocli validatorgroup:commission --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--apply | --queue-update <value>]
 
 FLAGS
-  --apply                                                   Applies a previously queued
-                                                            update. Should be called
-                                                            after the update delay.
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address for the
-                                                            Validator Group or Validator
-                                                            Group validator signer
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --queue-update=<value>                                    Queues an update to the
-                                                            commission, which can be
-                                                            applied after the update
-                                                            delay.
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --apply
+      Applies a previously queued update. Should be called after the update delay.
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address for the Validator Group or Validator Group validator signer
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --queue-update=<value>
+      Queues an update to the commission, which can be applied after the update delay.
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Manage the commission for a registered Validator Group. This represents the share of
@@ -52,6 +64,16 @@ EXAMPLES
   commission --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --queue-update 0.1
 
   commission --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --apply
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validatorgroup/commission.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validatorgroup/commission.ts)_
@@ -62,19 +84,34 @@ Deregister a Validator Group. Approximately 180 days after the validator group i
 
 ```
 USAGE
-  $ celocli validatorgroup:deregister --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli validatorgroup:deregister --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp]
 
 FLAGS
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Signer or
-                                                            ValidatorGroup's address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Signer or ValidatorGroup's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Deregister a Validator Group. Approximately 180 days after the validator group is
@@ -84,6 +121,16 @@ DESCRIPTION
 
 EXAMPLES
   deregister --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validatorgroup/deregister.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validatorgroup/deregister.ts)_
@@ -94,12 +141,18 @@ List registered Validator Groups, their names (if provided), commission, and mem
 
 ```
 USAGE
-  $ celocli validatorgroup:list [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli validatorgroup:list [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
+    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
   -x, --extended
       show extra columns
 
@@ -119,6 +172,10 @@ FLAGS
   --globalHelp
       View all available global flags
 
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
   --no-header
       hide table header from output
 
@@ -132,11 +189,24 @@ FLAGS
   --sort=<value>
       property to sort by (prepend '-' for descending)
 
+  --useLedger
+      Set it to use a ledger wallet
+
 DESCRIPTION
   List registered Validator Groups, their names (if provided), commission, and members.
 
 EXAMPLES
   list
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validatorgroup/list.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validatorgroup/list.ts)_
@@ -148,31 +218,48 @@ Add or remove members from a Validator Group
 ```
 USAGE
   $ celocli validatorgroup:member ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--globalHelp] [--yes]
-    [--accept | --remove | --reorder <value>]
+    [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--globalHelp] [--yes] [--accept | --remove | --reorder <value>]
 
 ARGUMENTS
   ARG1  Validator's address
 
 FLAGS
-  --accept                                                  Accept a validator whose
-                                                            affiliation is already set
-                                                            to the group
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) ValidatorGroup's
-                                                            address
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --remove                                                  Remove a validator from the
-                                                            members list
-  --reorder=<value>                                         Reorder a validator within
-                                                            the members list. Indices
-                                                            are 0 based
-  --yes                                                     Answer yes to prompt
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --accept
+      Accept a validator whose affiliation is already set to the group
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) ValidatorGroup's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --remove
+      Remove a validator from the members list
+
+  --reorder=<value>
+      Reorder a validator within the members list. Indices are 0 based
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --yes
+      Answer yes to prompt
 
 DESCRIPTION
   Add or remove members from a Validator Group
@@ -183,6 +270,16 @@ EXAMPLES
   member --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95 --remove 0x97f7333c51897469e8d98e7af8653aab468050a3
 
   member --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95 --reorder 3 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validatorgroup/member.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validatorgroup/member.ts)_
@@ -194,30 +291,56 @@ Register a new Validator Group
 ```
 USAGE
   $ celocli validatorgroup:register --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-    --commission <value> [--gasCurrency 0x1234567890123456789012345678901234567890]
+    --commission <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--globalHelp] [--yes]
 
 FLAGS
-  --commission=<value>                                      (required) The share of the
-                                                            epoch rewards given to
-                                                            elected Validators that goes
-                                                            to the group.
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Address for the
-                                                            Validator Group
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --yes                                                     Answer yes to prompt
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --commission=<value>
+      (required) The share of the epoch rewards given to elected Validators that goes to
+      the group.
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address for the Validator Group
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --yes
+      Answer yes to prompt
 
 DESCRIPTION
   Register a new Validator Group
 
 EXAMPLES
   register --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --commission 0.1
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validatorgroup/register.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validatorgroup/register.ts)_
@@ -228,26 +351,49 @@ Reset validator group slashing multiplier.
 
 ```
 USAGE
-  $ celocli validatorgroup:reset-slashing-multiplier ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli validatorgroup:reset-slashing-multiplier ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp]
 
 ARGUMENTS
   ARG1  ValidatorGroup's address
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Reset validator group slashing multiplier.
 
 EXAMPLES
   reset-slashing-multiplier 0x97f7333c51897469E8D98E7af8653aAb468050a3
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validatorgroup/reset-slashing-multiplier.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validatorgroup/reset-slashing-multiplier.ts)_
@@ -258,26 +404,49 @@ Show information about an existing Validator Group
 
 ```
 USAGE
-  $ celocli validatorgroup:show ARG1 [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp]
+  $ celocli validatorgroup:show ARG1 [-k <value> | --useLedger | ] [-n <value>]
+    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
+    <value> ] [--globalHelp]
 
 ARGUMENTS
   ARG1  ValidatorGroup's address
 
 FLAGS
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --useLedger
+      Set it to use a ledger wallet
 
 DESCRIPTION
   Show information about an existing Validator Group
 
 EXAMPLES
   show 0x97f7333c51897469E8D98E7af8653aAb468050a3
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
 ```
 
 _See code: [src/commands/validatorgroup/show.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/validatorgroup/show.ts)_

--- a/packages/cli/src/base-l2.test.ts
+++ b/packages/cli/src/base-l2.test.ts
@@ -1,0 +1,117 @@
+import { Connection } from '@celo/connect'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import { Config, ux } from '@oclif/core'
+import Web3 from 'web3'
+import { BaseCommand } from './base'
+import CustomHelp from './help'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from './test-utils/cliUtils'
+
+process.env.NO_SYNCCHECK = 'true'
+
+// doesnt use anvil because we are testing the connection to chain
+// doesnt use testLocally because that messes with the node connection
+describe('flags', () => {
+  let config: Config
+  class BasicCommand extends BaseCommand {
+    async run() {
+      console.log('Hello, world!')
+    }
+  }
+  beforeEach(async () => {
+    // copied from Commaand.run to load config
+    config = await Config.load(require.main?.filename || __dirname)
+  })
+  describe('--node  alfajores', () => {
+    it('it connects to 44787', async () => {
+      const command = new BasicCommand(['--node', 'alfajores'], config)
+      const runnerWeb3 = await command.getWeb3()
+      const connectdChain = await runnerWeb3.eth.getChainId()
+      expect(connectdChain).toBe(44787)
+    })
+  })
+  describe('--node  celo', () => {
+    it('it connects to 42220', async () => {
+      const command = new BasicCommand(['--node', 'celo'], config)
+      const runnerWeb3 = await command.getWeb3()
+      const connectdChain = await runnerWeb3.eth.getChainId()
+      expect(connectdChain).toBe(42220)
+    })
+  })
+  describe('--help', () => {
+    it('it shows help', async () => {
+      const writeSpy = jest.spyOn(ux.write, 'stdout')
+      const help = new CustomHelp(config)
+      // transfer:celo could be ANY command --help is the important part
+      await help.showHelp(['transfer:celo', '--help'])
+      expect(stripAnsiCodesFromNestedArray(writeSpy.mock.calls)).toHaveLength(3)
+      expect(stripAnsiCodesFromNestedArray(writeSpy.mock.calls)[1][0]).toEqual(
+        expect.stringContaining(
+          `-n, --node=<value>  URL of the node to run commands against or an alias`
+        )
+      )
+    })
+  })
+})
+
+testWithAnvilL2('BaseCommand', (web3: Web3) => {
+  it('logs command execution error', async () => {
+    class TestErrorCommand extends BaseCommand {
+      async run() {
+        throw new Error('test error')
+      }
+    }
+
+    const errorSpy = jest.spyOn(console, 'error')
+
+    await expect(testLocallyWithWeb3Node(TestErrorCommand, [], web3)).rejects.toThrow()
+
+    expect(errorSpy.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "
+      Received an error during command execution, if you believe this is a bug you can create an issue here: 
+                  
+      https://github.com/celo-org/developer-tooling/issues/new?assignees=&labels=bug+report&projects=&template=BUG-FORM.yml
+
+      ",
+          [Error: test error],
+        ],
+      ]
+    `)
+  })
+
+  it('logs connection close error', async () => {
+    class TestConnectionStopErrorCommand extends BaseCommand {
+      async run() {
+        console.log('Successful run')
+      }
+    }
+
+    const writeMock = jest.spyOn(ux.write, 'stdout')
+    const logSpy = jest.spyOn(console, 'log')
+    const errorSpy = jest.spyOn(console, 'error')
+
+    jest.spyOn(Connection.prototype, 'stop').mockImplementation(() => {
+      throw new Error('Mock connection stop error')
+    })
+
+    await testLocallyWithWeb3Node(TestConnectionStopErrorCommand, [], web3)
+
+    expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "Successful run",
+        ],
+      ]
+    `)
+    expect(errorSpy.mock.calls).toMatchInlineSnapshot(`[]`)
+    expect(writeMock.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "Failed to close the connection: Error: Mock connection stop error
+      ",
+        ],
+      ]
+    `)
+  })
+})

--- a/packages/cli/src/commands/account/new.ts
+++ b/packages/cli/src/commands/account/new.ts
@@ -24,6 +24,18 @@ export default class NewAccount extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flags,
+    privateKey: {
+      ...BaseCommand.flags.privateKey,
+      hidden: true,
+    },
+    useLedger: {
+      ...BaseCommand.flags.useLedger,
+      hidden: true,
+    },
+    ledgerAddresses: {
+      ...BaseCommand.flags.useLedger,
+      hidden: true,
+    },
     passphrasePath: Flags.string({
       description:
         'Path to a file that contains the BIP39 passphrase to combine with the mnemonic specified using the mnemonicPath flag and the index specified using the addressIndex flag. Every passphrase generates a different private key and wallet address.',


### PR DESCRIPTION
### Description

it was not at all clear for cli users how to use the --node flag especially that it had aliases for common nodes. This makes that obvious

#### Other changes

By making useLedger and privateKey no longer hidden users will be able to know how to provide them

### Tested

add new tests!

### Related issues

- Fixes #357

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `celocli` command-line interface by adding support for `--useLedger` and `--ledgerAddresses` flags across various commands, improving user experience for those utilizing Ledger wallets.

### Detailed summary
- Added `--useLedger` flag to multiple commands to support Ledger wallet integration.
- Introduced `--ledgerAddresses` flag to retrieve addresses from Ledger.
- Updated documentation to reflect new flags and their usage.
- Marked certain flags as hidden for improved clarity.

> The following files were skipped due to too many changes: `docs/command-line-interface/transfer.md`, `docs/command-line-interface/election.md`, `docs/command-line-interface/validatorgroup.md`, `docs/command-line-interface/exchange.md`, `docs/command-line-interface/lockedgold.md`, `docs/command-line-interface/validator.md`, `docs/command-line-interface/releasecelo.md`, `docs/command-line-interface/governance.md`, `docs/command-line-interface/account.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->