### PR TITLE
fix: rewards:show on l2 

### DIFF
--- a/.changeset/healthy-days-smile.md
+++ b/.changeset/healthy-days-smile.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Fix rewards:show for L2

--- a/.changeset/yellow-chicken-fold.md
+++ b/.changeset/yellow-chicken-fold.md
@@ -1,0 +1,5 @@
+---
+'@celo/contractkit': patch
+---
+
+Backwards compat for some methods using epoch's block numbers

--- a/docs/command-line-interface/rewards.md
+++ b/docs/command-line-interface/rewards.md
@@ -69,7 +69,7 @@ FLAGS
       <options: csv|json|yaml>
 
   --slashing
-      Show rewards for slashing
+      Show rewards for slashing (will be removed in L2)
 
   --sort=<value>
       property to sort by (prepend '-' for descending)

--- a/docs/sdk/contractkit/classes/wrappers_DowntimeSlasher.DowntimeSlasherWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_DowntimeSlasher.DowntimeSlasherWrapper.md
@@ -205,7 +205,7 @@ the specific interval.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:132](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L132)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:133](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L133)
 
 ___
 
@@ -229,7 +229,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:146](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L146)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:147](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L147)
 
 ___
 
@@ -457,7 +457,7 @@ True if the user already called the `setBitmapForInterval` for intervals.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:139](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L139)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:140](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L140)
 
 ___
 
@@ -481,7 +481,7 @@ intervals.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:180](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L180)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:181](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L181)
 
 ___
 
@@ -551,7 +551,7 @@ Tests if the given validator or signer did not sign any blocks in the interval.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:153](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L153)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:154](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L154)
 
 ___
 
@@ -577,4 +577,4 @@ True if the validator signature does not appear in any block within the window.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:167](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L167)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:168](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L168)

--- a/docs/sdk/contractkit/classes/wrappers_Election.ElectionWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_Election.ElectionWrapper.md
@@ -121,7 +121,7 @@ Election threshold.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:93](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L93)
+[packages/sdk/contractkit/src/wrappers/Election.ts:94](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L94)
 
 ___
 
@@ -193,7 +193,7 @@ List of current validator signers.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:158](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L158)
+[packages/sdk/contractkit/src/wrappers/Election.ts:159](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L159)
 
 ___
 
@@ -227,7 +227,7 @@ The groups that `account` has voted for.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:231](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L231)
+[packages/sdk/contractkit/src/wrappers/Election.ts:232](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L232)
 
 ___
 
@@ -257,7 +257,7 @@ The total votes received across all groups.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:152](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L152)
+[packages/sdk/contractkit/src/wrappers/Election.ts:153](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L153)
 
 ___
 
@@ -281,7 +281,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:269](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L269)
+[packages/sdk/contractkit/src/wrappers/Election.ts:270](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L270)
 
 ___
 
@@ -319,7 +319,7 @@ The total votes for `group` made by `account`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:209](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L209)
+[packages/sdk/contractkit/src/wrappers/Election.ts:210](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L210)
 
 ___
 
@@ -363,7 +363,7 @@ Size of the current elected validator set.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:142](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L142)
+[packages/sdk/contractkit/src/wrappers/Election.ts:143](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L143)
 
 ___
 
@@ -397,7 +397,7 @@ Size of the validator set.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:132](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L132)
+[packages/sdk/contractkit/src/wrappers/Election.ts:133](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L133)
 
 ___
 
@@ -431,7 +431,7 @@ Address of validator at the requested index.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:120](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L120)
+[packages/sdk/contractkit/src/wrappers/Election.ts:121](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L121)
 
 ___
 
@@ -470,7 +470,7 @@ Address of validator at the requested index.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:105](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L105)
+[packages/sdk/contractkit/src/wrappers/Election.ts:106](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L106)
 
 ## Accessors
 
@@ -513,7 +513,7 @@ Activates any activatable pending votes.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:350](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L350)
+[packages/sdk/contractkit/src/wrappers/Election.ts:351](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L351)
 
 ___
 
@@ -542,7 +542,7 @@ See https://en.wikipedia.org/wiki/D%27Hondt_method#Allocation for more informati
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:179](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L179)
+[packages/sdk/contractkit/src/wrappers/Election.ts:180](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L180)
 
 ___
 
@@ -560,7 +560,7 @@ The minimum and maximum number of validators that can be elected.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:84](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L84)
+[packages/sdk/contractkit/src/wrappers/Election.ts:85](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L85)
 
 ___
 
@@ -581,7 +581,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:467](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L467)
+[packages/sdk/contractkit/src/wrappers/Election.ts:468](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L468)
 
 ___
 
@@ -606,7 +606,7 @@ The active votes for `group`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:220](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L220)
+[packages/sdk/contractkit/src/wrappers/Election.ts:221](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L221)
 
 ___
 
@@ -622,7 +622,7 @@ Returns current configuration parameters.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:303](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L303)
+[packages/sdk/contractkit/src/wrappers/Election.ts:304](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L304)
 
 ___
 
@@ -644,7 +644,7 @@ Retrieves the set of validatorsparticipating in BFT at epochNumber.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:496](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L496)
+[packages/sdk/contractkit/src/wrappers/Election.ts:497](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L497)
 
 ___
 
@@ -660,7 +660,7 @@ Returns the current eligible validator groups and their total votes.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:452](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L452)
+[packages/sdk/contractkit/src/wrappers/Election.ts:453](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L453)
 
 ___
 
@@ -682,7 +682,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:591](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L591)
+[packages/sdk/contractkit/src/wrappers/Election.ts:598](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L598)
 
 ___
 
@@ -705,7 +705,7 @@ Retrieves GroupVoterRewards at epochNumber.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:508](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L508)
+[packages/sdk/contractkit/src/wrappers/Election.ts:509](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L509)
 
 ___
 
