### PR TITLE
fix: decorate missing trie error for L1

### DIFF
--- a/.changeset/strong-flowers-heal.md
+++ b/.changeset/strong-flowers-heal.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Gracefully throw if --estimate wasnt passed on L1

--- a/packages/cli/src/commands/rewards/show-l2.test.ts
+++ b/packages/cli/src/commands/rewards/show-l2.test.ts
@@ -1,0 +1,16 @@
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import Web3 from 'web3'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import Show from './show'
+
+process.env.NO_SYNCCHECK = 'true'
+
+testWithAnvilL2('rewards:show cmd', (web3: Web3) => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+  })
+
+  test.failing('default', async () => {
+    await expect(testLocallyWithWeb3Node(Show, [], web3)).resolves.not.toBeUndefined()
+  })
+})

--- a/packages/cli/src/commands/rewards/show.test.ts
+++ b/packages/cli/src/commands/rewards/show.test.ts
@@ -1,0 +1,245 @@
+import { LockedGoldWrapper } from '@celo/contractkit/lib/wrappers/LockedGold'
+import { ValidatorsWrapper } from '@celo/contractkit/lib/wrappers/Validators'
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
+import { ux } from '@oclif/core'
+import BigNumber from 'bignumber.js'
+import Web3 from 'web3'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import Show from './show'
+
+process.env.NO_SYNCCHECK = 'true'
+const KNOWN_DEVCHAIN_VALIDATOR = '0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f'
+
+testWithAnvilL1('rewards:show cmd', (web3: Web3) => {
+  const writeMock = jest.spyOn(ux.write, 'stdout')
+  const logMock = jest.spyOn(console, 'log')
+  const infoMock = jest.spyOn(console, 'info')
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+  })
+
+  test('default', async () => {
+    await testLocallyWithWeb3Node(Show, [], web3)
+    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "Running Checks:",
+        ],
+        [
+          "All checks passed",
+        ],
+      ]
+    `)
+    expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "No rewards.",
+        ],
+      ]
+    `)
+  })
+
+  test('--validator (invalid)', async () => {
+    await expect(
+      testLocallyWithWeb3Node(
+        Show,
+        ['--validator', '0x1234567890123456789012345678901234567890'],
+        web3
+      )
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
+    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "Running Checks:",
+        ],
+        [
+          "   ✘  0x1234567890123456789012345678901234567890 is Validator ",
+        ],
+      ]
+    `)
+  })
+
+  test('--validator (valid)', async () => {
+    const getValidatorRewardsMock = jest.spyOn(ValidatorsWrapper.prototype, 'getValidatorRewards')
+
+    const validatorPayment = 1234567890
+    const score = 1337
+    const testGroup = {
+      name: 'test-group',
+      address: '0x4242424242424242424242424242424242424242',
+      members: [KNOWN_DEVCHAIN_VALIDATOR],
+      membersUpdated: 1,
+      affiliates: [],
+      commission: new BigNumber(0),
+      nextCommission: new BigNumber(0),
+      nextCommissionBlock: new BigNumber(1),
+      lastSlashed: new BigNumber(-1),
+      slashingMultiplier: new BigNumber(1),
+    }
+    getValidatorRewardsMock.mockImplementationOnce(async () => [
+      {
+        validator: {
+          name: 'test-validator',
+          address: KNOWN_DEVCHAIN_VALIDATOR,
+          ecdsaPublicKey: 'test-ec-pubkey',
+          blsPublicKey: 'test-bls-pubkey',
+          affiliation: '',
+          score: new BigNumber(score),
+          signer: KNOWN_DEVCHAIN_VALIDATOR,
+        },
+        validatorPayment: new BigNumber(validatorPayment),
+        group: testGroup,
+        groupPayment: new BigNumber(1337),
+        epochNumber: 10000,
+      },
+    ])
+
+    await testLocallyWithWeb3Node(Show, ['--validator', KNOWN_DEVCHAIN_VALIDATOR], web3)
+    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "Running Checks:",
+        ],
+        [
+          "   ✔  0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f is Validator ",
+        ],
+        [
+          "All checks passed",
+        ],
+      ]
+    `)
+    expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "",
+        ],
+        [
+          "Validator rewards:",
+        ],
+      ]
+    `)
+    expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          " Validatorname  Validator                                  Validatorpayment Validatorscore Group                                      Epochnumber 
+      ",
+        ],
+        [
+          " ────────────── ────────────────────────────────────────── ──────────────── ────────────── ────────────────────────────────────────── ─────────── 
+      ",
+        ],
+        [
+          " test-validator 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f 1234567890       1337           0x4242424242424242424242424242424242424242             
+      ",
+        ],
+      ]
+    `)
+  })
+
+  test('--validator (slashed)', async () => {
+    const getValidatorRewardsMock = jest.spyOn(ValidatorsWrapper.prototype, 'getValidatorRewards')
+    const lockedGoldMock = jest.spyOn(LockedGoldWrapper.prototype, 'getAccountsSlashed')
+
+    const validatorPayment = 1234567890
+    const score = 1337
+    const testGroup = {
+      name: 'test-group',
+      address: '0x4242424242424242424242424242424242424242',
+      members: [KNOWN_DEVCHAIN_VALIDATOR],
+      membersUpdated: 1,
+      affiliates: [],
+      commission: new BigNumber(0),
+      nextCommission: new BigNumber(0),
+      nextCommissionBlock: new BigNumber(1),
+      lastSlashed: new BigNumber(-1),
+      slashingMultiplier: new BigNumber(1),
+    }
+    getValidatorRewardsMock.mockImplementationOnce(async () => [
+      {
+        validator: {
+          name: 'test-validator',
+          address: KNOWN_DEVCHAIN_VALIDATOR,
+          ecdsaPublicKey: 'test-ec-pubkey',
+          blsPublicKey: 'test-bls-pubkey',
+          affiliation: '',
+          score: new BigNumber(score),
+          signer: KNOWN_DEVCHAIN_VALIDATOR,
+        },
+        validatorPayment: new BigNumber(validatorPayment),
+        group: testGroup,
+        groupPayment: new BigNumber(1337),
+        epochNumber: 10000,
+      },
+    ])
+
+    lockedGoldMock.mockImplementationOnce(async () => [
+      {
+        slashed: KNOWN_DEVCHAIN_VALIDATOR,
+        epochNumber: 1,
+        penalty: new BigNumber(2),
+        reporter: '',
+        reward: new BigNumber(10),
+      },
+    ])
+
+    await testLocallyWithWeb3Node(Show, ['--validator', KNOWN_DEVCHAIN_VALIDATOR], web3)
+    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "Running Checks:",
+        ],
+        [
+          "   ✔  0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f is Validator ",
+        ],
+        [
+          "All checks passed",
+        ],
+      ]
+    `)
+    expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "",
+        ],
+        [
+          "Validator rewards:",
+        ],
+        [
+          "",
+        ],
+        [
+          "Slashing penalties and rewards:",
+        ],
+      ]
+    `)
+    expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          " Validatorname  Validator                                  Validatorpayment Validatorscore Group                                      Epochnumber 
+      ",
+        ],
+        [
+          " ────────────── ────────────────────────────────────────── ──────────────── ────────────── ────────────────────────────────────────── ─────────── 
+      ",
+        ],
+        [
+          " test-validator 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f 1234567890       1337           0x4242424242424242424242424242424242424242             
+      ",
+        ],
+        [
+          " Slashed Penalty Reporter Reward Epochnumber 
+      ",
+        ],
+        [
+          " ─────── ─────── ──────── ────── ─────────── 
+      ",
+        ],
+        [
+          "         2                10                 
+      ",
+        ],
+      ]
+    `)
+  })
+})

--- a/packages/cli/src/commands/rewards/show.test.ts
+++ b/packages/cli/src/commands/rewards/show.test.ts
@@ -1,9 +1,12 @@
+import { newKitFromWeb3 } from '@celo/contractkit'
+import { ElectionWrapper } from '@celo/contractkit/lib/wrappers/Election'
 import { LockedGoldWrapper } from '@celo/contractkit/lib/wrappers/LockedGold'
 import { ValidatorsWrapper } from '@celo/contractkit/lib/wrappers/Validators'
 import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { registerAccount } from '../../test-utils/chain-setup'
 import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Show from './show'
 
@@ -19,9 +22,10 @@ testWithAnvilL1('rewards:show cmd', (web3: Web3) => {
     jest.clearAllMocks()
   })
 
-  test('default', async () => {
-    await testLocallyWithWeb3Node(Show, [], web3)
-    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+  describe('no arguments', () => {
+    test('default', async () => {
+      await testLocallyWithWeb3Node(Show, [], web3)
+      expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
       [
         [
           "Running Checks:",
@@ -31,215 +35,280 @@ testWithAnvilL1('rewards:show cmd', (web3: Web3) => {
         ],
       ]
     `)
