### PR TITLE
Mark methods that are L1only as deprecated

### DIFF
--- a/.changeset/real-camels-argue.md
+++ b/.changeset/real-camels-argue.md
@@ -1,0 +1,17 @@
+---
+'@celo/contractkit': patch
+---
+
+Mark contract wrapper methods that will not work on L2 because solidity contracts have onlyL1 modifier as deprecated.
+
+| Deprecated Contract / Method | Replacement or none |
+|--------|--------|
+| Validators#registerValidator | Validators#registerValidatorNoBLS |
+| BlockchainParams#getEpochNumberOfBlock | EpochManager#getEpochNumberOfBlock |
+| BlockchainParams#getFirstBlockNumberForEpoch | EpochManager#getFirstBlockAtEpoch|
+| Election#getCurrentValidatorSigners |  EpochManager#getElectedSigners |
+| Election#getGroupEpochRewards | Election#getGroupEpochRewardsBasedOnScore | 
+| GovernanceSlasher#slash |  GovernanceSlasher#slashL2 | 
+| DoubleSigningSlasher  | X | 
+| DowntimeSlasher  | X |
+

--- a/docs/sdk/contractkit/classes/wrappers_BaseSlasher.BaseSlasher.md
+++ b/docs/sdk/contractkit/classes/wrappers_BaseSlasher.BaseSlasher.md
@@ -4,6 +4,10 @@
 
 [wrappers/BaseSlasher](../modules/wrappers_BaseSlasher.md).BaseSlasher
 
+**`Deprecated`**
+
+Contract will be complete removed see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 ## Type parameters
 
 | Name | Type |
@@ -144,7 +148,7 @@ Rewards and penalties for slashing.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BaseSlasher.ts:70](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BaseSlasher.ts#L70)
+[packages/sdk/contractkit/src/wrappers/BaseSlasher.ts:72](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BaseSlasher.ts#L72)
 
 ## Accessors
 

--- a/docs/sdk/contractkit/classes/wrappers_BlockchainParameters.BlockchainParametersWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_BlockchainParameters.BlockchainParametersWrapper.md
@@ -6,6 +6,10 @@
 
 Network parameters that are configurable by governance.
 
+**`Deprecated`**
+
+Contract will be complete removed see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 ## Hierarchy
 
 - [`BaseWrapper`](wrappers_BaseWrapper.BaseWrapper.md)\<`BlockchainParameters`\>
@@ -135,7 +139,7 @@ Getting the block gas limit.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:34](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L34)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:35](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L35)
 
 ___
 
@@ -159,7 +163,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:104](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L104)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:105](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L105)
 
 ___
 
@@ -183,7 +187,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:106](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L106)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:107](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L107)
 
 ___
 
@@ -211,7 +215,7 @@ Get the extra intrinsic gas for transactions, where gas is paid using non-gold c
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:17](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L17)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:18](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L18)
 
 ___
 
@@ -239,7 +243,7 @@ Getting the uptime lookback window.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:54](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L54)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:55](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L55)
 
 ___
 
@@ -281,7 +285,7 @@ Setting the block gas limit.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:39](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L39)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:40](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L40)
 
 ___
 
@@ -309,7 +313,7 @@ Setting the extra intrinsic gas for transactions, where gas is paid using non-go
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:26](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L26)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:27](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L27)
 
 ___
 
@@ -337,7 +341,7 @@ Setting the uptime lookback window.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:62](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L62)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:63](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L63)
 
 ## Accessors
 
@@ -373,7 +377,7 @@ Returns current configuration parameters.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:44](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L44)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:45](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L45)
 
 ___
 
@@ -393,7 +397,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:93](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L93)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:94](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L94)
 
 ___
 
@@ -407,7 +411,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:67](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L67)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:68](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L68)
 
 ___
 
@@ -427,7 +431,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:73](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L73)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:74](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L74)
 
 ___
 
@@ -447,7 +451,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:83](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L83)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:84](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L84)
 
 ___
 

--- a/docs/sdk/contractkit/classes/wrappers_DoubleSigningSlasher.DoubleSigningSlasherWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_DoubleSigningSlasher.DoubleSigningSlasherWrapper.md
@@ -6,6 +6,10 @@
 
 Contract handling slashing for Validator double-signing
 
+**`Deprecated`**
+
+Contract will be complete removed see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 ## Hierarchy
 
 - [`BaseSlasher`](wrappers_BaseSlasher.BaseSlasher.md)\<`DoubleSigningSlasher`\>
