### PR TITLE
Dont show superfluous flags

### DIFF
--- a/.changeset/hip-suits-search.md
+++ b/.changeset/hip-suits-search.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Dont show flags for privateKey, gasCurrency, useLedger, and related flags in help for commands which dont actually make use of them.

--- a/docs/command-line-interface/account.md
+++ b/docs/command-line-interface/account.md
@@ -119,33 +119,18 @@ View Celo Stables and CELO balances for an address
 
 ```
 USAGE
-  $ celocli account:balance ARG1 [-k <value> | --useLedger | ] [-n <value>]
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp] [--erc20Address 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
+  $ celocli account:balance ARG1 [-n <value>] [--globalHelp] [--erc20Address
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --erc20Address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-      Address of generic ERC-20 token to also check balance for
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>                                             URL of the node to run
+                                                                 commands against or an
+                                                                 alias
+      --erc20Address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Address of generic
+                                                                 ERC-20 token to also
+                                                                 check balance for
+      --globalHelp                                               View all available
+                                                                 global flags
 
 DESCRIPTION
   View Celo Stables and CELO balances for an address
@@ -985,11 +970,10 @@ Creates a new account locally using the Celo Derivation Path (m/44'/52752'/0/cha
 
 ```
 USAGE
-  $ celocli account:new [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--globalHelp] [--passphrasePath
-    <value>] [--changeIndex <value>] [--addressIndex <value>] [--language chinese_simpli
-    fied|chinese_traditional|english|french|italian|japanese|korean|spanish]
-    [--mnemonicPath <value>] [--derivationPath <value>]
+  $ celocli account:new [-n <value>] [--globalHelp] [--passphrasePath <value>]
+    [--changeIndex <value>] [--addressIndex <value>] [--language chinese_simplified|chin
+    ese_traditional|english|french|italian|japanese|korean|spanish] [--mnemonicPath
+    <value>] [--derivationPath <value>]
 
 FLAGS
   -n, --node=<value>
@@ -1006,10 +990,6 @@ FLAGS
       as an alias of the Ethereum derivation path ("m/44'/60'/0'"). Recreating the same
       account requires knowledge of the mnemonic, passphrase (if any), and the derivation
       path
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
 
   --globalHelp
       View all available global flags
@@ -1660,30 +1640,11 @@ Show information for an account, including name, authorized vote, validator, and
 
 ```
 USAGE
-  $ celocli account:show ARG1 [-k <value> | --useLedger | ] [-n <value>]
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp]
+  $ celocli account:show ARG1 [-n <value>] [--globalHelp]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   Show information for an account, including name, authorized vote, validator, and
@@ -1763,59 +1724,25 @@ Show the data in a local metadata file
 
 ```
 USAGE