-    expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
+      expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
       [
         [
           "No rewards.",
         ],
       ]
     `)
+    })
+
+    test('trie missing error', async () => {
+      const electionMock = jest.spyOn(ElectionWrapper.prototype, 'getGroupVoterRewards')
+      electionMock.mockImplementationOnce(async () => {
+        throw new Error('missing trie node')
+      })
+      await expect(testLocallyWithWeb3Node(Show, [], web3)).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+        "Exact voter information is avaiable only for 1024 blocks after each epoch.
+        Supply --estimate to estimate rewards based on current votes, or use an archive node."
+      `)
+    })
   })
 
-  test('--validator (invalid)', async () => {
-    await expect(
-      testLocallyWithWeb3Node(
-        Show,
-        ['--validator', '0x1234567890123456789012345678901234567890'],
-        web3
-      )
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
-    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
-      [
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✘  0x1234567890123456789012345678901234567890 is Validator ",
-        ],
-      ]
-    `)
-  })
+  describe('--validator', () => {
+    test('invalid', async () => {
+      await expect(
+        testLocallyWithWeb3Node(
+          Show,
+          ['--validator', '0x1234567890123456789012345678901234567890'],
+          web3
+        )
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
+      expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+              [
+                [
+                  "Running Checks:",
+                ],
+                [
+                  "   ✘  0x1234567890123456789012345678901234567890 is Validator ",
+                ],
+              ]
+          `)
+    })
 