@@ -147,7 +151,7 @@ Rewards and penalties for slashing.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BaseSlasher.ts:70](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BaseSlasher.ts#L70)
+[packages/sdk/contractkit/src/wrappers/BaseSlasher.ts:72](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BaseSlasher.ts#L72)
 
 ## Accessors
 
@@ -191,7 +195,7 @@ Block number.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts:15](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts#L15)
+[packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts:16](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts#L16)
 
 ___
 
@@ -242,7 +246,7 @@ Slash a Validator signer for double-signing.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts:38](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts#L38)
+[packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts:39](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts#L39)
 
 ___
 
@@ -266,7 +270,7 @@ Slash a Validator for double-signing.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts:26](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts#L26)
+[packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts:27](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts#L27)
 
 ___
 

--- a/docs/sdk/contractkit/classes/wrappers_DowntimeSlasher.DowntimeSlasherWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_DowntimeSlasher.DowntimeSlasherWrapper.md
@@ -6,6 +6,10 @@
 
 Contract handling slashing for Validator downtime using intervals.
 
+**`Deprecated`**
+
+Contract will be complete removed https://github.com/celo-org/celo-monorepo/blob/release/core-contracts/12/packages/protocol/contracts/governance/DowntimeSlasher.sol
+
 ## Hierarchy
 
 - [`BaseSlasher`](wrappers_BaseSlasher.BaseSlasher.md)\<`DowntimeSlasher`\>
@@ -168,7 +172,7 @@ the current block.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:73](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L73)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:74](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L74)
 
 ___
 
@@ -205,7 +209,7 @@ the specific interval.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:132](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L132)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:133](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L133)
 
 ___
 
@@ -229,7 +233,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:146](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L146)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:147](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L147)
 
 ___
 
@@ -285,7 +289,7 @@ interval.start and interval.end must be in the same epoch.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:85](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L85)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:86](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L86)
 
 ___
 
@@ -316,7 +320,7 @@ can be slashed.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:37](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L37)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:38](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L38)
 
 ___
 
@@ -350,7 +354,7 @@ Rewards and penalties for slashing.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BaseSlasher.ts:70](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BaseSlasher.ts#L70)
+[packages/sdk/contractkit/src/wrappers/BaseSlasher.ts:72](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BaseSlasher.ts#L72)
 
 ## Accessors
 
@@ -386,7 +390,7 @@ Returns current configuration parameters.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:42](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L42)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:43](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L43)
 
 ___
 
@@ -406,7 +410,7 @@ Returns human readable configuration of the downtime slasher contract
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:54](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L54)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:55](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L55)
 
 ___
 
@@ -457,7 +461,7 @@ True if the user already called the `setBitmapForInterval` for intervals.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:139](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L139)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:140](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L140)
 
 ___
 
@@ -481,7 +485,7 @@ intervals.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:180](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L180)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:181](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L181)
 
 ___
 
@@ -510,7 +514,7 @@ if block is undefined, latest will be used
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:98](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L98)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:99](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L99)
 
 ___
 
@@ -551,7 +555,7 @@ Tests if the given validator or signer did not sign any blocks in the interval.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:153](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L153)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:154](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L154)
 
 ___
 
@@ -577,4 +581,4 @@ True if the validator signature does not appear in any block within the window.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:167](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L167)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:168](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L168)

--- a/docs/sdk/contractkit/classes/wrappers_Election.ElectionWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_Election.ElectionWrapper.md
@@ -179,6 +179,10 @@ ___
 
 Returns the current validator signers using the precompiles.
 
+**`Deprecated`**
+
+use EpochManagerWrapper.getElectedSigners instead. see see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 #### Type declaration
 
 ▸ (): `Promise`\<`string`[]\>
@@ -191,9 +195,13 @@ Returns the current validator signers using the precompiles.
 
 List of current validator signers.
 
+**`Deprecated`**
+
+use EpochManagerWrapper.getElectedSigners instead. see see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:158](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L158)
+[packages/sdk/contractkit/src/wrappers/Election.ts:159](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L159)
 
 ___
 
@@ -227,7 +235,7 @@ The groups that `account` has voted for.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:231](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L231)
+[packages/sdk/contractkit/src/wrappers/Election.ts:233](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L233)
 
 ___
 
@@ -281,7 +289,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:269](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L269)
+[packages/sdk/contractkit/src/wrappers/Election.ts:271](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L271)
 
 ___
 
@@ -319,7 +327,7 @@ The total votes for `group` made by `account`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:209](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L209)
+[packages/sdk/contractkit/src/wrappers/Election.ts:211](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L211)
 
 ___
 
@@ -513,7 +521,7 @@ Activates any activatable pending votes.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:350](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L350)
+[packages/sdk/contractkit/src/wrappers/Election.ts:352](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L352)
 
 ___
 
@@ -542,7 +550,7 @@ See https://en.wikipedia.org/wiki/D%27Hondt_method#Allocation for more informati
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:179](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L179)
+[packages/sdk/contractkit/src/wrappers/Election.ts:181](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L181)
 
 ___
 
@@ -581,7 +589,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:467](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L467)
+[packages/sdk/contractkit/src/wrappers/Election.ts:469](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L469)
 
 ___
 
