### PR TITLE
Fix/cli changes cgp156

### DIFF
--- a/.changeset/dirty-crabs-trade.md
+++ b/.changeset/dirty-crabs-trade.md
@@ -1,0 +1,5 @@
+---
+"@celo/contractkit": patch
+---
+
+fix: add transferOwnership() to proxy abi list

--- a/packages/sdk/contractkit/src/proxy.ts
+++ b/packages/sdk/contractkit/src/proxy.ts
@@ -86,10 +86,27 @@ export const SET_AND_INITIALIZE_IMPLEMENTATION_ABI: ABIDefinition = {
   signature: '0x03386ba3',
 }
 
+export const TRANSFER_OWNERSHIP_ABI: ABIDefinition = {
+  constant: false,
+  inputs: [
+    {
+      name: 'newOwner',
+      type: 'address',
+    },
+  ],
+  name: '_transferOwnership',
+  outputs: [],
+  payable: false,
+  stateMutability: 'nonpayable',
+  type: 'function',
+  signature: '0xd29d44ee',
+}
+
 export const PROXY_ABI: ABIDefinition[] = [
   GET_IMPLEMENTATION_ABI,
   SET_IMPLEMENTATION_ABI,
   SET_AND_INITIALIZE_IMPLEMENTATION_ABI,
+  TRANSFER_OWNERSHIP_ABI,
 ]
 
 export const PROXY_SET_IMPLEMENTATION_SIGNATURE = SET_IMPLEMENTATION_ABI.signature


### PR DESCRIPTION
(copied from https://github.com/celo-org/developer-tooling/pull/466)

### Description

This adds the abi definition for `_transferOwnership(address)` next to the other common proxy functions under `PROXY_ABI`, as we ran into an issue decoding a call on a proxy contract as part of [CGP156](https://github.com/celo-org/governance/pull/509)

#### Other changes

N/A

### Tested

Tested that the `_transferOwnership()` calls under [CGP156 json](https://github.com/nvtaveras/governance/blob/1ae2403e318a029e06f58957bbf7ea34d6ab268a/CGPs/cgp-0156/mainnet.json) can be decoded