@@ -757,7 +757,7 @@ The total votes for `group`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:197](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L197)
+[packages/sdk/contractkit/src/wrappers/Election.ts:198](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L198)
 
 ___
 
@@ -777,7 +777,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:319](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L319)
+[packages/sdk/contractkit/src/wrappers/Election.ts:320](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L320)
 
 ___
 
@@ -793,7 +793,7 @@ Returns the current registered validator groups and their total votes and eligib
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:336](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L336)
+[packages/sdk/contractkit/src/wrappers/Election.ts:337](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L337)
 
 ___
 
@@ -817,7 +817,7 @@ Address of each signer in the validator set.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:167](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L167)
+[packages/sdk/contractkit/src/wrappers/Election.ts:168](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L168)
 
 ___
 
@@ -838,7 +838,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:257](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L257)
+[packages/sdk/contractkit/src/wrappers/Election.ts:258](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L258)
 
 ___
 
@@ -863,7 +863,7 @@ Retrieves VoterRewards for address at epochNumber.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:542](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L542)
+[packages/sdk/contractkit/src/wrappers/Election.ts:549](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L549)
 
 ___
 
@@ -886,7 +886,7 @@ Retrieves a voter's share of active votes.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:576](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L576)
+[packages/sdk/contractkit/src/wrappers/Election.ts:583](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L583)
 
 ___
 
@@ -908,7 +908,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:235](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L235)
+[packages/sdk/contractkit/src/wrappers/Election.ts:236](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L236)
 
 ___
 
@@ -928,7 +928,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:292](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L292)
+[packages/sdk/contractkit/src/wrappers/Election.ts:293](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L293)
 
 ___
 
@@ -952,7 +952,7 @@ The groups that `account` has voted for.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:280](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L280)
+[packages/sdk/contractkit/src/wrappers/Election.ts:281](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L281)
 
 ___
 
@@ -974,7 +974,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:413](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L413)
+[packages/sdk/contractkit/src/wrappers/Election.ts:414](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L414)
 
 ___
 
@@ -1004,7 +1004,7 @@ Must pass both `lesserAfterVote` and `greaterAfterVote` or neither.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:388](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L388)
+[packages/sdk/contractkit/src/wrappers/Election.ts:389](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L389)
 
 ___
 
@@ -1026,7 +1026,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:364](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L364)
+[packages/sdk/contractkit/src/wrappers/Election.ts:365](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L365)
 
 ___
 
@@ -1067,4 +1067,4 @@ Increments the number of total and pending votes for `group`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:440](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L440)
+[packages/sdk/contractkit/src/wrappers/Election.ts:441](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L441)

--- a/docs/sdk/contractkit/classes/wrappers_Governance.GovernanceWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_Governance.GovernanceWrapper.md
@@ -163,7 +163,7 @@ Only the `approver` address will succeed in sending this transaction
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:989](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L989)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:990](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L990)
 
 ___
 
@@ -361,7 +361,7 @@ keccak256 hash of abi encoded transactions computed on-chain
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:1011](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L1011)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:1012](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L1012)
 
 ___
 
@@ -690,7 +690,7 @@ Returns the number of validators that whitelisted the hotfix
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:969](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L969)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:970](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L970)
 
 ___
 
@@ -786,7 +786,7 @@ Returns whether a given hotfix can be passed.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:954](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L954)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:955](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L955)
 
 ___
 
@@ -822,7 +822,7 @@ Returns whether a given hotfix has been whitelisted by a given address.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:945](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L945)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:946](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L946)
 
 ___
 
@@ -1054,7 +1054,7 @@ Returns the number of validators required to reach a Byzantine quorum
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:959](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L959)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:960](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L960)
 
 ___
 
@@ -1086,7 +1086,7 @@ Marks the given hotfix prepared for current epoch if quorum of validators have w
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:999](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L999)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:1000](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L1000)
 
 ___
 
@@ -1240,7 +1240,7 @@ Marks the given hotfix whitelisted by `sender`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:978](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L978)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:979](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L979)
 
 ___
 

--- a/docs/sdk/contractkit/classes/wrappers_LockedGold.LockedGoldWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_LockedGold.LockedGoldWrapper.md
@@ -106,7 +106,7 @@ Contract for handling deposits needed for voting.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/LockedGold.ts:402](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/LockedGold.ts#L402)
+[packages/sdk/contractkit/src/wrappers/LockedGold.ts:416](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/LockedGold.ts#L416)
 
 ___
 
@@ -529,7 +529,7 @@ List of (group, voting gold) to decrement from `account`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/LockedGold.ts:341](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/LockedGold.ts#L341)
+[packages/sdk/contractkit/src/wrappers/LockedGold.ts:355](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/LockedGold.ts#L355)
 
 ___
 
@@ -551,7 +551,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/LockedGold.ts:348](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/LockedGold.ts#L348)
+[packages/sdk/contractkit/src/wrappers/LockedGold.ts:362](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/LockedGold.ts#L362)
 
 ___
 
@@ -809,7 +809,7 @@ The count of pending withdrawals.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/LockedGold.ts:398](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/LockedGold.ts#L398)
+[packages/sdk/contractkit/src/wrappers/LockedGold.ts:412](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/LockedGold.ts#L412)
 
 ___
 

--- a/docs/sdk/contractkit/classes/wrappers_Validators.ValidatorsWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_Validators.ValidatorsWrapper.md
@@ -141,7 +141,7 @@ De-affiliates with the previously affiliated group if present.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:493](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L493)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:499](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L499)
 
 ___
 
@@ -171,7 +171,7 @@ Fails if the account is not a validator with non-zero affiliation.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:503](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L503)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:509](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L509)
 
 ___
 
@@ -260,7 +260,7 @@ Removes a validator from the group for which it is a member.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:509](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L509)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:515](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L515)
 
 ___
 