@@ -606,7 +614,7 @@ The active votes for `group`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:220](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L220)
+[packages/sdk/contractkit/src/wrappers/Election.ts:222](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L222)
 
 ___
 
@@ -622,7 +630,7 @@ Returns current configuration parameters.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:303](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L303)
+[packages/sdk/contractkit/src/wrappers/Election.ts:305](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L305)
 
 ___
 
@@ -644,7 +652,7 @@ Retrieves the set of validatorsparticipating in BFT at epochNumber.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:496](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L496)
+[packages/sdk/contractkit/src/wrappers/Election.ts:498](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L498)
 
 ___
 
@@ -660,7 +668,7 @@ Returns the current eligible validator groups and their total votes.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:452](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L452)
+[packages/sdk/contractkit/src/wrappers/Election.ts:454](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L454)
 
 ___
 
@@ -682,7 +690,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:591](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L591)
+[packages/sdk/contractkit/src/wrappers/Election.ts:593](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L593)
 
 ___
 
@@ -705,7 +713,7 @@ Retrieves GroupVoterRewards at epochNumber.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:508](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L508)
+[packages/sdk/contractkit/src/wrappers/Election.ts:510](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L510)
 
 ___
 
@@ -757,7 +765,7 @@ The total votes for `group`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:197](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L197)
+[packages/sdk/contractkit/src/wrappers/Election.ts:199](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L199)
 
 ___
 
@@ -777,7 +785,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:319](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L319)
+[packages/sdk/contractkit/src/wrappers/Election.ts:321](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L321)
 
 ___
 
@@ -793,7 +801,7 @@ Returns the current registered validator groups and their total votes and eligib
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:336](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L336)
+[packages/sdk/contractkit/src/wrappers/Election.ts:338](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L338)
 
 ___
 
@@ -815,9 +823,13 @@ Returns the validator signers for block `blockNumber`.
 
 Address of each signer in the validator set.
 
+**`Deprecated`**
+
+see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:167](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L167)
+[packages/sdk/contractkit/src/wrappers/Election.ts:169](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L169)
 
 ___
 
@@ -838,7 +850,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:257](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L257)
+[packages/sdk/contractkit/src/wrappers/Election.ts:259](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L259)
 
 ___
 
@@ -863,7 +875,7 @@ Retrieves VoterRewards for address at epochNumber.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:542](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L542)
+[packages/sdk/contractkit/src/wrappers/Election.ts:544](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L544)
 
 ___
 
@@ -886,7 +898,7 @@ Retrieves a voter's share of active votes.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:576](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L576)
+[packages/sdk/contractkit/src/wrappers/Election.ts:578](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L578)
 
 ___
 
@@ -908,7 +920,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:235](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L235)
+[packages/sdk/contractkit/src/wrappers/Election.ts:237](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L237)
 
 ___
 
@@ -928,7 +940,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:292](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L292)
+[packages/sdk/contractkit/src/wrappers/Election.ts:294](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L294)
 
 ___
 
@@ -952,7 +964,7 @@ The groups that `account` has voted for.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:280](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L280)
+[packages/sdk/contractkit/src/wrappers/Election.ts:282](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L282)
 
 ___
 
@@ -974,7 +986,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:413](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L413)
+[packages/sdk/contractkit/src/wrappers/Election.ts:415](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L415)
 
 ___
 
@@ -1004,7 +1016,7 @@ Must pass both `lesserAfterVote` and `greaterAfterVote` or neither.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:388](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L388)
+[packages/sdk/contractkit/src/wrappers/Election.ts:390](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L390)
 
 ___
 
@@ -1026,7 +1038,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:364](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L364)
+[packages/sdk/contractkit/src/wrappers/Election.ts:366](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L366)
 
 ___
 
@@ -1067,4 +1079,4 @@ Increments the number of total and pending votes for `group`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:440](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L440)
+[packages/sdk/contractkit/src/wrappers/Election.ts:442](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L442)

--- a/docs/sdk/contractkit/classes/wrappers_GasPriceMinimum.GasPriceMinimumWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_GasPriceMinimum.GasPriceMinimumWrapper.md
@@ -8,7 +8,7 @@ Stores the gas price minimum
 
 **`Deprecated`**
 
-Contract will be complete removed
+Contract will be complete removed see https://specs.celo.org/smart_contract_updates_from_l1.html
 
 ## Hierarchy
 

--- a/docs/sdk/contractkit/classes/wrappers_GasPriceMinimum.GasPriceMinimumWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_GasPriceMinimum.GasPriceMinimumWrapper.md
@@ -6,6 +6,10 @@
 
 Stores the gas price minimum
 
+**`Deprecated`**
+
+Contract will be complete removed
+
 ## Hierarchy
 
 - [`BaseWrapper`](wrappers_BaseWrapper.BaseWrapper.md)\<`GasPriceMinimum`\>