-  $ celocli account:show-metadata ARG1 [-k <value> | --useLedger | ] [-n <value>]
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header |
-    [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli account:show-metadata ARG1 [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 ARGUMENTS
   ARG1  Path of the metadata file
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  -x, --extended
-      show extra columns
-
-  --columns=<value>
-      only show provided columns (comma-separated)
-
-  --csv
-      output is csv format [alias: --output=csv]
-
-  --filter=<value>
-      filter property by partial string matching, ex: name=foo
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --no-header
-      hide table header from output
-
-  --no-truncate
-      do not truncate output to fit screen
-
-  --output=<option>
-      output in a more machine friendly format
-      <options: csv|json|yaml>
-
-  --sort=<value>
-      property to sort by (prepend '-' for descending)
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>     URL of the node to run commands against or an alias
+  -x, --extended         show extra columns
+      --columns=<value>  only show provided columns (comma-separated)
+      --csv              output is csv format [alias: --output=csv]
+      --filter=<value>   filter property by partial string matching, ex: name=foo
+      --globalHelp       View all available global flags
+      --no-header        hide table header from output
+      --no-truncate      do not truncate output to fit screen
+      --output=<option>  output in a more machine friendly format
+                         <options: csv|json|yaml>
+      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Show the data in a local metadata file

--- a/docs/command-line-interface/config.md
+++ b/docs/command-line-interface/config.md
@@ -12,30 +12,11 @@ Output network node configuration
 
 ```
 USAGE
-  $ celocli config:get [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+  $ celocli config:get [-n <value>] [--globalHelp]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   Output network node configuration
@@ -59,36 +40,17 @@ Configure running node information for propagating transactions to network
 
 ```
 USAGE
-  $ celocli config:set [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+  $ celocli config:set [-n <value>] [--globalHelp]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   Configure running node information for propagating transactions to network
 
 EXAMPLES
-  set --node mainnet # alias for `forno`
+  set --node celo # alias for `forno`
 
   set --node forno # alias for https://forno.celo.org
 

--- a/docs/command-line-interface/election.md
+++ b/docs/command-line-interface/election.md
@@ -161,56 +161,22 @@ Prints the list of validator groups, the number of votes they have received, the
 
 ```
 USAGE
-  $ celocli election:list [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli election:list [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  -x, --extended
-      show extra columns
-
-  --columns=<value>
-      only show provided columns (comma-separated)
-
-  --csv
-      output is csv format [alias: --output=csv]
-
-  --filter=<value>
-      filter property by partial string matching, ex: name=foo
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --no-header
-      hide table header from output
-
-  --no-truncate
-      do not truncate output to fit screen
-
-  --output=<option>
-      output in a more machine friendly format
-      <options: csv|json|yaml>
-
-  --sort=<value>
-      property to sort by (prepend '-' for descending)
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>     URL of the node to run commands against or an alias
+  -x, --extended         show extra columns
+      --columns=<value>  only show provided columns (comma-separated)
+      --csv              output is csv format [alias: --output=csv]
+      --filter=<value>   filter property by partial string matching, ex: name=foo
+      --globalHelp       View all available global flags
+      --no-header        hide table header from output
+      --no-truncate      do not truncate output to fit screen
+      --output=<option>  output in a more machine friendly format
+                         <options: csv|json|yaml>
+      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Prints the list of validator groups, the number of votes they have received, the
@@ -299,56 +265,22 @@ Runs a "mock" election and prints out the validators that would be elected if th
 
 ```
 USAGE
-  $ celocli election:run [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli election:run [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  -x, --extended
-      show extra columns
-
-  --columns=<value>
-      only show provided columns (comma-separated)
-
-  --csv
-      output is csv format [alias: --output=csv]
-
-  --filter=<value>
-      filter property by partial string matching, ex: name=foo
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --no-header
-      hide table header from output
-
-  --no-truncate
-      do not truncate output to fit screen
-
-  --output=<option>
-      output in a more machine friendly format
-      <options: csv|json|yaml>
-
-  --sort=<value>
-      property to sort by (prepend '-' for descending)
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>     URL of the node to run commands against or an alias
+  -x, --extended         show extra columns
+      --columns=<value>  only show provided columns (comma-separated)
+      --csv              output is csv format [alias: --output=csv]
+      --filter=<value>   filter property by partial string matching, ex: name=foo
+      --globalHelp       View all available global flags
+      --no-header        hide table header from output
+      --no-truncate      do not truncate output to fit screen
+      --output=<option>  output in a more machine friendly format
+                         <options: csv|json|yaml>
+      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Runs a "mock" election and prints out the validators that would be elected if the
@@ -373,39 +305,16 @@ Show election information about a voter or registered Validator Group
 
 ```
 USAGE
-  $ celocli election:show ARG1 [-k <value> | --useLedger | ] [-n <value>]
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp] [--voter | --group]
+  $ celocli election:show ARG1 [-n <value>] [--globalHelp] [--voter | --group]
 
 ARGUMENTS
   ARG1  Voter or Validator Groups's address
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --group
-      Show information about a group running in Validator elections
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --useLedger
-      Set it to use a ledger wallet
-
-  --voter
-      Show information about an account voting in Validator elections
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
+      --group         Show information about a group running in Validator elections
+      --voter         Show information about an account voting in Validator elections
 
 DESCRIPTION
   Show election information about a voter or registered Validator Group

--- a/docs/command-line-interface/governance.md
+++ b/docs/command-line-interface/governance.md
@@ -673,65 +673,33 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:show [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--raw] [--jsonTransactions <value>] [--notwhitelisted]
-    [--whitelisters | --nonwhitelisters |  | [--proposalID <value> | --account <value> |
-    --hotfix <value>]] [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:show [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
+    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
+    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --account=<value>
-      Address of account or voter
-
-  --afterExecutingID=<value>
-      Governance proposal identifier which will be executed prior to proposal
-
-  --afterExecutingProposal=<value>
-      Path to proposal which will be executed prior to proposal
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --hotfix=<value>
-      Hash of hotfix proposal
-
-  --jsonTransactions=<value>
-      Output proposal JSON to provided file
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --nonwhitelisters
-      If set, displays validators that have not whitelisted the hotfix.(will be removed
-      when L2 launches
-
-  --notwhitelisted
-      List validators who have not whitelisted the specified hotfix (will be removed when
-      L2 launches
-
-  --proposalID=<value>
-      UUID of proposal to view
-
-  --raw
-      Display proposal in raw bytes format
-
-  --useLedger
-      Set it to use a ledger wallet
-
-  --whitelisters
-      If set, displays validators that have whitelisted the hotfix.(will be removed when
-      L2 launches
+  -n, --node=<value>                    URL of the node to run commands against or an
+                                        alias
+      --account=<value>                 Address of account or voter
+      --afterExecutingID=<value>        Governance proposal identifier which will be
+                                        executed prior to proposal
+      --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
+                                        proposal
+      --globalHelp                      View all available global flags
+      --hotfix=<value>                  Hash of hotfix proposal
+      --jsonTransactions=<value>        Output proposal JSON to provided file
+      --nonwhitelisters                 If set, displays validators that have not
+                                        whitelisted the hotfix.(will be removed when L2
+                                        launches
+      --notwhitelisted                  List validators who have not whitelisted the
+                                        specified hotfix (will be removed when L2
+                                        launches
+      --proposalID=<value>              UUID of proposal to view
+      --raw                             Display proposal in raw bytes format
+      --whitelisters                    If set, displays validators that have
+                                        whitelisted the hotfix.(will be removed when L2
+                                        launches
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -776,65 +744,33 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:showaccount [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--raw] [--jsonTransactions <value>] [--notwhitelisted]
-    [--whitelisters | --nonwhitelisters |  | [--proposalID <value> | --account <value> |
-    --hotfix <value>]] [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:showaccount [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
+    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
+    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --account=<value>
-      Address of account or voter
-
-  --afterExecutingID=<value>
-      Governance proposal identifier which will be executed prior to proposal
-
-  --afterExecutingProposal=<value>
-      Path to proposal which will be executed prior to proposal
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --hotfix=<value>
-      Hash of hotfix proposal
-
-  --jsonTransactions=<value>
-      Output proposal JSON to provided file
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --nonwhitelisters
-      If set, displays validators that have not whitelisted the hotfix.(will be removed
-      when L2 launches
-
-  --notwhitelisted
-      List validators who have not whitelisted the specified hotfix (will be removed when
-      L2 launches
-
-  --proposalID=<value>
-      UUID of proposal to view
-
-  --raw
-      Display proposal in raw bytes format
-
-  --useLedger
-      Set it to use a ledger wallet
-
-  --whitelisters
-      If set, displays validators that have whitelisted the hotfix.(will be removed when
-      L2 launches
+  -n, --node=<value>                    URL of the node to run commands against or an
+                                        alias
+      --account=<value>                 Address of account or voter
+      --afterExecutingID=<value>        Governance proposal identifier which will be
+                                        executed prior to proposal
+      --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
+                                        proposal
+      --globalHelp                      View all available global flags
+      --hotfix=<value>                  Hash of hotfix proposal
+      --jsonTransactions=<value>        Output proposal JSON to provided file
+      --nonwhitelisters                 If set, displays validators that have not
+                                        whitelisted the hotfix.(will be removed when L2
+                                        launches
+      --notwhitelisted                  List validators who have not whitelisted the
+                                        specified hotfix (will be removed when L2
+                                        launches
+      --proposalID=<value>              UUID of proposal to view
+      --raw                             Display proposal in raw bytes format
+      --whitelisters                    If set, displays validators that have
+                                        whitelisted the hotfix.(will be removed when L2
+                                        launches
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -877,65 +813,33 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:showhotfix [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--raw] [--jsonTransactions <value>] [--notwhitelisted]
-    [--whitelisters | --nonwhitelisters |  | [--proposalID <value> | --account <value> |
-    --hotfix <value>]] [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:showhotfix [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
+    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
+    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --account=<value>
-      Address of account or voter
-
-  --afterExecutingID=<value>
-      Governance proposal identifier which will be executed prior to proposal
-
-  --afterExecutingProposal=<value>
-      Path to proposal which will be executed prior to proposal
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --hotfix=<value>
-      Hash of hotfix proposal
-
-  --jsonTransactions=<value>
-      Output proposal JSON to provided file
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --nonwhitelisters
-      If set, displays validators that have not whitelisted the hotfix.(will be removed
-      when L2 launches
-
-  --notwhitelisted
-      List validators who have not whitelisted the specified hotfix (will be removed when
-      L2 launches
-
-  --proposalID=<value>
-      UUID of proposal to view
-
-  --raw
-      Display proposal in raw bytes format
-
-  --useLedger
-      Set it to use a ledger wallet
-
-  --whitelisters
-      If set, displays validators that have whitelisted the hotfix.(will be removed when
-      L2 launches
+  -n, --node=<value>                    URL of the node to run commands against or an
+                                        alias
+      --account=<value>                 Address of account or voter
+      --afterExecutingID=<value>        Governance proposal identifier which will be
+                                        executed prior to proposal
+      --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
+                                        proposal
+      --globalHelp                      View all available global flags
+      --hotfix=<value>                  Hash of hotfix proposal
+      --jsonTransactions=<value>        Output proposal JSON to provided file
+      --nonwhitelisters                 If set, displays validators that have not
+                                        whitelisted the hotfix.(will be removed when L2
+                                        launches
+      --notwhitelisted                  List validators who have not whitelisted the
+                                        specified hotfix (will be removed when L2
+                                        launches
+      --proposalID=<value>              UUID of proposal to view
+      --raw                             Display proposal in raw bytes format
+      --whitelisters                    If set, displays validators that have
+                                        whitelisted the hotfix.(will be removed when L2
+                                        launches
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -1035,65 +939,33 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:view [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--raw] [--jsonTransactions <value>] [--notwhitelisted]
-    [--whitelisters | --nonwhitelisters |  | [--proposalID <value> | --account <value> |
-    --hotfix <value>]] [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:view [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
+    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
+    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --account=<value>
-      Address of account or voter
-
-  --afterExecutingID=<value>
-      Governance proposal identifier which will be executed prior to proposal
-
-  --afterExecutingProposal=<value>
-      Path to proposal which will be executed prior to proposal
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --hotfix=<value>
-      Hash of hotfix proposal
-
-  --jsonTransactions=<value>
-      Output proposal JSON to provided file
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --nonwhitelisters
-      If set, displays validators that have not whitelisted the hotfix.(will be removed
-      when L2 launches
-
-  --notwhitelisted
-      List validators who have not whitelisted the specified hotfix (will be removed when
-      L2 launches
-
-  --proposalID=<value>
-      UUID of proposal to view
-
-  --raw
-      Display proposal in raw bytes format
-
-  --useLedger
-      Set it to use a ledger wallet
-
-  --whitelisters
-      If set, displays validators that have whitelisted the hotfix.(will be removed when
-      L2 launches
+  -n, --node=<value>                    URL of the node to run commands against or an
+                                        alias
+      --account=<value>                 Address of account or voter
+      --afterExecutingID=<value>        Governance proposal identifier which will be
+                                        executed prior to proposal
+      --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
+                                        proposal
+      --globalHelp                      View all available global flags
+      --hotfix=<value>                  Hash of hotfix proposal
+      --jsonTransactions=<value>        Output proposal JSON to provided file
+      --nonwhitelisters                 If set, displays validators that have not
+                                        whitelisted the hotfix.(will be removed when L2
+                                        launches
+      --notwhitelisted                  List validators who have not whitelisted the
+                                        specified hotfix (will be removed when L2
+                                        launches
+      --proposalID=<value>              UUID of proposal to view
+      --raw                             Display proposal in raw bytes format
+      --whitelisters                    If set, displays validators that have
+                                        whitelisted the hotfix.(will be removed when L2
+                                        launches
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -1136,65 +1008,33 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:viewaccount [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--raw] [--jsonTransactions <value>] [--notwhitelisted]
-    [--whitelisters | --nonwhitelisters |  | [--proposalID <value> | --account <value> |
-    --hotfix <value>]] [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:viewaccount [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
+    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
+    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --account=<value>
-      Address of account or voter
-
-  --afterExecutingID=<value>
-      Governance proposal identifier which will be executed prior to proposal
-
-  --afterExecutingProposal=<value>
-      Path to proposal which will be executed prior to proposal
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --hotfix=<value>
-      Hash of hotfix proposal
-
-  --jsonTransactions=<value>
-      Output proposal JSON to provided file
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --nonwhitelisters
-      If set, displays validators that have not whitelisted the hotfix.(will be removed
-      when L2 launches
-
-  --notwhitelisted
-      List validators who have not whitelisted the specified hotfix (will be removed when
-      L2 launches
-
-  --proposalID=<value>
-      UUID of proposal to view
-
-  --raw
-      Display proposal in raw bytes format
-
-  --useLedger
-      Set it to use a ledger wallet
-
-  --whitelisters
-      If set, displays validators that have whitelisted the hotfix.(will be removed when
-      L2 launches
+  -n, --node=<value>                    URL of the node to run commands against or an
+                                        alias
+      --account=<value>                 Address of account or voter
+      --afterExecutingID=<value>        Governance proposal identifier which will be
+                                        executed prior to proposal
+      --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
+                                        proposal
+      --globalHelp                      View all available global flags
+      --hotfix=<value>                  Hash of hotfix proposal
+      --jsonTransactions=<value>        Output proposal JSON to provided file
+      --nonwhitelisters                 If set, displays validators that have not
+                                        whitelisted the hotfix.(will be removed when L2
+                                        launches
+      --notwhitelisted                  List validators who have not whitelisted the
+                                        specified hotfix (will be removed when L2
+                                        launches
+      --proposalID=<value>              UUID of proposal to view
+      --raw                             Display proposal in raw bytes format
+      --whitelisters                    If set, displays validators that have
+                                        whitelisted the hotfix.(will be removed when L2
+                                        launches
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.
@@ -1237,65 +1077,33 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:viewhotfix [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--raw] [--jsonTransactions <value>] [--notwhitelisted]
-    [--whitelisters | --nonwhitelisters |  | [--proposalID <value> | --account <value> |
-    --hotfix <value>]] [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:viewhotfix [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
+    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
+    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --account=<value>
-      Address of account or voter
-
-  --afterExecutingID=<value>
-      Governance proposal identifier which will be executed prior to proposal
-
-  --afterExecutingProposal=<value>
-      Path to proposal which will be executed prior to proposal
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --hotfix=<value>
-      Hash of hotfix proposal
-
-  --jsonTransactions=<value>
-      Output proposal JSON to provided file
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --nonwhitelisters
-      If set, displays validators that have not whitelisted the hotfix.(will be removed
-      when L2 launches
-
-  --notwhitelisted
-      List validators who have not whitelisted the specified hotfix (will be removed when
-      L2 launches
-
-  --proposalID=<value>
-      UUID of proposal to view
-
-  --raw
-      Display proposal in raw bytes format
-
-  --useLedger
-      Set it to use a ledger wallet
-
-  --whitelisters
-      If set, displays validators that have whitelisted the hotfix.(will be removed when
-      L2 launches
+  -n, --node=<value>                    URL of the node to run commands against or an
+                                        alias
+      --account=<value>                 Address of account or voter
+      --afterExecutingID=<value>        Governance proposal identifier which will be
+                                        executed prior to proposal
+      --afterExecutingProposal=<value>  Path to proposal which will be executed prior to
+                                        proposal
+      --globalHelp                      View all available global flags
+      --hotfix=<value>                  Hash of hotfix proposal
+      --jsonTransactions=<value>        Output proposal JSON to provided file
+      --nonwhitelisters                 If set, displays validators that have not
+                                        whitelisted the hotfix.(will be removed when L2
+                                        launches
+      --notwhitelisted                  List validators who have not whitelisted the
+                                        specified hotfix (will be removed when L2
+                                        launches
+      --proposalID=<value>              UUID of proposal to view
+      --raw                             Display proposal in raw bytes format
+      --whitelisters                    If set, displays validators that have
+                                        whitelisted the hotfix.(will be removed when L2
+                                        launches
 
 DESCRIPTION
   Show information about a governance proposal, hotfix, or account.

--- a/docs/command-line-interface/lockedgold.md
+++ b/docs/command-line-interface/lockedgold.md
@@ -302,30 +302,11 @@ Show Locked Gold information for a given account. This includes the total amount
 
 ```
 USAGE
-  $ celocli lockedgold:show ARG1 [-k <value> | --useLedger | ] [-n <value>]
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp]
+  $ celocli lockedgold:show ARG1 [-n <value>] [--globalHelp]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   Show Locked Gold information for a given account. This includes the total amount of

--- a/docs/command-line-interface/multisig.md
+++ b/docs/command-line-interface/multisig.md
@@ -73,39 +73,15 @@ Shows information about multi-sig contract
 
 ```
 USAGE
-  $ celocli multisig:show ARG1 [-k <value> | --useLedger | ] [-n <value>]
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp] [--tx <value>] [--all] [--raw]
+  $ celocli multisig:show ARG1 [-n <value>] [--globalHelp] [--tx <value>] [--all]
+    [--raw]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --all
-      Show info about all transactions
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --raw
-      Do not attempt to parse transactions
-
-  --tx=<value>
-      Show info for a transaction
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --all           Show info about all transactions
+      --globalHelp    View all available global flags
+      --raw           Do not attempt to parse transactions
+      --tx=<value>    Show info for a transaction
 
 DESCRIPTION
   Shows information about multi-sig contract

--- a/docs/command-line-interface/network.md
+++ b/docs/command-line-interface/network.md
@@ -14,56 +14,22 @@ Lists Celo core contracts and their addresses.
 
 ```
 USAGE
-  $ celocli network:contracts [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli network:contracts [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  -x, --extended
-      show extra columns
-
-  --columns=<value>
-      only show provided columns (comma-separated)
-
-  --csv
-      output is csv format [alias: --output=csv]
-
-  --filter=<value>
-      filter property by partial string matching, ex: name=foo
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --no-header
-      hide table header from output
-
-  --no-truncate
-      do not truncate output to fit screen
-
-  --output=<option>
-      output in a more machine friendly format
-      <options: csv|json|yaml>
-
-  --sort=<value>
-      property to sort by (prepend '-' for descending)
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>     URL of the node to run commands against or an alias
+  -x, --extended         show extra columns
+      --columns=<value>  only show provided columns (comma-separated)
+      --csv              output is csv format [alias: --output=csv]
+      --filter=<value>   filter property by partial string matching, ex: name=foo
+      --globalHelp       View all available global flags
+      --no-header        hide table header from output
+      --no-truncate      do not truncate output to fit screen
+      --output=<option>  output in a more machine friendly format
+                         <options: csv|json|yaml>
+      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Lists Celo core contracts and their addresses.
@@ -87,33 +53,12 @@ View general network information such as the current block number
 
 ```
 USAGE
-  $ celocli network:info [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--lastN <value>]
+  $ celocli network:info [-n <value>] [--globalHelp] [--lastN <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --lastN=<value>
-      [default: 1] Fetch info about the last n epochs
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>   URL of the node to run commands against or an alias
+      --globalHelp     View all available global flags
+      --lastN=<value>  [default: 1] Fetch info about the last n epochs
 
 DESCRIPTION
   View general network information such as the current block number
@@ -137,33 +82,12 @@ View parameters of the network, including but not limited to configuration for t
 
 ```
 USAGE
-  $ celocli network:parameters [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--raw]
+  $ celocli network:parameters [-n <value>] [--globalHelp] [--raw]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --raw
-      Display raw numerical configuration
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
+      --raw           Display raw numerical configuration
 
 DESCRIPTION
   View parameters of the network, including but not limited to configuration for the
@@ -188,56 +112,22 @@ List the whitelisted fee currencies
 
 ```
 USAGE
-  $ celocli network:whitelist [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli network:whitelist [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  -x, --extended
-      show extra columns
-
-  --columns=<value>
-      only show provided columns (comma-separated)
-
-  --csv
-      output is csv format [alias: --output=csv]
-
-  --filter=<value>
-      filter property by partial string matching, ex: name=foo
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --no-header
-      hide table header from output
-
-  --no-truncate
-      do not truncate output to fit screen
-
-  --output=<option>
-      output in a more machine friendly format
-      <options: csv|json|yaml>
-
-  --sort=<value>
-      property to sort by (prepend '-' for descending)
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>     URL of the node to run commands against or an alias
+  -x, --extended         show extra columns
+      --columns=<value>  only show provided columns (comma-separated)
+      --csv              output is csv format [alias: --output=csv]
+      --filter=<value>   filter property by partial string matching, ex: name=foo
+      --globalHelp       View all available global flags
+      --no-header        hide table header from output
+      --no-truncate      do not truncate output to fit screen
+      --output=<option>  output in a more machine friendly format
+                         <options: csv|json|yaml>
+      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List the whitelisted fee currencies

--- a/docs/command-line-interface/oracle.md
+++ b/docs/command-line-interface/oracle.md
@@ -14,33 +14,14 @@ List oracle addresses for a given token
 
 ```
 USAGE
-  $ celocli oracle:list ARG1 [-k <value> | --useLedger | ] [-n <value>]
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp]
+  $ celocli oracle:list ARG1 [-n <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to list the oracles for
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   List oracle addresses for a given token

--- a/docs/command-line-interface/releasecelo.md
+++ b/docs/command-line-interface/releasecelo.md
@@ -785,34 +785,17 @@ Show info on a ReleaseGold instance contract.
 
 ```
 USAGE
-  $ celocli releasecelo:show --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
-    <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+  $ celocli releasecelo:show --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-n
+    <value>] [--globalHelp]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-      (required) Address of the ReleaseGold Contract
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>                                         URL of the node to run
+                                                             commands against or an
+                                                             alias
+      --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
+                                                             ReleaseGold Contract
+      --globalHelp                                           View all available global
+                                                             flags
 
 DESCRIPTION
   Show info on a ReleaseGold instance contract.

--- a/docs/command-line-interface/rewards.md
+++ b/docs/command-line-interface/rewards.md
@@ -11,77 +11,48 @@ Show rewards information about a voter, registered Validator, or Validator Group
 
 ```
 USAGE
-  $ celocli rewards:show [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--estimate] [--voter 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
-    [--validator 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--group
+  $ celocli rewards:show [-n <value>] [--globalHelp] [--estimate] [--voter
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--validator
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--group
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--slashing] [--epochs <value>]
     [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
     [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  -x, --extended
-      show extra columns
-
-  --columns=<value>
-      only show provided columns (comma-separated)
-
-  --csv
-      output is csv format [alias: --output=csv]
-
-  --epochs=<value>
-      [default: 1] Show results for the last N epochs
-
-  --estimate
-      Estimate voter rewards from current votes
-
-  --filter=<value>
-      filter property by partial string matching, ex: name=foo
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-      Validator Group to show rewards for
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --no-header
-      hide table header from output
-
-  --no-truncate
-      do not truncate output to fit screen
-
-  --output=<option>
-      output in a more machine friendly format
-      <options: csv|json|yaml>
-
-  --slashing
-      Show rewards for slashing (will be removed in L2)
-
-  --sort=<value>
-      property to sort by (prepend '-' for descending)
-
-  --useLedger
-      Set it to use a ledger wallet
-
-  --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-      Validator to show rewards for
-
-  --voter=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-      Voter to show rewards for
+  -n, --node=<value>                                          URL of the node to run
+                                                              commands against or an
+                                                              alias
+  -x, --extended                                              show extra columns
+      --columns=<value>                                       only show provided columns
+                                                              (comma-separated)
+      --csv                                                   output is csv format
+                                                              [alias: --output=csv]
+      --epochs=<value>                                        [default: 1] Show results
+                                                              for the last N epochs
+      --estimate                                              Estimate voter rewards
+                                                              from current votes
+      --filter=<value>                                        filter property by partial
+                                                              string matching, ex:
+                                                              name=foo
+      --globalHelp                                            View all available global
+                                                              flags
+      --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Validator Group to show
+                                                              rewards for
+      --no-header                                             hide table header from
+                                                              output
+      --no-truncate                                           do not truncate output to
+                                                              fit screen
+      --output=<option>                                       output in a more machine
+                                                              friendly format
+                                                              <options: csv|json|yaml>
+      --slashing                                              Show rewards for slashing
+                                                              (will be removed in L2)
+      --sort=<value>                                          property to sort by
+                                                              (prepend '-' for
+                                                              descending)
+      --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Validator to show rewards
+                                                              for
+      --voter=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Voter to show rewards for
 
 DESCRIPTION
   Show rewards information about a voter, registered Validator, or Validator Group

--- a/docs/command-line-interface/validator.md
+++ b/docs/command-line-interface/validator.md
@@ -270,56 +270,22 @@ List registered Validators, their name (if provided), affiliation, uptime score,
 
 ```
 USAGE
-  $ celocli validator:list [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli validator:list [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  -x, --extended
-      show extra columns
-
-  --columns=<value>
-      only show provided columns (comma-separated)
-
-  --csv
-      output is csv format [alias: --output=csv]
-
-  --filter=<value>
-      filter property by partial string matching, ex: name=foo
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --no-header
-      hide table header from output
-
-  --no-truncate
-      do not truncate output to fit screen
-
-  --output=<option>
-      output in a more machine friendly format
-      <options: csv|json|yaml>
-
-  --sort=<value>
-      property to sort by (prepend '-' for descending)
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>     URL of the node to run commands against or an alias
+  -x, --extended         show extra columns
+      --columns=<value>  only show provided columns (comma-separated)
+      --csv              output is csv format [alias: --output=csv]
+      --filter=<value>   filter property by partial string matching, ex: name=foo
+      --globalHelp       View all available global flags
+      --no-header        hide table header from output
+      --no-truncate      do not truncate output to fit screen
+      --output=<option>  output in a more machine friendly format
+                         <options: csv|json|yaml>
+      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List registered Validators, their name (if provided), affiliation, uptime score, and
@@ -532,33 +498,14 @@ Show information about a registered Validator.
 
 ```
 USAGE
-  $ celocli validator:show ARG1 [-k <value> | --useLedger | ] [-n <value>]
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp]
+  $ celocli validator:show ARG1 [-n <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  Validator's address
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   Show information about a registered Validator.

--- a/docs/command-line-interface/validatorgroup.md
+++ b/docs/command-line-interface/validatorgroup.md
@@ -141,56 +141,22 @@ List registered Validator Groups, their names (if provided), commission, and mem
 
 ```
 USAGE
-  $ celocli validatorgroup:list [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
-    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli validatorgroup:list [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  -x, --extended
-      show extra columns
-
-  --columns=<value>
-      only show provided columns (comma-separated)
-
-  --csv
-      output is csv format [alias: --output=csv]
-
-  --filter=<value>
-      filter property by partial string matching, ex: name=foo
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --no-header
-      hide table header from output
-
-  --no-truncate
-      do not truncate output to fit screen
-
-  --output=<option>
-      output in a more machine friendly format
-      <options: csv|json|yaml>
-
-  --sort=<value>
-      property to sort by (prepend '-' for descending)
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>     URL of the node to run commands against or an alias
+  -x, --extended         show extra columns
+      --columns=<value>  only show provided columns (comma-separated)
+      --csv              output is csv format [alias: --output=csv]
+      --filter=<value>   filter property by partial string matching, ex: name=foo
+      --globalHelp       View all available global flags
+      --no-header        hide table header from output
+      --no-truncate      do not truncate output to fit screen
+      --output=<option>  output in a more machine friendly format
+                         <options: csv|json|yaml>
+      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List registered Validator Groups, their names (if provided), commission, and members.
@@ -404,33 +370,14 @@ Show information about an existing Validator Group
 
 ```
 USAGE
-  $ celocli validatorgroup:show ARG1 [-k <value> | --useLedger | ] [-n <value>]
-    [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp]
+  $ celocli validatorgroup:show ARG1 [-n <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  ValidatorGroup's address
 
 FLAGS
-  -k, --privateKey=<value>
-      Use a private key to sign local transactions with
-
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --gasCurrency=0x1234567890123456789012345678901234567890
-      Use a specific gas currency for transaction fees (defaults to CELO if no gas
-      currency is supplied). It must be a whitelisted token.
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerAddresses=<value>
-      [default: 1] If --useLedger is set, this will get the first N addresses for local
-      signing
-
-  --useLedger
-      Set it to use a ledger wallet
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   Show information about an existing Validator Group

--- a/packages/cli/src/commands/account/balance.ts
+++ b/packages/cli/src/commands/account/balance.ts
@@ -1,12 +1,13 @@
 import { BaseCommand } from '../../base'
 import { failWith, printValueMap } from '../../utils/cli'
 import { CustomArgs, CustomFlags } from '../../utils/command'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class Balance extends BaseCommand {
   static description = 'View Celo Stables and CELO balances for an address'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     erc20Address: CustomFlags.address({
       description: 'Address of generic ERC-20 token to also check balance for',
     }),

--- a/packages/cli/src/commands/account/new.ts
+++ b/packages/cli/src/commands/account/new.ts
@@ -14,6 +14,7 @@ import chalk from 'chalk'
 import * as fs from 'fs-extra'
 import { BaseCommand } from '../../base'
 import { printValueMap } from '../../utils/cli'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 const ETHEREUM_DERIVATION_PATH = "m/44'/60'/0'"
 

--- a/packages/cli/src/commands/account/new.ts
+++ b/packages/cli/src/commands/account/new.ts
@@ -23,19 +23,7 @@ export default class NewAccount extends BaseCommand {
     "\n\nWARN: In 7.0 the default derivation path will be Eth (\"m/44'/60'/0'\") forum.celo.org/t/deprecating-the-celo-derivation-path/9229"
 
   static flags = {
-    ...BaseCommand.flags,
-    privateKey: {
-      ...BaseCommand.flags.privateKey,
-      hidden: true,
-    },
-    useLedger: {
-      ...BaseCommand.flags.useLedger,
-      hidden: true,
-    },
-    ledgerAddresses: {
-      ...BaseCommand.flags.useLedger,
-      hidden: true,
-    },
+    ...ViewCommmandFlags,
     passphrasePath: Flags.string({
       description:
         'Path to a file that contains the BIP39 passphrase to combine with the mnemonic specified using the mnemonicPath flag and the index specified using the addressIndex flag. Every passphrase generates a different private key and wallet address.',

--- a/packages/cli/src/commands/account/show-metadata.ts
+++ b/packages/cli/src/commands/account/show-metadata.ts
@@ -3,12 +3,13 @@ import { ux } from '@oclif/core'
 
 import { BaseCommand } from '../../base'
 import { CustomArgs } from '../../utils/command'
+import { ViewCommmandFlags } from '../../utils/flags'
 import { displayMetadata } from '../../utils/identity'
 
 export default class ShowMetadata extends BaseCommand {
   static description = 'Show the data in a local metadata file'
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     ...(ux.table.flags() as object),
   }
   static args = {

--- a/packages/cli/src/commands/account/show.ts
+++ b/packages/cli/src/commands/account/show.ts
@@ -2,13 +2,14 @@ import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { printValueMapRecursive } from '../../utils/cli'
 import { CustomArgs } from '../../utils/command'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class Show extends BaseCommand {
   static description =
     'Show information for an account, including name, authorized vote, validator, and attestation signers, the URL at which account metadata is hosted, the address the account is using with the mobile wallet, and a public key that can be used to encrypt information for the account.'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
   }
 
   static args = {

--- a/packages/cli/src/commands/config/get.ts
+++ b/packages/cli/src/commands/config/get.ts
@@ -1,12 +1,13 @@
 import { BaseCommand } from '../../base'
 import { printValueMap } from '../../utils/cli'
 import { readConfig } from '../../utils/config'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class Get extends BaseCommand {
   static description = 'Output network node configuration'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
   }
 
   requireSynced = false

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -2,11 +2,12 @@ import { ux } from '@oclif/core'
 import chalk from 'chalk'
 import { BaseCommand } from '../../base'
 import { CeloConfig, readConfig, writeConfig } from '../../utils/config'
+import { ViewCommmandFlags } from '../../utils/flags'
 export default class Set extends BaseCommand {
   static description = 'Configure running node information for propagating transactions to network'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     node: {
       ...BaseCommand.flags.node,
       hidden: false,
@@ -14,7 +15,7 @@ export default class Set extends BaseCommand {
   }
 
   static examples = [
-    'set --node mainnet # alias for `forno`',
+    'set --node celo # alias for `forno`',
     'set --node forno # alias for https://forno.celo.org',
     'set --node baklava # alias for https://baklava-forno.celo-testnet.org',
     'set --node alfajores # alias for https://alfajores-forno.celo-testnet.org',

--- a/packages/cli/src/commands/election/list.ts
+++ b/packages/cli/src/commands/election/list.ts
@@ -1,13 +1,14 @@
 import { ux } from '@oclif/core'
 
 import { BaseCommand } from '../../base'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class ElectionList extends BaseCommand {
   static description =
     'Prints the list of validator groups, the number of votes they have received, the number of additional votes they are able to receive, and whether or not they are eligible to elect validators.'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     ...(ux.table.flags() as object),
   }
 

--- a/packages/cli/src/commands/election/run.ts
+++ b/packages/cli/src/commands/election/run.ts
@@ -2,6 +2,7 @@ import { ContractKit } from '@celo/contractkit/lib'
 import { ux } from '@oclif/core'
 
 import { BaseCommand } from '../../base'
+import { ViewCommmandFlags } from '../../utils/flags'
 import { validatorTable } from '../validator/list'
 
 async function performElections(kit: ContractKit) {
@@ -21,7 +22,7 @@ export default class ElectionRun extends BaseCommand {
     'Runs a "mock" election and prints out the validators that would be elected if the epoch ended right now.'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     ...(ux.table.flags() as object),
   }
 

--- a/packages/cli/src/commands/election/show.ts
+++ b/packages/cli/src/commands/election/show.ts
@@ -3,12 +3,13 @@ import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { printValueMapRecursive } from '../../utils/cli'
 import { CustomArgs } from '../../utils/command'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class ElectionShow extends BaseCommand {
   static description = 'Show election information about a voter or registered Validator Group'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     voter: Flags.boolean({
       exclusive: ['group'],
       description: 'Show information about an account voting in Validator elections',

--- a/packages/cli/src/commands/governance/show.ts
+++ b/packages/cli/src/commands/governance/show.ts
@@ -7,6 +7,7 @@ import { writeFileSync } from 'fs'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { printValueMap, printValueMapRecursive } from '../../utils/cli'
+import { ViewCommmandFlags } from '../../utils/flags'
 import {
   addExistingProposalIDToBuilder,
   addExistingProposalJSONFileToBuilder,
@@ -25,7 +26,7 @@ export default class Show extends BaseCommand {
   static description = 'Show information about a governance proposal, hotfix, or account.'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     raw: Flags.boolean({ required: false, description: 'Display proposal in raw bytes format' }),
     jsonTransactions: Flags.string({
       required: false,

--- a/packages/cli/src/commands/lockedgold/show.ts
+++ b/packages/cli/src/commands/lockedgold/show.ts
@@ -2,13 +2,14 @@ import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { printValueMapRecursive } from '../../utils/cli'
 import { CustomArgs } from '../../utils/command'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class Show extends BaseCommand {
   static description =
     'Show Locked Gold information for a given account. This includes the total amount of locked celo, the amount being used for voting in Validator Elections, the Locked Gold balance this account is required to maintain due to a registered Validator or Validator Group, and any pending withdrawals that have been initiated via "lockedgold:unlock".'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
   }
 
   static args = {

--- a/packages/cli/src/commands/multisig/show.ts
+++ b/packages/cli/src/commands/multisig/show.ts
@@ -5,12 +5,13 @@ import { Flags } from '@oclif/core'
 import { BaseCommand } from '../../base'
 import { printValueMapRecursive } from '../../utils/cli'
 import { CustomArgs } from '../../utils/command'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class ShowMultiSig extends BaseCommand {
   static description = 'Shows information about multi-sig contract'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     tx: Flags.integer({
       default: undefined,
       description: 'Show info for a transaction',

--- a/packages/cli/src/commands/network/contracts.ts
+++ b/packages/cli/src/commands/network/contracts.ts
@@ -5,6 +5,7 @@ import { CeloContract } from '@celo/contractkit'
 import { ux } from '@oclif/core'
 
 import { BaseCommand } from '../../base'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 const UNVERSIONED_CONTRACTS = [
   CeloContract.Registry,
@@ -20,7 +21,7 @@ export default class Contracts extends BaseCommand {
   static description = 'Lists Celo core contracts and their addresses.'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     ...(ux.table.flags() as object),
   }
 

--- a/packages/cli/src/commands/network/info.ts
+++ b/packages/cli/src/commands/network/info.ts
@@ -1,12 +1,13 @@
 import { Flags } from '@oclif/core'
 import { BaseCommand } from '../../base'
 import { printValueMapRecursive } from '../../utils/cli'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class Info extends BaseCommand {
   static description = 'View general network information such as the current block number'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     lastN: Flags.integer({
       // We cannot use char: 'n' here because it conflicts with the node flag
       description: 'Fetch info about the last n epochs',

--- a/packages/cli/src/commands/network/parameters.ts
+++ b/packages/cli/src/commands/network/parameters.ts
@@ -1,13 +1,14 @@
 import { Flags } from '@oclif/core'
 import { BaseCommand } from '../../base'
 import { printValueMapRecursive } from '../../utils/cli'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class Parameters extends BaseCommand {
   static description =
     'View parameters of the network, including but not limited to configuration for the various Celo core smart contracts.'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     raw: Flags.boolean({
       description: 'Display raw numerical configuration',
       required: false,

--- a/packages/cli/src/commands/network/whitelist.ts
+++ b/packages/cli/src/commands/network/whitelist.ts
@@ -1,12 +1,13 @@
 import { ux } from '@oclif/core'
 import { BaseCommand } from '../../base'
 import { getFeeCurrencyContractWrapper } from '../../utils/fee-currency'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class Whitelist extends BaseCommand {
   static description = 'List the whitelisted fee currencies'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     ...(ux.table.flags() as object),
   }
 

--- a/packages/cli/src/commands/oracle/list.ts
+++ b/packages/cli/src/commands/oracle/list.ts
@@ -2,12 +2,13 @@ import { CeloContract } from '@celo/contractkit'
 import { Args } from '@oclif/core'
 import { BaseCommand } from '../../base'
 import { failWith } from '../../utils/cli'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class List extends BaseCommand {
   static description = 'List oracle addresses for a given token'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
   }
 
   static args = {

--- a/packages/cli/src/commands/releasecelo/show.ts
+++ b/packages/cli/src/commands/releasecelo/show.ts
@@ -1,4 +1,5 @@
 import { printValueMapRecursive } from '../../utils/cli'
+import { ViewCommmandFlags } from '../../utils/flags'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 
 export default class Show extends ReleaseGoldBaseCommand {
@@ -6,6 +7,7 @@ export default class Show extends ReleaseGoldBaseCommand {
 
   static flags = {
     ...ReleaseGoldBaseCommand.flags,
+    ...ViewCommmandFlags,
   }
 
   static examples = ['show --contract 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95']

--- a/packages/cli/src/commands/rewards/show.ts
+++ b/packages/cli/src/commands/rewards/show.ts
@@ -8,6 +8,7 @@ import BigNumber from 'bignumber.js'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { CustomFlags } from '../../utils/command'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 interface ExplainedVoterReward extends VoterReward {
   validators: Validator[]
@@ -22,7 +23,7 @@ export default class Show extends BaseCommand {
     'Show rewards information about a voter, registered Validator, or Validator Group'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     estimate: Flags.boolean({
       description: 'Estimate voter rewards from current votes',
     }),

--- a/packages/cli/src/commands/validator/list.ts
+++ b/packages/cli/src/commands/validator/list.ts
@@ -2,6 +2,7 @@ import { Validator } from '@celo/contractkit/lib/wrappers/Validators'
 import { ux } from '@oclif/core'
 
 import { BaseCommand } from '../../base'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export const validatorTable: ux.Table.table.Columns<Record<'v', Validator>> = {
   address: { get: (row) => row.v.address },
@@ -19,7 +20,7 @@ export default class ValidatorList extends BaseCommand {
     'List registered Validators, their name (if provided), affiliation, uptime score, and public keys used for validating.'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     ...(ux.table.flags() as object),
   }
 

--- a/packages/cli/src/commands/validator/show.ts
+++ b/packages/cli/src/commands/validator/show.ts
@@ -2,12 +2,13 @@ import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { printValueMap } from '../../utils/cli'
 import { CustomArgs } from '../../utils/command'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class ValidatorShow extends BaseCommand {
   static description = 'Show information about a registered Validator.'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
   }
 
   static args = {

--- a/packages/cli/src/commands/validatorgroup/list.ts
+++ b/packages/cli/src/commands/validatorgroup/list.ts
@@ -1,13 +1,14 @@
 import { ux } from '@oclif/core'
 
 import { BaseCommand } from '../../base'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class ValidatorGroupList extends BaseCommand {
   static description =
     'List registered Validator Groups, their names (if provided), commission, and members.'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
     ...(ux.table.flags() as object),
   }
 

--- a/packages/cli/src/commands/validatorgroup/show.ts
+++ b/packages/cli/src/commands/validatorgroup/show.ts
@@ -2,12 +2,13 @@ import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { printValueMap } from '../../utils/cli'
 import { CustomArgs } from '../../utils/command'
+import { ViewCommmandFlags } from '../../utils/flags'
 
 export default class ValidatorGroupShow extends BaseCommand {
   static description = 'Show information about an existing Validator Group'
 
   static flags = {
-    ...BaseCommand.flags,
+    ...ViewCommmandFlags,
   }
 
   static args = {

--- a/packages/cli/src/utils/flags.ts
+++ b/packages/cli/src/utils/flags.ts
@@ -1,0 +1,25 @@
+import { BaseCommand } from '../base'
+
+export const ViewCommmandFlags = {
+  ...BaseCommand.flags,
+  gasCurrency: {
+    ...BaseCommand.flags.gasCurrency,
+    hidden: true,
+  },
+  useLedger: {
+    ...BaseCommand.flags.useLedger,
+    hidden: true,
+  },
+  ledgerAddresses: {
+    ...BaseCommand.flags.ledgerAddresses,
+    hidden: true,
+  },
+  ledgerCustomAddresses: {
+    ...BaseCommand.flags.ledgerCustomAddresses,
+    hidden: true,
+  },
+  privateKey: {
+    ...BaseCommand.flags.privateKey,
+    hidden: true,
+  },
+}


### PR DESCRIPTION
### Description

we had been showing flags that are only useful when signing transactions across several commands which made no use of them when given. This bloated the help and made it confusing.|

Add a new file flags.ts for groups of flags. so far ViewCommandFlags is the only one

#### Other changes

n/a
### Tested

I went through each  of the commands i modified to double check that the removed flags were in no way useful. 




<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on streamlining command-line interfaces by hiding certain flags (`privateKey`, `gasCurrency`, `useLedger`, etc.) that are not applicable to various commands. It also consolidates the flags into a new set called `ViewCommmandFlags`.

### Detailed summary
- Added `ViewCommmandFlags` to include relevant flags while hiding certain ones.
- Updated multiple command files to use `ViewCommmandFlags` instead of `BaseCommand.flags`.
- Modified help documentation for commands to remove hidden flags from usage instructions.

> The following files were skipped due to too many changes: `docs/command-line-interface/governance.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->