@@ -290,7 +290,7 @@ The Locked Gold requirements for a specific account.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:129](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L129)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:135](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L135)
 
 ___
 
@@ -318,7 +318,7 @@ Returns the update delay, in blocks, for the group commission.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:147](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L147)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:153](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L153)
 
 ___
 
@@ -346,7 +346,7 @@ Returns the validator downtime grace period
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:156](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L156)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:162](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L162)
 
 ___
 
@@ -370,7 +370,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:442](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L442)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:448](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L448)
 
 ___
 
@@ -394,7 +394,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:444](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L444)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:450](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L450)
 
 ___
 
@@ -416,7 +416,7 @@ Get list of registered validator group addresses
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:397](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L397)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:403](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L403)
 
 ___
 
@@ -444,7 +444,7 @@ Returns the reset period, in seconds, for slashing multiplier.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:138](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L138)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:144](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L144)
 
 ___
 
@@ -472,7 +472,7 @@ Get the size (amount of members) of a ValidatorGroup
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:384](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L384)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:390](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L390)
 
 ___
 
@@ -506,7 +506,7 @@ The group membership history of a validator.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:363](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L363)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:369](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L369)
 
 ___
 
@@ -540,7 +540,7 @@ The group membership history of a validator.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:375](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L375)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:381](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L381)
 
 ___
 
@@ -574,7 +574,7 @@ Whether a particular address is a registered validator.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:251](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L251)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:257](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L257)
 
 ___
 
@@ -608,7 +608,7 @@ Whether a particular address is a registered validator group.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:258](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L258)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:264](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L264)
 
 ___
 
@@ -675,7 +675,7 @@ Fails if the account is already a validator or validator group.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:426](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L426)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:432](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L432)
 
 ___
 
@@ -699,7 +699,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:436](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L436)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:442](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L442)
 
 ___
 
@@ -733,7 +733,7 @@ The ValidatorGroup is specified by the `from` of the tx.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:550](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L550)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:556](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L556)
 
 ___
 
@@ -763,7 +763,7 @@ the last time the group was slashed.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:518](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L518)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:524](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L524)
 
 ___
 
@@ -796,7 +796,7 @@ Queues an update to a validator group's commission.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:87](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L87)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:93](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L93)
 
 ___
 
@@ -837,7 +837,7 @@ True upon success.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:239](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L239)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:245](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L245)
 
 ___
 
@@ -859,7 +859,7 @@ Updates a validator group's commission based on the previously queued update
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:96](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L96)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:102](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L102)
 
 ## Accessors
 
@@ -903,7 +903,7 @@ Fails if `validator` has not set their affiliation to this account.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:528](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L528)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:534](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L534)
 
 ___
 
@@ -919,7 +919,7 @@ Returns the current set of validator signer addresses
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:643](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L643)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:659](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L659)
 
 ___
 
@@ -935,7 +935,7 @@ Returns the current set of validator signer and account addresses
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:653](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L653)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:669](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L669)
 
 ___
 
@@ -957,7 +957,7 @@ De-registers a validator, removing it from the group for which it is a member.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:450](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L450)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:456](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L456)
 
 ___
 
@@ -979,7 +979,7 @@ De-registers a validator Group
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:478](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L478)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:484](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L484)
 
 ___
 
@@ -1004,7 +1004,7 @@ Index for epoch or -1.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:686](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L686)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:702](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L702)
 
 ___
 
@@ -1020,7 +1020,7 @@ Returns current configuration parameters.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:165](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L165)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:171](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L171)
 
 ___
 
@@ -1040,7 +1040,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:600](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L600)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:611](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L611)
 
 ___
 
@@ -1054,7 +1054,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:588](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L588)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:594](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L594)
 
 ___
 
@@ -1072,7 +1072,7 @@ The Locked Gold requirements for validator groups.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:117](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L117)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:123](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L123)
 
 ___
 
@@ -1092,7 +1092,7 @@ Returns human readable configuration of the validators contract
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:190](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L190)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:196](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L196)
 
 ___
 
@@ -1112,7 +1112,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:594](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L594)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:600](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L600)
 
 ___
 
@@ -1155,7 +1155,7 @@ Get list of registered validator groups
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:408](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L408)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:414](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L414)
 
 ___
 
@@ -1177,7 +1177,7 @@ Get list of registered validators
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:402](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L402)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:408](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L408)
 
 ___
 
@@ -1199,7 +1199,7 @@ Get list of registered validator addresses
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:391](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L391)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:397](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L397)
 
 ___
 
@@ -1222,7 +1222,7 @@ Get Validator information
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:286](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L286)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:292](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L292)
 
 ___
 
@@ -1243,7 +1243,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:307](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L307)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:313](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L313)
 
 ___
 
@@ -1267,7 +1267,7 @@ Get ValidatorGroup information
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:325](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L325)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:331](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L331)
 
 ___
 
@@ -1285,7 +1285,7 @@ The Locked Gold requirements for validators.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:105](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L105)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:111](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L111)
 
 ___
 
@@ -1310,7 +1310,7 @@ Group and membership history index for `validator`.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:667](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L667)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:683](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L683)
 
 ___
 
@@ -1333,7 +1333,7 @@ Retrieves ValidatorRewards for epochNumber.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:610](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L610)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:626](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L626)
 
 ___
 
@@ -1353,7 +1353,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:303](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L303)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:309](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L309)
 
 ___
 
@@ -1377,7 +1377,7 @@ Whether an account meets the requirements to register a validator.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:265](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L265)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:271](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L271)
 
 ___
 
@@ -1401,7 +1401,7 @@ Whether an account meets the requirements to register a group.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:278](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L278)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:284](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L284)
 
 ___
 
@@ -1425,7 +1425,7 @@ Fails if the account does not have sufficient weight.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:467](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L467)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:473](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L473)
 
 ___
 