@@ -91,7 +95,7 @@ multiplier that impacts how quickly gas price minimum is adjusted.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts:44](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts#L44)
+[packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts:45](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts#L45)
 
 ___
 
@@ -162,7 +166,7 @@ current gas price minimum in CELO
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts:19](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts#L19)
+[packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts:20](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts#L20)
 
 ___
 
@@ -192,7 +196,7 @@ current gas price minimum in the requested currency
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts:25](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts#L25)
+[packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts:26](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts#L26)
 
 ___
 
@@ -236,7 +240,7 @@ the current block density targeted by the gas price minimum algorithm.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts:35](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts#L35)
+[packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts:36](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts#L36)
 
 ## Accessors
 
@@ -272,7 +276,7 @@ Returns current configuration parameters.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts:52](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts#L52)
+[packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts:53](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts#L53)
 
 ___
 

--- a/docs/sdk/contractkit/classes/wrappers_Governance.GovernanceWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_Governance.GovernanceWrapper.md
@@ -163,7 +163,7 @@ Only the `approver` address will succeed in sending this transaction
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:989](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L989)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:993](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L993)
 
 ___
 
@@ -361,7 +361,7 @@ keccak256 hash of abi encoded transactions computed on-chain
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:1011](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L1011)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:1015](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L1015)
 
 ___
 
@@ -672,6 +672,10 @@ Returns the number of validators that whitelisted the hotfix
 
 keccak256 hash of hotfix's associated abi encoded transactions
 
+**`Deprecated`**
+
+see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 #### Type declaration
 
 ▸ (`...args`): `Promise`\<`string`\>
@@ -688,9 +692,13 @@ Returns the number of validators that whitelisted the hotfix
 
 `Promise`\<`string`\>
 
+**`Deprecated`**
+
+see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:969](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L969)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:972](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L972)
 
 ___
 
@@ -768,6 +776,10 @@ Returns whether a given hotfix can be passed.
 
 keccak256 hash of hotfix's associated abi encoded transactions
 
+**`Deprecated`**
+
+see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 #### Type declaration
 
 ▸ (`...args`): `Promise`\<`boolean`\>
@@ -784,9 +796,13 @@ Returns whether a given hotfix can be passed.
 
 `Promise`\<`boolean`\>
 
+**`Deprecated`**
+
+see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:954](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L954)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:956](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L956)
 
 ___
 
@@ -804,6 +820,10 @@ keccak256 hash of hotfix's associated abi encoded transactions
 
 address of whitelister
 
+**`Deprecated`**
+
+see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 #### Type declaration
 
 ▸ (`...args`): `Promise`\<`boolean`\>
@@ -820,9 +840,13 @@ Returns whether a given hotfix has been whitelisted by a given address.
 
 `Promise`\<`boolean`\>
 
+**`Deprecated`**
+
+see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:945](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L945)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:946](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L946)
 
 ___
 
@@ -1054,7 +1078,7 @@ Returns the number of validators required to reach a Byzantine quorum
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:959](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L959)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:961](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L961)
 
 ___
 
@@ -1086,7 +1110,7 @@ Marks the given hotfix prepared for current epoch if quorum of validators have w
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:999](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L999)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:1003](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L1003)
 
 ___
 
@@ -1222,6 +1246,10 @@ Marks the given hotfix whitelisted by `sender`.
 
 keccak256 hash of hotfix's associated abi encoded transactions
 
+**`Deprecated`**
+
+see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 #### Type declaration
 
 ▸ (`...args`): `CeloTransactionObject`\<`void`\>
@@ -1238,9 +1266,13 @@ Marks the given hotfix whitelisted by `sender`.
 
 `CeloTransactionObject`\<`void`\>
 
+**`Deprecated`**
+
+see https://specs.celo.org/smart_contract_updates_from_l1.html
+
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:978](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L978)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:982](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L982)
 
 ___
 

--- a/docs/sdk/contractkit/classes/wrappers_Validators.ValidatorsWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_Validators.ValidatorsWrapper.md
@@ -141,7 +141,7 @@ De-affiliates with the previously affiliated group if present.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:493](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L493)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:495](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L495)
 
 ___
 
@@ -171,7 +171,7 @@ Fails if the account is not a validator with non-zero affiliation.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:503](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L503)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:505](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L505)
 
 ___
 
@@ -260,7 +260,7 @@ Removes a validator from the group for which it is a member.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:509](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L509)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:511](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L511)
 
 ___
 
@@ -370,7 +370,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:442](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L442)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:444](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L444)
 
 ___
 
@@ -394,7 +394,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:444](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L444)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:446](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L446)
 
 ___
 
@@ -416,7 +416,7 @@ Get list of registered validator group addresses
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:397](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L397)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:398](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L398)
 
 ___
 