-  test('--validator (valid)', async () => {
-    const getValidatorRewardsMock = jest.spyOn(ValidatorsWrapper.prototype, 'getValidatorRewards')
+    test('valid', async () => {
+      const getValidatorRewardsMock = jest.spyOn(ValidatorsWrapper.prototype, 'getValidatorRewards')
 
-    const validatorPayment = 1234567890
-    const score = 1337
-    const testGroup = {
-      name: 'test-group',
-      address: '0x4242424242424242424242424242424242424242',
-      members: [KNOWN_DEVCHAIN_VALIDATOR],
-      membersUpdated: 1,
-      affiliates: [],
-      commission: new BigNumber(0),
-      nextCommission: new BigNumber(0),
-      nextCommissionBlock: new BigNumber(1),
-      lastSlashed: new BigNumber(-1),
-      slashingMultiplier: new BigNumber(1),
-    }
-    getValidatorRewardsMock.mockImplementationOnce(async () => [
-      {
-        validator: {
-          name: 'test-validator',
-          address: KNOWN_DEVCHAIN_VALIDATOR,
-          ecdsaPublicKey: 'test-ec-pubkey',
-          blsPublicKey: 'test-bls-pubkey',
-          affiliation: '',
-          score: new BigNumber(score),
-          signer: KNOWN_DEVCHAIN_VALIDATOR,
+      const validatorPayment = 1234567890
+      const score = 1337
+      const testGroup = {
+        name: 'test-group',
+        address: '0x4242424242424242424242424242424242424242',
+        members: [KNOWN_DEVCHAIN_VALIDATOR],
+        membersUpdated: 1,
+        affiliates: [],
+        commission: new BigNumber(0),
+        nextCommission: new BigNumber(0),
+        nextCommissionBlock: new BigNumber(1),
+        lastSlashed: new BigNumber(-1),
+        slashingMultiplier: new BigNumber(1),
+      }
+      getValidatorRewardsMock.mockImplementationOnce(async () => [
+        {
+          validator: {
+            name: 'test-validator',
+            address: KNOWN_DEVCHAIN_VALIDATOR,
+            ecdsaPublicKey: 'test-ec-pubkey',
+            blsPublicKey: 'test-bls-pubkey',
+            affiliation: '',
+            score: new BigNumber(score),
+            signer: KNOWN_DEVCHAIN_VALIDATOR,
+          },
+          validatorPayment: new BigNumber(validatorPayment),
+          group: testGroup,
+          groupPayment: new BigNumber(1337),
+          epochNumber: 10000,
         },
-        validatorPayment: new BigNumber(validatorPayment),
-        group: testGroup,
-        groupPayment: new BigNumber(1337),
-        epochNumber: 10000,
-      },
-    ])
+      ])
 
-    await testLocallyWithWeb3Node(Show, ['--validator', KNOWN_DEVCHAIN_VALIDATOR], web3)
-    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
-      [
-        [
-          "Running Checks:",
-        ],
-        [
-          "   ✔  0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f is Validator ",
-        ],
-        [
-          "All checks passed",
-        ],
-      ]
-    `)
-    expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
-      [
-        [
-          "",
-        ],
-        [
-          "Validator rewards:",
-        ],
-      ]
-    `)
-    expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
-      [
-        [
-          " Validatorname  Validator                                  Validatorpayment Validatorscore Group                                      Epochnumber 
-      ",
-        ],
-        [
-          " ────────────── ────────────────────────────────────────── ──────────────── ────────────── ────────────────────────────────────────── ─────────── 
-      ",
-        ],
-        [
-          " test-validator 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f 1234567890       1337           0x4242424242424242424242424242424242424242             
-      ",
-        ],
-      ]
-    `)
-  })
+      await testLocallyWithWeb3Node(Show, ['--validator', KNOWN_DEVCHAIN_VALIDATOR], web3)
+      expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+              [
+                [
+                  "Running Checks:",
+                ],
+                [
+                  "   ✔  0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f is Validator ",
+                ],
+                [
+                  "All checks passed",
+                ],
+              ]
+          `)
+      expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
+              [
+                [
+                  "",
+                ],
+                [
+                  "Validator rewards:",
+                ],
+              ]
+          `)
+      expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
+              [
+                [
+                  " Validatorname  Validator                                  Validatorpayment Validatorscore Group                                      Epochnumber 
+              ",
+                ],
+                [
+                  " ────────────── ────────────────────────────────────────── ──────────────── ────────────── ────────────────────────────────────────── ─────────── 
+              ",
+                ],
+                [
+                  " test-validator 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f 1234567890       1337           0x4242424242424242424242424242424242424242             
+              ",
+                ],
+              ]
+          `)
+    })
 
