### PR TITLE
adjust codecoverage config.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
         only_pulls: true
 
 comment:
-  layout: 'header, diff, flags, components'
+  layout: 'header, diff, components'
 
 ignore:
   - 'packages/typescript'
@@ -24,20 +24,16 @@ component_management:
       name: celocli
       paths:
         - packages/cli
-    - component_id: dev-utils
-      name: dev-utils
-      paths:
-        - packages/dev-utils
     - component_id: sdks
       name: sdk
       paths:
-        - '!packages/sdk/wallets'
-        - 'packages/sdk/*'
+        - '!packages/sdk/wallets/**'
+        - 'packages/sdk/**'
     - component_id: wallets
       name: wallets
       paths:
-        - 'packages/sdk/wallets/*'
+        - 'packages/sdk/wallets/**'
     - component_id: viem-sdks
       name: viem-sdks
       paths:
-        - 'packages/viem-*'
+        - 'packages/viem-**'


### PR DESCRIPTION
### Description

we dont use flags so dont comment on them,

use double asterisk to fix nothing found at head error

**now percentages show**

<img width="846" alt="Screenshot 2024-11-22 at 4 52 46 PM" src="https://github.com/user-attachments/assets/1a9894be-01ab-4fdf-85c5-3452eb60e582">

**before**
<img width="851" alt="Screenshot 2024-11-22 at 11 13 30 AM" src="https://github.com/user-attachments/assets/409839c6-61a6-4f87-86aa-ef7b359a7e3c">


#### Other changes

dev utils component will never find tests because it is utils for tests 
### Tested


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `codecov.yml` configuration file by modifying the `layout` setting and refining the `paths` for various components to include subdirectories.

### Detailed summary
- Changed `layout` from `'header, diff, flags, components'` to `'header, diff, components'`.
- Updated `paths` for `sdk` to include all subdirectories with `'packages/sdk/**'`.
- Updated `paths` for `wallets` to include all subdirectories with `'packages/sdk/wallets/**'`.
- Updated `paths` for `viem-sdks` to include all subdirectories with `'packages/viem-**'`.
- Removed references to `dev-utils` and its paths.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->