@@ -1450,7 +1450,7 @@ Fails if `validator` is not a member of the account's validator group.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:559](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L559)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:565](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L565)
 
 ___
 
@@ -1478,7 +1478,7 @@ Fails if the `signer` is not an account or previously authorized signer.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:226](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L226)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:232](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L232)
 
 ___
 
@@ -1506,7 +1506,7 @@ Fails if the `signer` is not an account or currently authorized validator.
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:215](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L215)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:221](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L221)
 
 ___
 

--- a/docs/sdk/contractkit/interfaces/wrappers_Election.ElectableValidators.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Election.ElectableValidators.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:65](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L65)
+[packages/sdk/contractkit/src/wrappers/Election.ts:66](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L66)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:64](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L64)
+[packages/sdk/contractkit/src/wrappers/Election.ts:65](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L65)

--- a/docs/sdk/contractkit/interfaces/wrappers_Election.ElectionConfig.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Election.ElectionConfig.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:73](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L73)
+[packages/sdk/contractkit/src/wrappers/Election.ts:74](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L74)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:70](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L70)
+[packages/sdk/contractkit/src/wrappers/Election.ts:71](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L71)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:69](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L69)
+[packages/sdk/contractkit/src/wrappers/Election.ts:70](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L70)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:71](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L71)
+[packages/sdk/contractkit/src/wrappers/Election.ts:72](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L72)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:72](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L72)
+[packages/sdk/contractkit/src/wrappers/Election.ts:73](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L73)

--- a/docs/sdk/contractkit/interfaces/wrappers_Election.GroupVote.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Election.GroupVote.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:54](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L54)
+[packages/sdk/contractkit/src/wrappers/Election.ts:55](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L55)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:52](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L52)
+[packages/sdk/contractkit/src/wrappers/Election.ts:53](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L53)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:53](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L53)
+[packages/sdk/contractkit/src/wrappers/Election.ts:54](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L54)

--- a/docs/sdk/contractkit/interfaces/wrappers_Election.GroupVoterReward.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Election.GroupVoterReward.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:60](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L60)
+[packages/sdk/contractkit/src/wrappers/Election.ts:61](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L61)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:58](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L58)
+[packages/sdk/contractkit/src/wrappers/Election.ts:59](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L59)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:59](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L59)
+[packages/sdk/contractkit/src/wrappers/Election.ts:60](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L60)

--- a/docs/sdk/contractkit/interfaces/wrappers_Election.ValidatorGroupVote.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Election.ValidatorGroupVote.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:32](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L32)
+[packages/sdk/contractkit/src/wrappers/Election.ts:33](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L33)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:35](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L35)
+[packages/sdk/contractkit/src/wrappers/Election.ts:36](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L36)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:36](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L36)
+[packages/sdk/contractkit/src/wrappers/Election.ts:37](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L37)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:33](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L33)
+[packages/sdk/contractkit/src/wrappers/Election.ts:34](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L34)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:34](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L34)
+[packages/sdk/contractkit/src/wrappers/Election.ts:35](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L35)

--- a/docs/sdk/contractkit/interfaces/wrappers_Election.Voter.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Election.Voter.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:40](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L40)
+[packages/sdk/contractkit/src/wrappers/Election.ts:41](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L41)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:41](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L41)
+[packages/sdk/contractkit/src/wrappers/Election.ts:42](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L42)

--- a/docs/sdk/contractkit/interfaces/wrappers_Election.VoterReward.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Election.VoterReward.md
@@ -21,7 +21,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:45](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L45)
+[packages/sdk/contractkit/src/wrappers/Election.ts:46](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L46)
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:46](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L46)
+[packages/sdk/contractkit/src/wrappers/Election.ts:47](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L47)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:48](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L48)
+[packages/sdk/contractkit/src/wrappers/Election.ts:49](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L49)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:47](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L47)
+[packages/sdk/contractkit/src/wrappers/Election.ts:48](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L48)

--- a/docs/sdk/contractkit/interfaces/wrappers_Validators.GroupMembership.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Validators.GroupMembership.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:68](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L68)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:74](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L74)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:69](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L69)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:75](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L75)

--- a/docs/sdk/contractkit/interfaces/wrappers_Validators.LockedGoldRequirements.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Validators.LockedGoldRequirements.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:54](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L54)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:60](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L60)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:53](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L53)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:59](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L59)

--- a/docs/sdk/contractkit/interfaces/wrappers_Validators.MembershipHistoryExtraData.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Validators.MembershipHistoryExtraData.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:73](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L73)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:79](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L79)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:74](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L74)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:80](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L80)

--- a/docs/sdk/contractkit/interfaces/wrappers_Validators.Validator.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Validators.Validator.md
@@ -24,7 +24,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:23](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L23)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:29](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L29)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:26](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L26)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:32](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L32)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:25](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L25)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:31](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L31)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:24](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L24)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:30](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L30)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:22](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L22)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:28](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L28)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:27](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L27)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:33](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L33)
 
 ___
 
@@ -84,4 +84,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:28](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L28)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:34](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L34)

--- a/docs/sdk/contractkit/interfaces/wrappers_Validators.ValidatorGroup.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Validators.ValidatorGroup.md
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:33](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L33)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:39](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L39)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:36](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L36)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:42](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L42)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:37](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L37)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:43](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L43)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:40](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L40)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:46](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L46)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:34](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L34)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:40](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L40)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:35](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L35)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:41](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L41)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:32](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L32)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:38](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L38)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:38](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L38)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:44](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L44)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:39](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L39)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:45](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L45)
 
 ___
 
@@ -117,4 +117,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:41](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L41)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:47](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L47)