@@ -472,7 +472,7 @@ Get the size (amount of members) of a ValidatorGroup
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:384](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L384)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:385](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L385)
 
 ___
 
@@ -506,7 +506,7 @@ The group membership history of a validator.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:363](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L363)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:364](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L364)
 
 ___
 
@@ -540,7 +540,7 @@ The group membership history of a validator.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:375](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L375)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:376](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L376)
 
 ___
 
@@ -574,7 +574,7 @@ Whether a particular address is a registered validator.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:251](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L251)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:252](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L252)
 
 ___
 
@@ -608,7 +608,7 @@ Whether a particular address is a registered validator group.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:258](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L258)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:259](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L259)
 
 ___
 
@@ -653,6 +653,10 @@ The BLS public key that the validator is using for consensus, should pass proof
 The BLS public key proof-of-possession, which consists of a signature on the
   account address. 96 bytes.
 
+**`Deprecated`**
+
+use registerValidatorNoBls
+
 #### Type declaration
 
 ▸ (`ecdsaPublicKey`, `blsPublicKey`, `blsPop`): `CeloTransactionObject`\<`boolean`\>
@@ -673,9 +677,13 @@ Fails if the account is already a validator or validator group.
 
 `CeloTransactionObject`\<`boolean`\>
 
+**`Deprecated`**
+
+use registerValidatorNoBls
+
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:426](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L426)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:428](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L428)
 
 ___
 
@@ -699,7 +707,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:436](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L436)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:438](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L438)
 
 ___
 
@@ -733,7 +741,7 @@ The ValidatorGroup is specified by the `from` of the tx.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:550](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L550)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:552](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L552)
 
 ___
 
@@ -763,7 +771,7 @@ the last time the group was slashed.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:518](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L518)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:520](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L520)
 
 ___
 
@@ -816,6 +824,10 @@ The BLS public key that the validator is using for consensus, should pass proof
 The BLS public key proof-of-possession, which consists of a signature on the
   account address. 96 bytes.
 
+**`Deprecated`**
+
+bls keys are not used anymore
+
 #### Type declaration
 
 ▸ (`blsPublicKey`, `blsPop`): `CeloTransactionObject`\<`boolean`\>
@@ -835,9 +847,13 @@ Updates a validator's BLS key.
 
 True upon success.
 
+**`Deprecated`**
+
+bls keys are not used anymore
+
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:239](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L239)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:240](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L240)
 
 ___
 
@@ -903,7 +919,7 @@ Fails if `validator` has not set their affiliation to this account.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:528](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L528)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:530](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L530)
 
 ___
 
@@ -919,7 +935,7 @@ Returns the current set of validator signer addresses
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:643](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L643)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:645](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L645)
 
 ___
 
@@ -935,7 +951,7 @@ Returns the current set of validator signer and account addresses
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:653](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L653)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:655](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L655)
 
 ___
 
@@ -957,7 +973,7 @@ De-registers a validator, removing it from the group for which it is a member.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:450](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L450)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:452](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L452)
 
 ___
 
@@ -979,7 +995,7 @@ De-registers a validator Group
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:478](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L478)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:480](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L480)
 
 ___
 
@@ -1004,7 +1020,7 @@ Index for epoch or -1.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:686](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L686)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:688](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L688)
 
 ___
 
@@ -1040,7 +1056,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:600](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L600)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:602](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L602)
 
 ___
 
@@ -1054,7 +1070,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:588](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L588)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:590](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L590)
 
 ___
 
@@ -1112,7 +1128,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:594](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L594)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:596](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L596)
 
 ___
 
@@ -1155,7 +1171,7 @@ Get list of registered validator groups
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:408](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L408)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:409](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L409)
 
 ___
 
@@ -1177,7 +1193,7 @@ Get list of registered validators
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:402](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L402)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:403](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L403)
 
 ___
 
@@ -1199,7 +1215,7 @@ Get list of registered validator addresses
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:391](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L391)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:392](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L392)
 
 ___
 
@@ -1222,7 +1238,7 @@ Get Validator information
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:286](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L286)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:287](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L287)
 
 ___
 
@@ -1243,7 +1259,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:307](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L307)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:308](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L308)
 
 ___
 
@@ -1267,7 +1283,7 @@ Get ValidatorGroup information
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:325](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L325)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:326](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L326)
 
 ___
 
@@ -1310,7 +1326,7 @@ Group and membership history index for `validator`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:667](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L667)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:669](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L669)
 
 ___
 
@@ -1333,7 +1349,7 @@ Retrieves ValidatorRewards for epochNumber.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:610](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L610)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:612](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L612)
 
 ___
 
@@ -1353,7 +1369,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:303](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L303)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:304](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L304)
 
 ___
 
@@ -1377,7 +1393,7 @@ Whether an account meets the requirements to register a validator.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:265](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L265)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:266](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L266)
 
 ___
 
