### PR TITLE
remove restriction on gathering component coverage from master branch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,8 +19,6 @@ component_management:
     statuses:
       - type: project
         target: auto
-        branches:
-          - '!master'
   individual_components:
     - component_id: celocli
       name: celocli


### PR DESCRIPTION
### Description
when merging prs we dont see the coverage for every section. 

<img width="892" alt="Screenshot 2024-11-22 at 11 13 41 AM" src="https://github.com/user-attachments/assets/72564d25-17a5-4048-ad7b-def56122bc6c">

Likewise looking at ci checks that run on master commits. only the project cod coverage comes up
<img width="697" alt="Screenshot 2024-11-22 at 11 14 02 AM" src="https://github.com/user-attachments/assets/e0b4a062-e83e-470b-8f4e-7d93ea93534f">


While for PRs part of the issue is of course that pr didnt change anything in the component section we should still see the score overall. 


### Tested

im not exactly sure how this will look until its merged. But should mean we have component scores all the time



<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `codecov.yml` configuration file to adjust the settings for code coverage reporting.

### Detailed summary
- Changed `type` from `project` to `auto`.
- Removed the `branches` setting that excluded the `master` branch.
- Retained the `individual_components` section with `component_id` set to `celocli` and `name` as `celocli`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->