### PR TITLE
deprecate flags, use dynamic on chain values, add tests

### DIFF
--- a/.changeset/perfect-pianos-jump.md
+++ b/.changeset/perfect-pianos-jump.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Show deprecated warning on flags which will be removed after cel2 launch

--- a/.changeset/rude-schools-help.md
+++ b/.changeset/rude-schools-help.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+use onchain values instead of static for lock requirements

--- a/docs/command-line-interface/validator.md
+++ b/docs/command-line-interface/validator.md
@@ -136,7 +136,7 @@ _See code: [src/commands/validator/deaffiliate.ts](https://github.com/celo-org/d
 
 ## `celocli validator:deregister`
 
-Deregister a Validator. Approximately 60 days after the validator is no longer part of any group, it will be possible to deregister the validator and start unlocking the CELO. If you wish to deregister your validator, you must first remove it from it's group, such as by deaffiliating it, then wait the required 60 days before running this command.
+Deregister a Validator. Wait the require lock period after the validator is no longer part of any group, then it will be possible to deregister the validator and start unlocking the CELO. If you wish to deregister your validator, you must first remove it from it's group, such as by deaffiliating it, then wait the required days before running this command.
 
 ```
 USAGE
@@ -170,11 +170,11 @@ FLAGS
       Set it to use a ledger wallet
 
 DESCRIPTION
-  Deregister a Validator. Approximately 60 days after the validator is no longer part of
-  any group, it will be possible to deregister the validator and start unlocking the
-  CELO. If you wish to deregister your validator, you must first remove it from it's
-  group, such as by deaffiliating it, then wait the required 60 days before running this
-  command.
+  Deregister a Validator. Wait the require lock period after the validator is no longer
+  part of any group, then it will be possible to deregister the validator and start
+  unlocking the CELO. If you wish to deregister your validator, you must first remove it
+  from it's group, such as by deaffiliating it, then wait the required days before
+  running this command.
 
 EXAMPLES
   deregister --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95

--- a/docs/command-line-interface/validatorgroup.md
+++ b/docs/command-line-interface/validatorgroup.md
@@ -80,7 +80,7 @@ _See code: [src/commands/validatorgroup/commission.ts](https://github.com/celo-o
 
 ## `celocli validatorgroup:deregister`
 
-Deregister a Validator Group. Approximately 180 days after the validator group is empty, it will be possible to deregister it start unlocking the CELO. If you wish to deregister your validator group, you must first remove all members, then wait the required 180 days before running this command.
+Deregister a Validator Group. After the group lock perioid has passed it will be possible to deregister it start unlocking the CELO. If you wish to deregister your validator group, you must first remove all members, then wait the required time before running this command.
 
 ```
 USAGE
@@ -114,10 +114,10 @@ FLAGS
       Set it to use a ledger wallet
 
 DESCRIPTION
-  Deregister a Validator Group. Approximately 180 days after the validator group is
-  empty, it will be possible to deregister it start unlocking the CELO. If you wish to
-  deregister your validator group, you must first remove all members, then wait the
-  required 180 days before running this command.
+  Deregister a Validator Group. After the group lock perioid has passed it will be
+  possible to deregister it start unlocking the CELO. If you wish to deregister your
+  validator group, you must first remove all members, then wait the required time before
+  running this command.
 
 EXAMPLES
   deregister --from 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95

--- a/packages/cli/src/base-l2.test.ts
+++ b/packages/cli/src/base-l2.test.ts
@@ -45,9 +45,7 @@ describe('flags', () => {
       await help.showHelp(['transfer:celo', '--help'])
       expect(stripAnsiCodesFromNestedArray(writeSpy.mock.calls)).toHaveLength(3)
       expect(stripAnsiCodesFromNestedArray(writeSpy.mock.calls)[1][0]).toEqual(
-        expect.stringContaining(
-          `-n, --node=<value>  URL of the node to run commands against or an alias`
-        )
+        expect.stringContaining(`-n, --node=<value>`)
       )
     })
   })