--- a/docs/sdk/contractkit/interfaces/wrappers_Validators.ValidatorReward.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Validators.ValidatorReward.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:49](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L49)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:55](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L55)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:47](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L47)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:53](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L53)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:48](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L48)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:54](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L54)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:45](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L45)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:51](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L51)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:46](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L46)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:52](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L52)

--- a/docs/sdk/contractkit/interfaces/wrappers_Validators.ValidatorsConfig.md
+++ b/docs/sdk/contractkit/interfaces/wrappers_Validators.ValidatorsConfig.md
@@ -24,7 +24,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:63](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L63)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:69](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L69)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:64](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L64)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:70](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L70)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:58](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L58)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:64](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L64)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:60](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L60)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:66](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L66)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:61](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L61)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:67](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L67)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:62](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L62)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:68](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L68)
 
 ___
 
@@ -84,4 +84,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:59](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L59)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:65](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L65)

--- a/docs/sdk/contractkit/modules/test_utils_utils.md
+++ b/docs/sdk/contractkit/modules/test_utils_utils.md
@@ -94,4 +94,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/test-utils/utils.ts:58](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/test-utils/utils.ts#L58)
+[packages/sdk/contractkit/src/test-utils/utils.ts:60](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/test-utils/utils.ts#L60)

--- a/docs/sdk/contractkit/modules/test_utils_utils.md
+++ b/docs/sdk/contractkit/modules/test_utils_utils.md
@@ -94,4 +94,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/test-utils/utils.ts:60](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/test-utils/utils.ts#L60)
+[packages/sdk/contractkit/src/test-utils/utils.ts:58](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/test-utils/utils.ts#L58)

--- a/docs/sdk/contractkit/modules/wrappers_DowntimeSlasher.md
+++ b/docs/sdk/contractkit/modules/wrappers_DowntimeSlasher.md
@@ -25,4 +25,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:229](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L229)
+[packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts:230](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts#L230)

--- a/docs/sdk/contractkit/modules/wrappers_Election.md
+++ b/docs/sdk/contractkit/modules/wrappers_Election.md
@@ -30,4 +30,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Election.ts:603](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L603)
+[packages/sdk/contractkit/src/wrappers/Election.ts:610](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Election.ts#L610)

--- a/docs/sdk/contractkit/modules/wrappers_Governance.md
+++ b/docs/sdk/contractkit/modules/wrappers_Governance.md
@@ -47,7 +47,7 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Governance.ts:1014](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L1014)
+[packages/sdk/contractkit/src/wrappers/Governance.ts:1015](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Governance.ts#L1015)
 
 ___
 

--- a/docs/sdk/contractkit/modules/wrappers_LockedGold.md
+++ b/docs/sdk/contractkit/modules/wrappers_LockedGold.md
@@ -28,4 +28,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/LockedGold.ts:409](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/LockedGold.ts#L409)
+[packages/sdk/contractkit/src/wrappers/LockedGold.ts:423](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/LockedGold.ts#L423)

--- a/docs/sdk/contractkit/modules/wrappers_Validators.md
+++ b/docs/sdk/contractkit/modules/wrappers_Validators.md
@@ -30,4 +30,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/Validators.ts:695](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L695)
+[packages/sdk/contractkit/src/wrappers/Validators.ts:711](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/Validators.ts#L711)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  collectCoverageFrom: ['**/src/**/*.ts', '!**/*.d.ts'],
+  collectCoverageFrom: ['**/src/**/*.ts', '!**/*.d.ts', '!**/test-utils/*.ts'],
   moduleFileExtensions: ['ts', 'js', 'json', 'node'],
   testMatch: ['**/?(*.)(spec|test).ts'],
   transform: {

--- a/packages/cli/src/commands/rewards/show-l2.test.ts
+++ b/packages/cli/src/commands/rewards/show-l2.test.ts
@@ -1,16 +1,195 @@
+import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ElectionWrapper } from '@celo/contractkit/lib/wrappers/Election'
+import { LockedGoldWrapper } from '@celo/contractkit/lib/wrappers/LockedGold'
+import { ValidatorsWrapper } from '@celo/contractkit/lib/wrappers/Validators'
 import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import { timeTravel } from '@celo/dev-utils/lib/ganache-test'
+import { ux } from '@oclif/core'
+import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import Switch from '../epochs/switch'
 import Show from './show'
 
 process.env.NO_SYNCCHECK = 'true'
+const KNOWN_DEVCHAIN_VALIDATOR = '0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f'
 
 testWithAnvilL2('rewards:show cmd', (web3: Web3) => {
+  let kit: ContractKit
+  const writeMock = jest.spyOn(ux.write, 'stdout')
+  const logMock = jest.spyOn(console, 'log')
+  const infoMock = jest.spyOn(console, 'info')
+
   beforeEach(async () => {
+    kit = newKitFromWeb3(web3)
+    const epochManager = await kit.contracts.getEpochManager()
+    await timeTravel((await epochManager.epochDuration()) + 1, web3)
+    await testLocallyWithWeb3Node(Switch, ['--from', (await web3.eth.getAccounts())[0]], web3)
     jest.clearAllMocks()
   })
 
-  test.failing('default', async () => {
-    await expect(testLocallyWithWeb3Node(Show, [], web3)).resolves.not.toBeUndefined()
+  describe('no arguments', () => {
+    test('default', async () => {
+      await expect(testLocallyWithWeb3Node(Show, [], web3)).resolves.toBeUndefined()
+      expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
+        [
+          [
+            "No rewards.",
+          ],
+        ]
+      `)
+    })
+
+    test('trie missing error', async () => {
+      jest
+        .spyOn(ElectionWrapper.prototype, 'getGroupVoterRewards')
+        .mockImplementationOnce(async () => {
+          throw new Error('test missing trie node')
+        })
+      await expect(testLocallyWithWeb3Node(Show, [], web3)).rejects.toMatchInlineSnapshot(`
+        [Error: Exact voter information is available only for 1024 blocks after each epoch.
+        Supply --estimate to estimate rewards based on current votes, or use an archive node.]
+      `)
+    })
+  })
+
+  describe('--validator', () => {
+    test('invalid', async () => {
+      await expect(
+        testLocallyWithWeb3Node(
+          Show,
+          ['--validator', '0x1234567890123456789012345678901234567890'],
+          web3
+        )
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
+      expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+              [
+                [
+                  "Running Checks:",
+                ],
+                [
+                  "   ✘  0x1234567890123456789012345678901234567890 is Validator ",
+                ],
+              ]
+          `)
+    })
+
+    test('valid', async () => {
+      await testLocallyWithWeb3Node(Show, ['--validator', KNOWN_DEVCHAIN_VALIDATOR], web3)
+      expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+        [
+          [
+            "Running Checks:",
+          ],
+          [
+            "   ✔  0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f is Validator ",
+          ],
+          [
+            "All checks passed",
+          ],
+        ]
+      `)
+      expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
+        [
+          [
+            "No rewards.",
+          ],
+        ]
+      `)
+      expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`[]`)
+    })
+
+    test('slashed', async () => {
+      const getValidatorRewardsMock = jest.spyOn(ValidatorsWrapper.prototype, 'getValidatorRewards')
+      const lockedGoldMock = jest.spyOn(LockedGoldWrapper.prototype, 'getAccountsSlashed')
+
+      const validatorPayment = 1234567890
+      const score = 1337
+      const testGroup = {
+        name: 'test-group',
+        address: '0x4242424242424242424242424242424242424242',
+        members: [KNOWN_DEVCHAIN_VALIDATOR],
+        membersUpdated: 1,
+        affiliates: [],
+        commission: new BigNumber(0),
+        nextCommission: new BigNumber(0),
+        nextCommissionBlock: new BigNumber(1),
+        lastSlashed: new BigNumber(-1),
+        slashingMultiplier: new BigNumber(1),
+      }
+      getValidatorRewardsMock.mockImplementationOnce(async () => [
+        {
+          validator: {
+            name: 'test-validator',
+            address: KNOWN_DEVCHAIN_VALIDATOR,
+            ecdsaPublicKey: 'test-ec-pubkey',
+            blsPublicKey: 'test-bls-pubkey',
+            affiliation: '',
+            score: new BigNumber(score),
+            signer: KNOWN_DEVCHAIN_VALIDATOR,
+          },
+          validatorPayment: new BigNumber(validatorPayment),
+          group: testGroup,
+          groupPayment: new BigNumber(1337),
+          epochNumber: 10000,
+        },
+      ])
+
+      lockedGoldMock.mockImplementationOnce(async () => [
+        {
+          slashed: KNOWN_DEVCHAIN_VALIDATOR,
+          epochNumber: 1,
+          penalty: new BigNumber(2),
+          reporter: '',
+          reward: new BigNumber(10),
+        },
+      ])
+
+      await testLocallyWithWeb3Node(Show, ['--validator', KNOWN_DEVCHAIN_VALIDATOR], web3)
+      expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+        [
+          [
+            "Running Checks:",
+          ],
+          [
+            "   ✔  0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f is Validator ",
+          ],
+          [
+            "All checks passed",
+          ],
+        ]
+      `)
+      expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
+        [
+          [
+            "",
+          ],
+          [
+            "Validator rewards:",
+          ],
+        ]
+      `)
+      expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
+        [
+          [
+            " Validatorname  Validator                                  Validatorpayment Validatorscore Group                                      Epochnumber 
+        ",
+          ],
+          [
+            " ────────────── ────────────────────────────────────────── ──────────────── ────────────── ────────────────────────────────────────── ─────────── 
+        ",
+          ],
+          [
+            " test-validator 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f 1234567890       1337           0x4242424242424242424242424242424242424242             
+        ",
+          ],
+        ]
+      `)
+    })
+  })
+
+  describe('--voter', () => {
+    test.todo('invalid')
+    test.todo('valid')
   })
 })

--- a/packages/cli/src/commands/rewards/show-l2.test.ts
+++ b/packages/cli/src/commands/rewards/show-l2.test.ts
@@ -227,11 +227,6 @@ testWithAnvilL2('rewards:show cmd', (web3: Web3) => {
           [
             "All checks passed",
           ],
-          [
-            {
-              "epochNumber": 4,
-            },
-          ], 
         ]
       `)
       expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`

--- a/packages/cli/src/commands/rewards/show-l2.test.ts
+++ b/packages/cli/src/commands/rewards/show-l2.test.ts
@@ -231,7 +231,7 @@ testWithAnvilL2('rewards:show cmd', (web3: Web3) => {
             {
               "epochNumber": 4,
             },
-          ],
+          ], 
         ]
       `)
       expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`

--- a/packages/cli/src/commands/rewards/show.test.ts
+++ b/packages/cli/src/commands/rewards/show.test.ts
@@ -51,7 +51,7 @@ testWithAnvilL1('rewards:show cmd', (web3: Web3) => {
       })
       await expect(testLocallyWithWeb3Node(Show, [], web3)).rejects
         .toThrowErrorMatchingInlineSnapshot(`
-        "Exact voter information is avaiable only for 1024 blocks after each epoch.
+        "Exact voter information is available only for 1024 blocks after each epoch.
         Supply --estimate to estimate rewards based on current votes, or use an archive node."
       `)
     })

--- a/packages/sdk/contractkit/src/test-utils/utils.ts
+++ b/packages/sdk/contractkit/src/test-utils/utils.ts
@@ -1,6 +1,6 @@
 import { StableToken } from '@celo/base'
 import { STABLES_ADDRESS, withImpersonatedAccount } from '@celo/dev-utils/lib/anvil-test'
-import { mineBlocks } from '@celo/dev-utils/lib/ganache-test'
+import { mineBlocks, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { ContractKit } from '../kit'
@@ -47,6 +47,8 @@ export const startAndFinishEpochProcess = async (kit: ContractKit) => {
   await epochManagerWrapper.startNextEpochProcess().sendAndWaitForReceipt({
     from: accounts[0],
   })
+
+  await timeTravel((await epochManagerWrapper.epochDuration()) + 1, kit.connection.web3)
 
   await (
     await epochManagerWrapper.finishNextEpochProcessTx()

--- a/packages/sdk/contractkit/src/test-utils/utils.ts
+++ b/packages/sdk/contractkit/src/test-utils/utils.ts
@@ -1,6 +1,6 @@
 import { StableToken } from '@celo/base'
 import { STABLES_ADDRESS, withImpersonatedAccount } from '@celo/dev-utils/lib/anvil-test'
-import { mineBlocks, timeTravel } from '@celo/dev-utils/lib/ganache-test'
+import { mineBlocks } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { ContractKit } from '../kit'
@@ -47,8 +47,6 @@ export const startAndFinishEpochProcess = async (kit: ContractKit) => {
   await epochManagerWrapper.startNextEpochProcess().sendAndWaitForReceipt({
     from: accounts[0],
   })
-
-  await timeTravel((await epochManagerWrapper.epochDuration()) + 1, kit.connection.web3)
 
   await (
     await epochManagerWrapper.finishNextEpochProcessTx()

--- a/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts
+++ b/packages/sdk/contractkit/src/wrappers/DowntimeSlasher.ts
@@ -107,6 +107,7 @@ export class DowntimeSlasherWrapper extends BaseSlasher<DowntimeSlasher> {
 
     let end = window.end
     const intervals: Interval[] = []
+    // TODO(L2): this is deprecated and not supported in L2
     const isL2 = await isCel2(this.connection.web3)
     while (end > window.start) {
       const epochNumber = isL2

--- a/packages/sdk/contractkit/src/wrappers/Election.ts
+++ b/packages/sdk/contractkit/src/wrappers/Election.ts
@@ -13,6 +13,7 @@ import {
   CeloTransactionObject,
   CeloTxObject,
   EventLog,
+  isCel2,
   toTransactionObject,
 } from '@celo/connect'
 import BigNumber from 'bignumber.js'
@@ -509,9 +510,15 @@ export class ElectionWrapper extends BaseWrapperForGoverning<Election> {
     epochNumber: number,
     useBlockNumber?: boolean
   ): Promise<GroupVoterReward[]> {
-    const blockchainParamsWrapper = await this.contracts.getBlockchainParameters()
-
-    const blockNumber = await blockchainParamsWrapper.getLastBlockNumberForEpoch(epochNumber)
+    let blockNumber: number
+    // TODO(L2): this is deprecated and not supported in L2
+    if (await isCel2(this.connection.web3)) {
+      const epochManager = await this.contracts.getEpochManager()
+      blockNumber = await epochManager.getLastBlockAtEpoch(epochNumber)
+    } else {
+      const blockchainParamsWrapper = await this.contracts.getBlockchainParameters()
+      blockNumber = await blockchainParamsWrapper.getLastBlockNumberForEpoch(epochNumber)
+    }
     const events = await this.getPastEvents('EpochRewardsDistributedToVoters', {
       fromBlock: blockNumber,
       toBlock: blockNumber,

--- a/packages/sdk/contractkit/src/wrappers/Governance.ts
+++ b/packages/sdk/contractkit/src/wrappers/Governance.ts
@@ -905,6 +905,7 @@ export class GovernanceWrapper extends BaseWrapperForGoverning<Governance> {
     const version = await this.version()
 
     if (version.isAtLeast(new ContractVersion(1, 4, 2, 0))) {
+      // TODO(L2): this is deprecated and not supported in L2
       if (await isCel2(this.connection.web3)) {
         // is L2
         const res = await this.contract.methods.getL2HotfixRecord(bufferToHex(hash)).call()

--- a/packages/sdk/contractkit/src/wrappers/LockedGold-l2.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/LockedGold-l2.test.ts
@@ -1,12 +1,12 @@
 import { StrongAddress } from '@celo/base'
-import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import BigNumber from 'bignumber.js'
 import { newKitFromWeb3 } from '../kit'
-import { mineToNextEpoch } from '../test-utils/utils'
+import { startAndFinishEpochProcess } from '../test-utils/utils'
 import { AccountsWrapper } from './Accounts'
 import { LockedGoldWrapper } from './LockedGold'
 
-testWithAnvilL1('LockedGold Wrapper', (web3) => {
+testWithAnvilL2('LockedGold Wrapper', (web3) => {
   const kit = newKitFromWeb3(web3)
   let accounts: AccountsWrapper
   let lockedGold: LockedGoldWrapper
@@ -76,10 +76,12 @@ testWithAnvilL1('LockedGold Wrapper', (web3) => {
       'Bad pending withdrawal index'
     )
   })
+
   test('get accounts slashed', async () => {
-    const epoch = (
-      await (await kit.contracts.getBlockchainParameters()).getEpochNumber()
-    ).toNumber()
+    // const epoch = (
+    //   await (await kit.contracts.getBlockchainParameters()).getEpochNumber()
+    // ).toNumber()
+    const epoch = await (await kit.contracts.getEpochManager()).getCurrentEpochNumber()
     jest.spyOn(lockedGold, 'getPastEvents').mockResolvedValueOnce([
       // @ts-expect-error
       {
@@ -100,7 +102,7 @@ testWithAnvilL1('LockedGold Wrapper', (web3) => {
         },
       },
     ])
-    await mineToNextEpoch(kit.connection.web3)
+    await startAndFinishEpochProcess(kit)
     await expect(lockedGold.getAccountsSlashed(epoch)).resolves.toMatchInlineSnapshot(`
       [
         {

--- a/packages/sdk/contractkit/src/wrappers/LockedGold.ts
+++ b/packages/sdk/contractkit/src/wrappers/LockedGold.ts
@@ -5,7 +5,7 @@ import {
   linkedListChanges as baseLinkedListChanges,
   zip,
 } from '@celo/base/lib/collections'
-import { Address, CeloTransactionObject, EventLog } from '@celo/connect'
+import { Address, BlockNumber, CeloTransactionObject, EventLog, isCel2 } from '@celo/connect'
 import BigNumber from 'bignumber.js'
 import {
   proxyCall,
@@ -316,11 +316,25 @@ export class LockedGoldWrapper extends BaseWrapperForGoverning<LockedGold> {
    * @param epochNumber The epoch to retrieve AccountSlashed at.
    */
   async getAccountsSlashed(epochNumber: number): Promise<AccountSlashed[]> {
-    const blockchainParamsWrapper = await this.contracts.getBlockchainParameters()
-    const events = await this.getPastEvents('AccountSlashed', {
-      fromBlock: await blockchainParamsWrapper.getFirstBlockNumberForEpoch(epochNumber),
-      toBlock: await blockchainParamsWrapper.getLastBlockNumberForEpoch(epochNumber),
-    })
+    let fromBlock: BlockNumber
+    let toBlock: BlockNumber
+
+    // TODO(L2): this is deprecated and not supported in L2
+    if (await isCel2(this.connection.web3)) {
+      const epochManagerWrapper = await this.contracts.getEpochManager()
+      ;[fromBlock, toBlock] = await Promise.all([
+        epochManagerWrapper.getFirstBlockAtEpoch(epochNumber),
+        epochManagerWrapper.getLastBlockAtEpoch(epochNumber),
+      ])
+    } else {
+      const blockchainParamsWrapper = await this.contracts.getBlockchainParameters()
+      ;[fromBlock, toBlock] = await Promise.all([
+        blockchainParamsWrapper.getFirstBlockNumberForEpoch(epochNumber),
+        blockchainParamsWrapper.getLastBlockNumberForEpoch(epochNumber),
+      ])
+    }
+
+    const events = await this.getPastEvents('AccountSlashed', { fromBlock, toBlock })
     return events.map(
       (e: EventLog): AccountSlashed => ({
         epochNumber,

--- a/packages/sdk/contractkit/src/wrappers/Validators.ts
+++ b/packages/sdk/contractkit/src/wrappers/Validators.ts
@@ -2,7 +2,13 @@ import { Validators } from '@celo/abis-12/web3/Validators'
 import { eqAddress, findAddressIndex, NULL_ADDRESS } from '@celo/base/lib/address'
 import { concurrentMap } from '@celo/base/lib/async'
 import { zeroRange, zip } from '@celo/base/lib/collections'
-import { Address, CeloTransactionObject, EventLog, toTransactionObject } from '@celo/connect'
+import {
+  Address,
+  CeloTransactionObject,
+  EventLog,
+  isCel2,
+  toTransactionObject,
+} from '@celo/connect'
 import { fromFixed, toFixed } from '@celo/utils/lib/fixidity'
 import BigNumber from 'bignumber.js'
 import {
@@ -592,15 +598,25 @@ export class ValidatorsWrapper extends BaseWrapperForGoverning<Validators> {
   }
 
   async getLastBlockNumberForEpoch(epochNumber: number): Promise<number> {
-    const blockchainParamsWrapper = await this.contracts.getBlockchainParameters()
-
-    return blockchainParamsWrapper.getLastBlockNumberForEpoch(epochNumber)
+    // TODO(L2): this is deprecated and not supported in L2
+    if (await isCel2(this.connection.web3)) {
+      const epochManagerWrapper = await this.contracts.getEpochManager()
+      return epochManagerWrapper.getLastBlockAtEpoch(epochNumber)
+    } else {
+      const blockchainParamsWrapper = await this.contracts.getBlockchainParameters()
+      return blockchainParamsWrapper.getLastBlockNumberForEpoch(epochNumber)
+    }
   }
 
   async getEpochNumberOfBlock(blockNumber: number): Promise<number> {
-    const blockchainParamsWrapper = await this.contracts.getBlockchainParameters()
-
-    return blockchainParamsWrapper.getEpochNumberOfBlock(blockNumber)
+    // TODO(L2): this is deprecated and not supported in L2
+    if (await isCel2(this.connection.web3)) {
+      const epochManagerWrapper = await this.contracts.getEpochManager()
+      return epochManagerWrapper.getEpochNumberOfBlock(blockNumber)
+    } else {
+      const blockchainParamsWrapper = await this.contracts.getBlockchainParameters()
+      return blockchainParamsWrapper.getEpochNumberOfBlock(blockNumber)
+    }
   }
 
   /**


### PR DESCRIPTION
### Description

fixes the `rewards:show` to work on cel2

#### Other changes

More Cel2  coverage in wrappers

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving support for Layer 2 (L2) functionality within the Celo ecosystem, including deprecating certain methods and enhancing compatibility for L2 operations.

### Detailed summary
- Updated `rewards:show` command description to indicate removal in L2.
- Added backward compatibility for methods using epoch's block numbers in `@celo/contractkit`.
- Deprecated methods in `DowntimeSlasher`, `Governance`, and `Validators` for L2 support.
- Adjusted tests to accommodate L2 changes, including new functionality for fetching epoch block information.
- Enhanced coverage for `show` and `show-l2` commands with additional tests.

> The following files were skipped due to too many changes: `docs/sdk/contractkit/classes/wrappers_Election.ElectionWrapper.md`, `docs/sdk/contractkit/classes/wrappers_Validators.ValidatorsWrapper.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->