@@ -1401,7 +1417,7 @@ Whether an account meets the requirements to register a group.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:278](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L278)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:279](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L279)
 
 ___
 
@@ -1425,7 +1441,7 @@ Fails if the account does not have sufficient weight.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:467](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L467)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:469](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L469)
 
 ___
 
@@ -1450,7 +1466,7 @@ Fails if `validator` is not a member of the account's validator group.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:559](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L559)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:561](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L561)
 
 ___
 

--- a/docs/sdk/contractkit/modules/wrappers_BlockchainParameters.md
+++ b/docs/sdk/contractkit/modules/wrappers_BlockchainParameters.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:109](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L109)
+[packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts:110](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts#L110)

--- a/docs/sdk/contractkit/modules/wrappers_DoubleSigningSlasher.md
+++ b/docs/sdk/contractkit/modules/wrappers_DoubleSigningSlasher.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts:51](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts#L51)
+[packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts:52](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts#L52)

--- a/docs/sdk/contractkit/modules/wrappers_DowntimeSlasher.md
+++ b/docs/sdk/contractkit/modules/wrappers_DowntimeSlasher.md
@@ -25,4 +25,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:229](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L229)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:230](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L230)

--- a/docs/sdk/contractkit/modules/wrappers_Election.md
+++ b/docs/sdk/contractkit/modules/wrappers_Election.md
@@ -30,4 +30,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:603](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L603)
+[packages/sdk/contractkit/src/wrappers/Election.ts:605](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L605)

--- a/docs/sdk/contractkit/modules/wrappers_GasPriceMinimum.md
+++ b/docs/sdk/contractkit/modules/wrappers_GasPriceMinimum.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts:66](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts#L66)
+[packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts:67](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts#L67)

--- a/docs/sdk/contractkit/modules/wrappers_Governance.md
+++ b/docs/sdk/contractkit/modules/wrappers_Governance.md
@@ -47,7 +47,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:1014](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L1014)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:1018](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L1018)
 
 ___
 

--- a/docs/sdk/contractkit/modules/wrappers_Validators.md
+++ b/docs/sdk/contractkit/modules/wrappers_Validators.md
@@ -30,4 +30,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:695](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L695)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:697](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L697)

--- a/packages/cli/src/commands/validator/list.ts
+++ b/packages/cli/src/commands/validator/list.ts
@@ -9,6 +9,7 @@ export const validatorTable: ux.Table.table.Columns<Record<'v', Validator>> = {
   affiliation: { get: (row) => row.v.affiliation },
   score: { get: (row) => row.v.score.toFixed() },
   ecdsaPublicKey: { get: (row) => row.v.ecdsaPublicKey },
+  // TODO(L2) remove
   blsPublicKey: { get: (row) => row.v.blsPublicKey },
   signer: { get: (row) => row.v.signer },
 }

--- a/packages/sdk/contractkit/src/wrappers/BaseSlasher.ts
+++ b/packages/sdk/contractkit/src/wrappers/BaseSlasher.ts
@@ -22,7 +22,9 @@ interface SlasherContract extends Contract {
     }>
   }
 }