--- a/packages/cli/src/commands/account/authorize.ts
+++ b/packages/cli/src/commands/account/authorize.ts
@@ -23,12 +23,14 @@ export default class Authorize extends BaseCommand {
     }),
     signer: CustomFlags.address({ required: true }),
     blsKey: CustomFlags.blsPublicKey({
+      deprecated: true,
       description:
         'The BLS public key that the validator is using for consensus, should pass proof of possession. 96 bytes.',
       dependsOn: ['blsPop'],
       required: false,
     }),
     blsPop: CustomFlags.blsProofOfPossession({
+      deprecated: true,
       description:
         'The BLS public key proof-of-possession, which consists of a signature on the account address. 48 bytes.',
       dependsOn: ['blsKey'],

--- a/packages/cli/src/commands/dkg/register.ts
+++ b/packages/cli/src/commands/dkg/register.ts
@@ -12,7 +12,7 @@ export default class DKGRegister extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flags,
-    blsKey: Flags.string({ required: true }),
+    blsKey: Flags.string({ required: true, deprecated: true }),
     address: CustomFlags.address({ required: true, description: 'DKG Contract Address' }),
     from: CustomFlags.address({ required: true, description: 'Address of the sender' }),
   }

--- a/packages/cli/src/commands/releasecelo/authorize.ts
+++ b/packages/cli/src/commands/releasecelo/authorize.ts
@@ -19,11 +19,13 @@ export default class Authorize extends ReleaseGoldBaseCommand {
       required: true,
     }),
     blsKey: CustomFlags.blsPublicKey({
+      deprecated: true,
       description:
         'The BLS public key that the validator is using for consensus, should pass proof of possession. 96 bytes.',
       dependsOn: ['blsPop'],
     }),
     blsPop: CustomFlags.blsProofOfPossession({
+      deprecated: true,
       description:
         'The BLS public key proof-of-possession, which consists of a signature on the account address. 48 bytes.',
       dependsOn: ['blsKey'],

--- a/packages/cli/src/commands/validator/affiliate.ts
+++ b/packages/cli/src/commands/validator/affiliate.ts
@@ -46,7 +46,7 @@ export default class ValidatorAffiliate extends BaseCommand {
         type: 'confirm',
         name: 'confirmation',
         message: `Are you sure you want to affiliate with this group?
-Affiliating with a Validator Group could result in Locked Gold requirements of up to ${requiredCelo} CELO for ${requiredDays} days. (y/n)`,
+Affiliating with a Validator Group could result in Locked Gold requirements of up to ${requiredCelo} CELO for ${requiredDays}. (y/n)`,
       })
 
       if (!response.confirmation) {

--- a/packages/cli/src/commands/validator/affiliate.ts
+++ b/packages/cli/src/commands/validator/affiliate.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 import prompts from 'prompts'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displaySendTx, huamnizeRequirements } from '../../utils/cli'
 import { CustomArgs, CustomFlags } from '../../utils/command'
 
 export default class ValidatorAffiliate extends BaseCommand {
@@ -39,12 +39,14 @@ export default class ValidatorAffiliate extends BaseCommand {
       .isValidatorGroup(groupAddress)
       .runChecks()
 
+    const requirements = await validators.getValidatorLockedGoldRequirements()
+    const { requiredCelo, requiredDays } = huamnizeRequirements(requirements)
     if (!res.flags.yes) {
       const response = await prompts({
         type: 'confirm',
         name: 'confirmation',
-        message:
-          'Are you sure you want to affiliate with this group?\nAffiliating with a Validator Group could result in Locked Gold requirements of up to 10,000 CELO for 60 days. (y/n)',
+        message: `Are you sure you want to affiliate with this group?
+Affiliating with a Validator Group could result in Locked Gold requirements of up to ${requiredCelo} CELO for ${requiredDays} days. (y/n)`,
       })
 
       if (!response.confirmation) {

--- a/packages/cli/src/commands/validator/affiliate.ts
+++ b/packages/cli/src/commands/validator/affiliate.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 import prompts from 'prompts'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx, huamnizeRequirements } from '../../utils/cli'
+import { displaySendTx, humanizeRequirements } from '../../utils/cli'
 import { CustomArgs, CustomFlags } from '../../utils/command'
 
 export default class ValidatorAffiliate extends BaseCommand {
@@ -40,7 +40,7 @@ export default class ValidatorAffiliate extends BaseCommand {
       .runChecks()
 
     const requirements = await validators.getValidatorLockedGoldRequirements()
-    const { requiredCelo, requiredDays } = huamnizeRequirements(requirements)
+    const { requiredCelo, requiredDays } = humanizeRequirements(requirements)
     if (!res.flags.yes) {
       const response = await prompts({
         type: 'confirm',

--- a/packages/cli/src/commands/validator/deregister.test.ts
+++ b/packages/cli/src/commands/validator/deregister.test.ts
@@ -136,7 +136,7 @@ testWithAnvilL2('validator:deregister', (web3: Web3) => {
                   "   ✔  Account isn't a member of a validator group ",
                 ],
                 [
-                  "   ✔  Enough time has passed since the account was removed from a validator group ",
+                  "   ✔  Enough time has passed since the account was removed from a validator group? ",
                 ],
                 [
                   "All checks passed",

--- a/packages/cli/src/commands/validator/deregister.test.ts
+++ b/packages/cli/src/commands/validator/deregister.test.ts
@@ -189,7 +189,7 @@ testWithAnvilL2('validator:deregister', (web3: Web3) => {
             "   ✘  Account isn't a member of a validator group ",
           ],
           [
-            "   ✘  Enough time has passed since the account was removed from a validator group ",
+            "   ✘  Enough time has passed since the account was removed from a validator group? ",
           ],
         ]
       `)

--- a/packages/cli/src/commands/validator/deregister.ts
+++ b/packages/cli/src/commands/validator/deregister.ts
@@ -4,9 +4,8 @@ import { displaySendTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class ValidatorDeregister extends BaseCommand {
-  // TODO time period to deregister might have changed for L2 consider adding a wait to show the actual
   static description =
-    "Deregister a Validator. Approximately 60 days after the validator is no longer part of any group, it will be possible to deregister the validator and start unlocking the CELO. If you wish to deregister your validator, you must first remove it from it's group, such as by deaffiliating it, then wait the required 60 days before running this command."
+    "Deregister a Validator. Wait the require lock period after the validator is no longer part of any group, then it will be possible to deregister the validator and start unlocking the CELO. If you wish to deregister your validator, you must first remove it from it's group, such as by deaffiliating it, then wait the required days before running this command."
 
   static flags = {
     ...BaseCommand.flags,

--- a/packages/cli/src/commands/validator/register.ts
+++ b/packages/cli/src/commands/validator/register.ts
@@ -13,8 +13,8 @@ export default class ValidatorRegister extends BaseCommand {
     ...BaseCommand.flags,
     from: CustomFlags.address({ required: true, description: 'Address for the Validator' }),
     ecdsaKey: CustomFlags.ecdsaPublicKey({ required: true }),
-    blsKey: CustomFlags.blsPublicKey({ required: false }),
-    blsSignature: CustomFlags.blsProofOfPossession({ required: false }),
+    blsKey: CustomFlags.blsPublicKey({ required: false, deprecated: true }),
+    blsSignature: CustomFlags.blsProofOfPossession({ required: false, deprecated: true }),
     yes: Flags.boolean({ description: 'Answer yes to prompt' }),
   }
 

--- a/packages/cli/src/commands/validatorgroup/deregister.test.ts
+++ b/packages/cli/src/commands/validatorgroup/deregister.test.ts
@@ -1,39 +1,40 @@
+import { Address } from '@celo/base'
+import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import Web3 from 'web3'
+import {
+  mockTimeForwardBy,
+  setupGroup,
+  setupValidatorAndAddToGroup,
+} from '../../test-utils/chain-setup'
 import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import AccountRegister from '../account/register'
-import Lock from '../lockedgold/lock'
 import DeRegisterValidatorGroup from './deregister'
-import ValidatorGroupRegister from './register'
+import ValidatorGroupMembers from './member'
 
 process.env.NO_SYNCCHECK = 'true'
 
 testWithAnvilL2('validatorgroup:deregister cmd', (web3: Web3) => {
+  let groupAddress: Address
+  let validatorAddress: Address
+  let kit: ContractKit
   beforeEach(async () => {
-    const accounts = await web3.eth.getAccounts()
-    await testLocallyWithWeb3Node(AccountRegister, ['--from', accounts[0]], web3)
-    await testLocallyWithWeb3Node(
-      Lock,
-      ['--from', accounts[0], '--value', '10000000000000000000000'],
-      web3
-    )
-    await testLocallyWithWeb3Node(
-      ValidatorGroupRegister,
-      ['--from', accounts[0], '--commission', '0.2', '--yes'],
-      web3
-    )
+    kit = newKitFromWeb3(web3)
+    const addresses = await web3.eth.getAccounts()
+    groupAddress = addresses[0]
+    validatorAddress = addresses[1]
+    await setupGroup(kit, groupAddress)
   })
   afterEach(() => {
     jest.clearAllMocks()
   })
   describe('when group never had members', () => {
     it('deregisters a group', async () => {
-      const logSpy = jest.spyOn(console, 'log')
-      const writeMock = jest.spyOn(ux.write, 'stdout')
-      const accounts = await web3.eth.getAccounts()
+      const logSpy = jest.spyOn(console, 'log').mockImplementation()
+      const writeMock = jest.spyOn(ux.write, 'stdout').mockImplementation()
 
-      await testLocallyWithWeb3Node(DeRegisterValidatorGroup, ['--from', accounts[0]], web3)
+      await testLocallyWithWeb3Node(DeRegisterValidatorGroup, ['--from', groupAddress], web3)
 
       expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
         [
@@ -48,6 +49,9 @@ testWithAnvilL2('validatorgroup:deregister cmd', (web3: Web3) => {
           ],
           [
             "   ✔  Signer account is ValidatorGroup ",
+          ],
+          [
+            "   ✔  Enough time has passed since the validator group removed its last member?  ",
           ],
           [
             "All checks passed",
@@ -65,22 +69,103 @@ testWithAnvilL2('validatorgroup:deregister cmd', (web3: Web3) => {
   })
 
   describe('when group has had members', () => {
-    beforeEach(async () => {})
-    it.todo(
-      'to test this need to register a validator and add it to the group then remove it then try to deregister the group'
-    )
+    beforeEach(async () => {
+      await setupValidatorAndAddToGroup(kit, validatorAddress, groupAddress)
+      await testLocallyWithWeb3Node(
+        ValidatorGroupMembers,
+        ['--yes', '--from', groupAddress, '--remove', validatorAddress],
+        web3
+      )
+      const validators = await kit.contracts.getValidators()
+      await validators.deaffiliate().sendAndWaitForReceipt({ from: validatorAddress })
+    })
+    describe('when not enough time has passed', () => {
+      it('shows error that wait period is not over', async () => {
+        const logMock = jest.spyOn(console, 'log').mockImplementation()
+        logMock.mockClear()
+        await expect(
+          testLocallyWithWeb3Node(DeRegisterValidatorGroup, ['--from', groupAddress], web3)
+        ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
+        expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+          [
+            [
+              "Running Checks:",
+            ],
+            [
+              "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is Signer or registered Account ",
+            ],
+            [
+              "   ✔  Signer can sign Validator Txs ",
+            ],
+            [
+              "   ✔  Signer account is ValidatorGroup ",
+            ],
+            [
+              "   ✘  Enough time has passed since the validator group removed its last member?  ",
+            ],
+          ]
+        `)
+        const validators = await kit.contracts.getValidators()
+        expect(validators.isValidatorGroup(groupAddress)).resolves.toBe(true)
+      })
+    })
+    describe('when wait duration for unlocking is over', () => {
+      it.only('deregisters the group', async () => {
+        const validators = await kit.contracts.getValidators()
+        const group = await validators.getValidatorGroup(groupAddress)
+        expect(group.members).toHaveLength(0)
+        expect(group.affiliates).toHaveLength(0)
+        const groupRequirements = await validators.getGroupLockedGoldRequirements()
+        const timeSpy = await mockTimeForwardBy(groupRequirements.duration.toNumber() * 2, web3)
+        const logMock = jest.spyOn(console, 'log').mockImplementation()
+        await expect(
+          testLocallyWithWeb3Node(DeRegisterValidatorGroup, ['--from', groupAddress], web3)
+        ).resolves.toBeUndefined()
+        expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+          [
+            [
+              "Running Checks:",
+            ],
+            [
+              "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is Signer or registered Account ",
+            ],
+            [
+              "   ✔  Signer can sign Validator Txs ",
+            ],
+            [
+              "   ✔  Signer account is ValidatorGroup ",
+            ],
+            [
+              "   ✔  Enough time has passed since the validator group removed its last member?  ",
+            ],
+            [
+              "All checks passed",
+            ],
+            [
+              "SendTransaction: deregister",
+            ],
+            [
+              "txHash: 0xtxhash",
+            ],
+          ]
+        `)
+        await expect(validators.isValidatorGroup(groupAddress)).resolves.toBe(false)
+        timeSpy.mockClear()
+      })
+    })
   })
 
   describe('when is not a validator group', () => {
     beforeEach(async () => {
       const accounts = await web3.eth.getAccounts()
-      await testLocallyWithWeb3Node(AccountRegister, ['--from', accounts[1]], web3)
+      await testLocallyWithWeb3Node(AccountRegister, ['--from', accounts[2]], web3)
     })
-    it('fails', async () => {
-      const logSpy = jest.spyOn(console, 'log')
+    it('shows error message', async () => {
+      const logSpy = jest.spyOn(console, 'log').mockImplementation()
       const accounts = await web3.eth.getAccounts()
+      logSpy.mockClear()
       await expect(
-        testLocallyWithWeb3Node(DeRegisterValidatorGroup, ['--from', accounts[1]], web3)
+        testLocallyWithWeb3Node(DeRegisterValidatorGroup, ['--from', accounts[2]], web3)
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
       expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
         [
@@ -88,91 +173,7 @@ testWithAnvilL2('validatorgroup:deregister cmd', (web3: Web3) => {
             "Running Checks:",
           ],
           [
-            "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is not a registered Account ",
-          ],
-          [
-            "All checks passed",
-          ],
-          [
-            "SendTransaction: register",
-          ],
-          [
-            "txHash: 0xtxhash",
-          ],
-          [
-            "Running Checks:",
-          ],
-          [
-            "   ✔  Value [10000000000000000000000] is > 0 ",
-          ],
-          [
-            "All checks passed",
-          ],
-          [
-            "Running Checks:",
-          ],
-          [
-            "   ✔  Account has at least 10000 CELO ",
-          ],
-          [
-            "All checks passed",
-          ],
-          [
-            "SendTransaction: lock",
-          ],
-          [
-            "txHash: 0xtxhash",
-          ],
-          [
-            "Running Checks:",
-          ],
-          [
-            "   ✔  Commission is in range [0,1] ",
-          ],
-          [
-            "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is Signer or registered Account ",
-          ],
-          [
-            "   ✔  Signer can sign Validator Txs ",
-          ],
-          [
-            "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is not a registered Validator ",
-          ],
-          [
-            "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 is not a registered ValidatorGroup ",
-          ],
-          [
-            "   ✔  Signer's account has enough locked celo for group registration ",
-          ],
-          [
-            "All checks passed",
-          ],
-          [
-            "SendTransaction: registerValidatorGroup",
-          ],
-          [
-            "txHash: 0xtxhash",
-          ],
-          [
-            "Running Checks:",
-          ],
-          [
-            "   ✔  0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb is not a registered Account ",
-          ],
-          [
-            "All checks passed",
-          ],
-          [
-            "SendTransaction: register",
-          ],
-          [
-            "txHash: 0xtxhash",
-          ],
-          [
-            "Running Checks:",
-          ],
-          [
-            "   ✔  0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb is Signer or registered Account ",
+            "   ✔  0xE36Ea790bc9d7AB70C55260C66D52b1eca985f84 is Signer or registered Account ",
           ],
           [
             "   ✔  Signer can sign Validator Txs ",

--- a/packages/cli/src/commands/validatorgroup/deregister.ts
+++ b/packages/cli/src/commands/validatorgroup/deregister.ts
@@ -4,9 +4,8 @@ import { displaySendTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class ValidatorGroupDeRegister extends BaseCommand {
-  // TODO with L2 the wait time may have changed on this.
   static description =
-    'Deregister a Validator Group. Approximately 180 days after the validator group is empty, it will be possible to deregister it start unlocking the CELO. If you wish to deregister your validator group, you must first remove all members, then wait the required 180 days before running this command.'
+    'Deregister a Validator Group. After the group lock perioid has passed it will be possible to deregister it start unlocking the CELO. If you wish to deregister your validator group, you must first remove all members, then wait the required time before running this command.'
 
   static flags = {
     ...BaseCommand.flags,
@@ -30,7 +29,8 @@ export default class ValidatorGroupDeRegister extends BaseCommand {
       .isSignerOrAccount()
       .canSignValidatorTxs()
       .signerAccountIsValidatorGroup()
-      .runChecks()
+      .validatorGroupDeregisterDurationPassed()
+      .then((checks) => checks.runChecks())
 
     await displaySendTx('deregister', await validators.deregisterValidatorGroup(account))
   }

--- a/packages/cli/src/commands/validatorgroup/member.ts
+++ b/packages/cli/src/commands/validatorgroup/member.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 import prompts from 'prompts'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displaySendTx, huamnizeRequirements } from '../../utils/cli'
 import { CustomArgs, CustomFlags } from '../../utils/command'
 
 export default class ValidatorGroupMembers extends BaseCommand {
@@ -57,11 +57,13 @@ export default class ValidatorGroupMembers extends BaseCommand {
     const validatorGroup = await validators.signerToAccount(res.flags.from)
     if (res.flags.accept) {
       if (!res.flags.yes) {
+        const requirements = await validators.getGroupLockedGoldRequirements()
+        const { requiredCelo, requiredDays } = huamnizeRequirements(requirements)
         const response = await prompts({
           type: 'confirm',
           name: 'confirmation',
-          message:
-            'Are you sure you want to accept this member?\nValidator Group Locked Gold requirements increase per member. Adding an additional member could result in an increase in Locked Gold requirements of up to 10,000 CELO for 180 days. (y/n)',
+          message: `Are you sure you want to accept this member?
+  Validator Group Locked Gold requirements increase per member. Adding an additional member could result in an increase in Locked Gold requirements of up to ${requiredCelo} CELO for ${requiredDays} days. (y/n)`,
         })
 
         if (!response.confirmation) {

--- a/packages/cli/src/commands/validatorgroup/member.ts
+++ b/packages/cli/src/commands/validatorgroup/member.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 import prompts from 'prompts'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx, huamnizeRequirements } from '../../utils/cli'
+import { displaySendTx, humanizeRequirements } from '../../utils/cli'
 import { CustomArgs, CustomFlags } from '../../utils/command'
 
 export default class ValidatorGroupMembers extends BaseCommand {
@@ -58,7 +58,7 @@ export default class ValidatorGroupMembers extends BaseCommand {
     if (res.flags.accept) {
       if (!res.flags.yes) {
         const requirements = await validators.getGroupLockedGoldRequirements()
-        const { requiredCelo, requiredDays } = huamnizeRequirements(requirements)
+        const { requiredCelo, requiredDays } = humanizeRequirements(requirements)
         const response = await prompts({
           type: 'confirm',
           name: 'confirmation',

--- a/packages/cli/src/commands/validatorgroup/member.ts
+++ b/packages/cli/src/commands/validatorgroup/member.ts
@@ -63,7 +63,7 @@ export default class ValidatorGroupMembers extends BaseCommand {
           type: 'confirm',
           name: 'confirmation',
           message: `Are you sure you want to accept this member?
-  Validator Group Locked Gold requirements increase per member. Adding an additional member could result in an increase in Locked Gold requirements of up to ${requiredCelo} CELO for ${requiredDays} days. (y/n)`,
+  Validator Group Locked Gold requirements increase per member. Adding an additional member could result in an increase in Locked Gold requirements of up to ${requiredCelo} CELO for ${requiredDays}. (y/n)`,
         })
 
         if (!response.confirmation) {

--- a/packages/cli/src/utils/cli.test.ts
+++ b/packages/cli/src/utils/cli.test.ts
@@ -1,6 +1,7 @@
 import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import BigNumber from 'bignumber.js'
 import { stripAnsiCodesFromNestedArray } from '../test-utils/cliUtils'
-import { printValueMapRecursive } from './cli'
+import { humanizeRequirements, printValueMapRecursive } from './cli'
 testWithAnvilL2('printValueMapRecursive', async () => {
   it('should print the key-value pairs in the value map recursively', () => {
     const valueMap = {
@@ -67,5 +68,52 @@ testWithAnvilL2('printValueMapRecursive', async () => {
         ],
       ]
     `)
+  })
+})
+
+describe('humanizeRequirements', () => {
+  describe('requiredDuration', () => {
+    const celoINWei = new BigNumber('1000000000000000000000')
+    it('shows when duration is hours ', () => {
+      const { requiredDays } = humanizeRequirements({
+        duration: new BigNumber(60 * 60),
+        value: celoINWei,
+      })
+      expect(requiredDays).toEqual('1 hour')
+    })
+    it('shows when duration is days ', () => {
+      const { requiredDays } = humanizeRequirements({
+        duration: new BigNumber(60 * 60 * 24 * 2),
+        value: celoINWei,
+      })
+      expect(requiredDays).toEqual('2 days')
+    })
+    it('shows when duration is weeks ', () => {
+      const { requiredDays } = humanizeRequirements({
+        duration: new BigNumber(60 * 60 * 24 * 15),
+        value: celoINWei,
+      })
+      expect(requiredDays).toEqual('2 weeks, 1 day')
+    })
+    it('shows when duration is months ', () => {
+      const { requiredDays } = humanizeRequirements({
+        duration: new BigNumber(60 * 60 * 24 * 65),
+        value: celoINWei,
+      })
+      expect(requiredDays).toEqual('2 months, 4 days, 3 hours')
+    })
+  })
+  describe('requiredCELO', () => {
+    const duration = new BigNumber(1000 * 60 * 60)
+    it('shows when value is small ', () => {
+      const celoINWei = new BigNumber('1e18')
+      const { requiredCelo } = humanizeRequirements({ duration, value: celoINWei })
+      expect(requiredCelo).toEqual('1.0')
+    })
+    it('shows when value is big ', () => {
+      const celoINWei = new BigNumber('1e23')
+      const { requiredCelo } = humanizeRequirements({ duration, value: celoINWei })
+      expect(requiredCelo).toEqual('100000.0')
+    })
   })
 })

--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -6,11 +6,13 @@ import {
   parseDecodedParams,
   TransactionResult,
 } from '@celo/connect'
+import { LockedGoldRequirements } from '@celo/contractkit/lib/wrappers/Validators'
 import { Errors, ux } from '@oclif/core'
 import { TransactionResult as SafeTransactionResult } from '@safe-global/types-kit'
 import BigNumber from 'bignumber.js'
 import chalk from 'chalk'
 import { ethers } from 'ethers'
+import { formatEther } from 'ethers/lib/utils'
 import { convertEthersToCeloTx } from './mento-broker-adaptor'
 
 const CLIError = Errors.CLIError
@@ -174,4 +176,10 @@ export async function binaryPrompt(promptMessage: string, defaultToNo?: boolean)
 
 export function getCurrentTimestamp() {
   return Math.floor(Date.now() / 1000)
+}
+
+export function huamnizeRequirements(requirements: LockedGoldRequirements) {
+  const requiredCelo = formatEther(requirements.value.toString())
+  const requiredDays = requirements.duration.toNumber() / (60 * 60 * 24)
+  return { requiredCelo, requiredDays }
 }

--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -178,7 +178,7 @@ export function getCurrentTimestamp() {
   return Math.floor(Date.now() / 1000)
 }
 
-export function huamnizeRequirements(requirements: LockedGoldRequirements) {
+export function humanizeRequirements(requirements: LockedGoldRequirements) {
   const requiredCelo = formatEther(requirements.value.toFixed())
   const requiredDays = requirements.duration.toNumber() / (60 * 60 * 24)
   return { requiredCelo, requiredDays }

--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -179,7 +179,7 @@ export function getCurrentTimestamp() {
 }
 
 export function huamnizeRequirements(requirements: LockedGoldRequirements) {
-  const requiredCelo = formatEther(requirements.value.toString())
+  const requiredCelo = formatEther(requirements.value.toFixed())
   const requiredDays = requirements.duration.toNumber() / (60 * 60 * 24)
   return { requiredCelo, requiredDays }
 }

--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -13,6 +13,7 @@ import BigNumber from 'bignumber.js'
 import chalk from 'chalk'
 import { ethers } from 'ethers'
 import { formatEther } from 'ethers/lib/utils'
+import humanizeDuration from 'humanize-duration'
 import { convertEthersToCeloTx } from './mento-broker-adaptor'
 
 const CLIError = Errors.CLIError
@@ -180,6 +181,9 @@ export function getCurrentTimestamp() {
 
 export function humanizeRequirements(requirements: LockedGoldRequirements) {
   const requiredCelo = formatEther(requirements.value.toFixed())
-  const requiredDays = requirements.duration.toNumber() / (60 * 60 * 24)
+  const requiredDays = humanizeDuration(requirements.duration.toNumber() * 1000, {
+    round: true,
+    maxDecimalPoints: 1,
+  })
   return { requiredCelo, requiredDays }
 }


### PR DESCRIPTION
### Description

* mark flags as deprecated which will be non functional on L2 
* use values from on chain for lock requirements
* test member add/remove and deregister

#### Other changes

add async conditional check to checks 

### Related issues

- Fixes #451

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `@celo/celocli` CLI tool by implementing deprecated warnings for certain flags, updating lock requirements to use on-chain values, and improving user prompts. It also refines the deregistration process for validators and validator groups.

### Detailed summary
- Added deprecated warnings to specific flags in `packages/cli/src/commands/dkg/register.ts`, `packages/cli/src/commands/releasecelo/authorize.ts`, `packages/cli/src/commands/account/authorize.ts`, and `packages/cli/src/commands/validator/register.ts`.
- Updated lock requirements to use on-chain values in `packages/cli/src/utils/cli.ts`.
- Enhanced user prompts in `packages/cli/src/commands/validator/affiliate.ts` and `packages/cli/src/commands/validatorgroup/member.ts` to include dynamic Locked Gold requirements.
- Modified deregistration description in `packages/cli/src/commands/validator/deregister.ts` and `packages/cli/src/commands/validatorgroup/deregister.ts` for clarity.
- Implemented new checks for deregistration timing in `packages/cli/src/commands/validator/deregister.ts` and `packages/cli/src/commands/validatorgroup/deregister.ts`.
- Created `humanizeRequirements` function in `packages/cli/src/utils/cli.ts` to format the display of required Locked Gold.
- Added tests for new functionality in `packages/cli/src/utils/cli.test.ts` and `packages/cli/src/commands/validatorgroup/member.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->