-  test('--validator (slashed)', async () => {
-    const getValidatorRewardsMock = jest.spyOn(ValidatorsWrapper.prototype, 'getValidatorRewards')
-    const lockedGoldMock = jest.spyOn(LockedGoldWrapper.prototype, 'getAccountsSlashed')
+    test('slashed', async () => {
+      const getValidatorRewardsMock = jest.spyOn(ValidatorsWrapper.prototype, 'getValidatorRewards')
+      const lockedGoldMock = jest.spyOn(LockedGoldWrapper.prototype, 'getAccountsSlashed')
 
-    const validatorPayment = 1234567890
-    const score = 1337
-    const testGroup = {
-      name: 'test-group',
-      address: '0x4242424242424242424242424242424242424242',
-      members: [KNOWN_DEVCHAIN_VALIDATOR],
-      membersUpdated: 1,
-      affiliates: [],
-      commission: new BigNumber(0),
-      nextCommission: new BigNumber(0),
-      nextCommissionBlock: new BigNumber(1),
-      lastSlashed: new BigNumber(-1),
-      slashingMultiplier: new BigNumber(1),
-    }
-    getValidatorRewardsMock.mockImplementationOnce(async () => [
-      {
-        validator: {
-          name: 'test-validator',
-          address: KNOWN_DEVCHAIN_VALIDATOR,
-          ecdsaPublicKey: 'test-ec-pubkey',
-          blsPublicKey: 'test-bls-pubkey',
-          affiliation: '',
-          score: new BigNumber(score),
-          signer: KNOWN_DEVCHAIN_VALIDATOR,
+      const validatorPayment = 1234567890
+      const score = 1337
+      const testGroup = {
+        name: 'test-group',
+        address: '0x4242424242424242424242424242424242424242',
+        members: [KNOWN_DEVCHAIN_VALIDATOR],
+        membersUpdated: 1,
+        affiliates: [],
+        commission: new BigNumber(0),
+        nextCommission: new BigNumber(0),
+        nextCommissionBlock: new BigNumber(1),
+        lastSlashed: new BigNumber(-1),
+        slashingMultiplier: new BigNumber(1),
+      }
+      getValidatorRewardsMock.mockImplementationOnce(async () => [
+        {
+          validator: {
+            name: 'test-validator',
+            address: KNOWN_DEVCHAIN_VALIDATOR,
+            ecdsaPublicKey: 'test-ec-pubkey',
+            blsPublicKey: 'test-bls-pubkey',
+            affiliation: '',
+            score: new BigNumber(score),
+            signer: KNOWN_DEVCHAIN_VALIDATOR,
+          },
+          validatorPayment: new BigNumber(validatorPayment),
+          group: testGroup,
+          groupPayment: new BigNumber(1337),
+          epochNumber: 10000,
         },
-        validatorPayment: new BigNumber(validatorPayment),
-        group: testGroup,
-        groupPayment: new BigNumber(1337),
-        epochNumber: 10000,
-      },
-    ])
+      ])
 
-    lockedGoldMock.mockImplementationOnce(async () => [
-      {
-        slashed: KNOWN_DEVCHAIN_VALIDATOR,
-        epochNumber: 1,
-        penalty: new BigNumber(2),
-        reporter: '',
-        reward: new BigNumber(10),
-      },
-    ])
+      lockedGoldMock.mockImplementationOnce(async () => [
+        {
+          slashed: KNOWN_DEVCHAIN_VALIDATOR,
+          epochNumber: 1,
+          penalty: new BigNumber(2),
+          reporter: '',
+          reward: new BigNumber(10),
+        },
+      ])
 
-    await testLocallyWithWeb3Node(Show, ['--validator', KNOWN_DEVCHAIN_VALIDATOR], web3)
-    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
-      [
+      await testLocallyWithWeb3Node(Show, ['--validator', KNOWN_DEVCHAIN_VALIDATOR], web3)
+      expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+              [
+                [
+                  "Running Checks:",
+                ],
+                [
+                  "   ✔  0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f is Validator ",
+                ],
+                [
+                  "All checks passed",
+                ],
+              ]
+          `)
+      expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
+              [
+                [
+                  "",
+                ],
+                [
+                  "Validator rewards:",
+                ],
+                [
+                  "",
+                ],
+                [
+                  "Slashing penalties and rewards:",
+                ],
+              ]
+          `)
+      expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
+              [
+                [
+                  " Validatorname  Validator                                  Validatorpayment Validatorscore Group                                      Epochnumber 
+              ",
+                ],
+                [
+                  " ────────────── ────────────────────────────────────────── ──────────────── ────────────── ────────────────────────────────────────── ─────────── 
+              ",
+                ],
+                [
+                  " test-validator 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f 1234567890       1337           0x4242424242424242424242424242424242424242             
+              ",
+                ],
+                [
+                  " Slashed Penalty Reporter Reward Epochnumber 
+              ",
+                ],
+                [
+                  " ─────── ─────── ──────── ────── ─────────── 
+              ",
+                ],
+                [
+                  "         2                10                 
+              ",
+                ],
+              ]
+          `)
+    })
+
+    describe('--voter', () => {
+      test('invalid', async () => {
+        await expect(
+          testLocallyWithWeb3Node(
+            Show,
+            ['--voter', '0x1234567890123456789012345678901234567890'],
+            web3
+          )
+        ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
+        expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [
-          "Running Checks:",
-        ],
+          [
+            "Running Checks:",
+          ],
+          [
+            "   ✘  0x1234567890123456789012345678901234567890 is a registered Account 0x1234567890123456789012345678901234567890 is not registered as an account. Try running account:register",
+          ],
+        ]
+      `)
+      })
+      test('valid', async () => {
+        const kit = newKitFromWeb3(web3)
+        const [fromAddress] = await web3.eth.getAccounts()
+        await registerAccount(kit, fromAddress)
+        await expect(
+          testLocallyWithWeb3Node(Show, ['--voter', fromAddress, '--estimate'], web3)
+        ).resolves.toMatchInlineSnapshot(`undefined`)
+        expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [
-          "   ✔  0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f is Validator ",
-        ],
+          [
+            "Running Checks:",
+          ],
+          [
+            "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is a registered Account ",
+          ],
+          [
+            "All checks passed",
+          ],
+        ]
+      `)
+        expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
         [
-          "All checks passed",
-        ],
-      ]
-    `)
-    expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
-      [
-        [
-          "",
-        ],
-        [
-          "Validator rewards:",
-        ],
-        [
-          "",
-        ],
-        [
-          "Slashing penalties and rewards:",
-        ],
-      ]
-    `)
-    expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
-      [
-        [
-          " Validatorname  Validator                                  Validatorpayment Validatorscore Group                                      Epochnumber 
-      ",
-        ],
-        [
-          " ────────────── ────────────────────────────────────────── ──────────────── ────────────── ────────────────────────────────────────── ─────────── 
-      ",
-        ],
-        [
-          " test-validator 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f 1234567890       1337           0x4242424242424242424242424242424242424242             
-      ",
-        ],
-        [
-          " Slashed Penalty Reporter Reward Epochnumber 
-      ",
-        ],
-        [
-          " ─────── ─────── ──────── ────── ─────────── 
-      ",
-        ],
-        [
-          "         2                10                 
-      ",
-        ],
-      ]
-    `)
+          [
+            "No rewards.",
+          ],
+        ]
+      `)
+      })
+    })
   })
 })

--- a/packages/cli/src/commands/rewards/show.ts
+++ b/packages/cli/src/commands/rewards/show.ts
@@ -89,18 +89,22 @@ export default class Show extends BaseCommand {
         const electedValidators = await election.getElectedValidators(epochNumber)
         if (!filter) {
           const useBlockNumber = !res.flags.estimate
-          const epochGroupVoterRewards = await election.getGroupVoterRewards(
-            epochNumber,
-            useBlockNumber
-          )
-          groupVoterRewards = groupVoterRewards.concat(
-            epochGroupVoterRewards.map(
-              (e: GroupVoterReward): ExplainedGroupVoterReward => ({
-                ...e,
-                validators: filterValidatorsByGroup(electedValidators, e.group.address),
-              })
+          try {
+            const epochGroupVoterRewards = await election.getGroupVoterRewards(
+              epochNumber,
+              useBlockNumber
             )
-          )
+            groupVoterRewards = groupVoterRewards.concat(
+              epochGroupVoterRewards.map(
+                (e: GroupVoterReward): ExplainedGroupVoterReward => ({
+                  ...e,
+                  validators: filterValidatorsByGroup(electedValidators, e.group.address),
+                })
+              )
+            )
+          } catch (err) {
+            throw decorateMissingTrieError(err)
+          }
         } else if (res.flags.voter) {
           const address = res.flags.voter
           try {


### PR DESCRIPTION
### Description

The command would fail not very gracefully if not passing --estimate

This is is for L1 only and does not resolve 
- #415

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `rewards:show` command by adding error handling for missing estimates and improving test coverage for various scenarios, including valid and invalid validators and voters.

### Detailed summary
- Added error handling for missing estimates in `show.ts`.
- Updated tests in `show-l2.test.ts` for the `rewards:show` command.
- Enhanced `show.test.ts` with tests for:
  - Default behavior without arguments.
  - Error handling for missing trie nodes.
  - Validation checks for both validators and voters.
  - Logging outputs for successful and failed checks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->