-
+/**
+ * @deprecated --
+ */
 export class BaseSlasher<T extends SlasherContract> extends BaseWrapperForGoverning<T> {
   protected async signerIndexAtBlock(address: string, blockNumber: number) {
     const election = await this.contracts.getElection()

--- a/packages/sdk/contractkit/src/wrappers/BaseSlasher.ts
+++ b/packages/sdk/contractkit/src/wrappers/BaseSlasher.ts
@@ -23,7 +23,7 @@ interface SlasherContract extends Contract {
   }
 }
 /**
- * @deprecated --
+ * @deprecated Contract will be complete removed see https://specs.celo.org/smart_contract_updates_from_l1.html
  */
 export class BaseSlasher<T extends SlasherContract> extends BaseWrapperForGoverning<T> {
   protected async signerIndexAtBlock(address: string, blockNumber: number) {

--- a/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts
+++ b/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts
@@ -9,7 +9,7 @@ export interface BlockchainParametersConfig {
 
 /**
  * Network parameters that are configurable by governance.
- * @deprecated Contract will be complete removed
+ * @deprecated Contract will be complete removed see https://specs.celo.org/smart_contract_updates_from_l1.html
  */
 export class BlockchainParametersWrapper extends BaseWrapper<BlockchainParameters> {
   /**

--- a/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts
+++ b/packages/sdk/contractkit/src/wrappers/BlockchainParameters.ts
@@ -9,6 +9,7 @@ export interface BlockchainParametersConfig {
 
 /**
  * Network parameters that are configurable by governance.
+ * @deprecated Contract will be complete removed
  */
 export class BlockchainParametersWrapper extends BaseWrapper<BlockchainParameters> {
   /**

--- a/packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts
+++ b/packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts
@@ -5,7 +5,7 @@ import { valueToInt } from './BaseWrapper'
 
 /**
  * Contract handling slashing for Validator double-signing
- * @deprecated Contract will be complete removed
+ * @deprecated Contract will be complete removed see https://specs.celo.org/smart_contract_updates_from_l1.html
  */
 export class DoubleSigningSlasherWrapper extends BaseSlasher<DoubleSigningSlasher> {
   /**

--- a/packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts
+++ b/packages/sdk/contractkit/src/wrappers/DoubleSigningSlasher.ts
@@ -5,6 +5,7 @@ import { valueToInt } from './BaseWrapper'
 
 /**
  * Contract handling slashing for Validator double-signing
+ * @deprecated Contract will be complete removed
  */
 export class DoubleSigningSlasherWrapper extends BaseSlasher<DoubleSigningSlasher> {
   /**

--- a/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts
+++ b/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts
@@ -27,6 +27,7 @@ const unpackInterval = (interval: Interval) => [interval.start, interval.end] as
 
 /**
  * Contract handling slashing for Validator downtime using intervals.
+ * @deprecated Contract will be complete removed https://github.com/celo-org/celo-monorepo/blob/release/core-contracts/12/packages/protocol/contracts/governance/DowntimeSlasher.sol
  */
 export class DowntimeSlasherWrapper extends BaseSlasher<DowntimeSlasher> {
   /**

--- a/packages/sdk/contractkit/src/wrappers/Election.ts
+++ b/packages/sdk/contractkit/src/wrappers/Election.ts
@@ -154,7 +154,7 @@ export class ElectionWrapper extends BaseWrapperForGoverning<Election> {
   /**
    * Returns the current validator signers using the precompiles.
    * @return List of current validator signers.
-   * @deprecated use EpochManagerWrapper.getElectedSigners instead
+   * @deprecated use EpochManagerWrapper.getElectedSigners instead. see see https://specs.celo.org/smart_contract_updates_from_l1.html
    */
   getCurrentValidatorSigners: () => Promise<Address[]> = proxyCall(
     this.contract.methods.getCurrentValidatorSigners
@@ -164,7 +164,7 @@ export class ElectionWrapper extends BaseWrapperForGoverning<Election> {
    * Returns the validator signers for block `blockNumber`.
    * @param blockNumber Block number to retrieve signers for.
    * @return Address of each signer in the validator set.
-   * @deprecated
+   * @deprecated see https://specs.celo.org/smart_contract_updates_from_l1.html
    */
   async getValidatorSigners(blockNumber: number): Promise<Address[]> {
     const numValidators = await this.numberValidatorsInSet(blockNumber)

--- a/packages/sdk/contractkit/src/wrappers/Election.ts
+++ b/packages/sdk/contractkit/src/wrappers/Election.ts
@@ -154,6 +154,7 @@ export class ElectionWrapper extends BaseWrapperForGoverning<Election> {
   /**
    * Returns the current validator signers using the precompiles.
    * @return List of current validator signers.
+   * @deprecated use EpochManagerWrapper.getElectedSigners instead
    */
   getCurrentValidatorSigners: () => Promise<Address[]> = proxyCall(
     this.contract.methods.getCurrentValidatorSigners
@@ -163,6 +164,7 @@ export class ElectionWrapper extends BaseWrapperForGoverning<Election> {
    * Returns the validator signers for block `blockNumber`.
    * @param blockNumber Block number to retrieve signers for.
    * @return Address of each signer in the validator set.
+   * @deprecated
    */
   async getValidatorSigners(blockNumber: number): Promise<Address[]> {
     const numValidators = await this.numberValidatorsInSet(blockNumber)

--- a/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts
+++ b/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts
@@ -10,7 +10,7 @@ export interface GasPriceMinimumConfig {
 
 /**
  * Stores the gas price minimum
- * @deprecated Contract will be complete removed
+ * @deprecated Contract will be complete removed see https://specs.celo.org/smart_contract_updates_from_l1.html
  */
 export class GasPriceMinimumWrapper extends BaseWrapper<GasPriceMinimum> {
   /**

--- a/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts
+++ b/packages/sdk/contractkit/src/wrappers/GasPriceMinimum.ts
@@ -10,6 +10,7 @@ export interface GasPriceMinimumConfig {
 
 /**
  * Stores the gas price minimum
+ * @deprecated Contract will be complete removed
  */
 export class GasPriceMinimumWrapper extends BaseWrapper<GasPriceMinimum> {
   /**

--- a/packages/sdk/contractkit/src/wrappers/Governance.ts
+++ b/packages/sdk/contractkit/src/wrappers/Governance.ts
@@ -941,7 +941,7 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
    * Returns whether a given hotfix has been whitelisted by a given address.
    * @param hash keccak256 hash of hotfix's associated abi encoded transactions
    * @param whitelister address of whitelister
-   * @deprecated
+   * @deprecated see https://specs.celo.org/smart_contract_updates_from_l1.html
    */
   isHotfixWhitelistedBy = proxyCall(
     this.contract.methods.isHotfixWhitelistedBy,
@@ -951,7 +951,7 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
   /**
    * Returns whether a given hotfix can be passed.
    * @param hash keccak256 hash of hotfix's associated abi encoded transactions
-   * @deprecated
+   * @deprecated see https://specs.celo.org/smart_contract_updates_from_l1.html
    */
   isHotfixPassing = proxyCall(this.contract.methods.isHotfixPassing, tupleParser(bufferToHex))
 
@@ -967,7 +967,7 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
   /**
    * Returns the number of validators that whitelisted the hotfix
    * @param hash keccak256 hash of hotfix's associated abi encoded transactions
-   * @deprecated
+   * @deprecated see https://specs.celo.org/smart_contract_updates_from_l1.html
    */
   hotfixWhitelistValidatorTally = proxyCall(
     this.contract.methods.hotfixWhitelistValidatorTally,
@@ -977,7 +977,7 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
   /**
    * Marks the given hotfix whitelisted by `sender`.
    * @param hash keccak256 hash of hotfix's associated abi encoded transactions
-   * @deprecated
+   * @deprecated see https://specs.celo.org/smart_contract_updates_from_l1.html
    */
   whitelistHotfix = proxySend(
     this.connection,

--- a/packages/sdk/contractkit/src/wrappers/Governance.ts
+++ b/packages/sdk/contractkit/src/wrappers/Governance.ts
@@ -941,6 +941,7 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
    * Returns whether a given hotfix has been whitelisted by a given address.
    * @param hash keccak256 hash of hotfix's associated abi encoded transactions
    * @param whitelister address of whitelister
+   * @deprecated
    */
   isHotfixWhitelistedBy = proxyCall(
     this.contract.methods.isHotfixWhitelistedBy,
@@ -950,6 +951,7 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
   /**
    * Returns whether a given hotfix can be passed.
    * @param hash keccak256 hash of hotfix's associated abi encoded transactions
+   * @deprecated
    */
   isHotfixPassing = proxyCall(this.contract.methods.isHotfixPassing, tupleParser(bufferToHex))
 
@@ -965,6 +967,7 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
   /**
    * Returns the number of validators that whitelisted the hotfix
    * @param hash keccak256 hash of hotfix's associated abi encoded transactions
+   * @deprecated
    */
   hotfixWhitelistValidatorTally = proxyCall(
     this.contract.methods.hotfixWhitelistValidatorTally,
@@ -974,6 +977,7 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
   /**
    * Marks the given hotfix whitelisted by `sender`.
    * @param hash keccak256 hash of hotfix's associated abi encoded transactions
+   * @deprecated
    */
   whitelistHotfix = proxySend(
     this.connection,

--- a/packages/sdk/contractkit/src/wrappers/Validators.ts
+++ b/packages/sdk/contractkit/src/wrappers/Validators.ts
@@ -235,6 +235,7 @@ export class ValidatorsWrapper extends BaseWrapperForGoverning<Validators> {
    * @param blsPop The BLS public key proof-of-possession, which consists of a signature on the
    *   account address. 96 bytes.
    * @return True upon success.
+   * @deprecated bls keys are not used anymore
    */
   updateBlsPublicKey: (blsPublicKey: string, blsPop: string) => CeloTransactionObject<boolean> =
     proxySend(
@@ -422,6 +423,7 @@ export class ValidatorsWrapper extends BaseWrapperForGoverning<Validators> {
    *   of possession. 48 bytes.
    * @param blsPop The BLS public key proof-of-possession, which consists of a signature on the
    *   account address. 96 bytes.
+   * @deprecated use registerValidatorNoBls
    */
   registerValidator: (
     ecdsaPublicKey: string,


### PR DESCRIPTION
### Description

went thru https://github.com/celo-org/celo-monorepo/tree/release/core-contracts/12/packages and marked methdods that have onlyL1 modifier that are called in contactkit as deprecated. 



### Related issues

- Fixes [#458](https://github.com/celo-org/developer-tooling/issues/458)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on marking various contract wrapper methods as deprecated, indicating they will be removed in the future. It also includes a note on the transition to L2, where certain methods will no longer function.

### Detailed summary
- Marked `GasPriceMinimumWrapper`, `BlockchainParametersWrapper`, and `DoubleSigningSlasherWrapper` as deprecated.
- Added deprecation notes for methods in `ValidatorsWrapper` and `ElectionWrapper`.
- Updated documentation to reflect deprecated status and replacements for several methods.
- Indicated that `blsPublicKey` is no longer used.
- Specified that contracts will be removed as per the provided links.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->