### PR TITLE
fix lib folder publish  for metadata claims

### DIFF
--- a/.changeset/tricky-bobcats-trade.md
+++ b/.changeset/tricky-bobcats-trade.md
@@ -1,0 +1,5 @@
+---
+'@celo/metadata-claims': patch
+---
+
+Publish lib instead of src

--- a/packages/sdk/metadata-claims/.npmignore
+++ b/packages/sdk/metadata-claims/.npmignore
@@ -1,0 +1,12 @@
+/node_modules
+/coverage
+/tsconfig.json
+/test
+/src
+
+# exclude ts files and sourcemaps
+*.map
+*.ts
+
+# include the .d.ts files
+!lib/**/*.d.ts


### PR DESCRIPTION
### BEFORE 

```
npm publish --dry-run

@celo/metadata-claims@1.0.0-beta.1 prepublishOnly
yarn build
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository" was changed from a string to an object
npm WARN publish "repository.url" was normalized to "git+https://github.com/celo-org/developer-tooling.git#master"
npm notice
npm notice 📦  @celo/metadata-claims@1.0.0-beta.1
npm notice === Tarball Contents ===
npm notice 57B   .eslintrc.js
npm notice 1.9kB CHANGELOG.md
npm notice 18B   README.md
npm notice 52B   eslint.tsconfig.json
npm notice 319B  jest.config.js
npm notice 263B  jestSetup.ts
npm notice 1.4kB package.json
npm notice 5.1kB src/account.test.ts
npm notice 1.6kB src/account.ts
npm notice 3.0kB src/claim.ts
npm notice 4.4kB src/domain.test.ts
npm notice 76B   src/index.ts
npm notice 2.3kB src/keybase.ts
npm notice 3.9kB src/metadata.test.ts
npm notice 7.2kB src/metadata.ts
npm notice 1.0kB src/types.ts
npm notice 3.5kB src/verify.ts
npm notice 186B  tsconfig.json
npm notice 365B  typedoc.json
npm notice === Tarball Details ===
npm notice name:          @celo/metadata-claims
npm notice version:       1.0.0-beta.1
npm notice filename:      celo-metadata-claims-1.0.0-beta.1.tgz
npm notice package size:  9.4 kB
npm notice unpacked size: 36.8 kB
npm notice shasum:        f3c8795ba01b3c9cca129703c59cd2a9e59364c4
npm notice integrity:     sha512-jfQ1YsuzE/Bsd[...]rJiD6wQUGdIMw==
npm notice total files:   19
npm notice
npm WARN This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
+ @celo/metadata-claims@1.0.0-beta.1

```

## AFTER

```
npm publish --dry-run

> @celo/metadata-claims@1.0.0-beta.1 prepublishOnly  
> yarn build

npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository" was changed from a string to an object
npm WARN publish "repository.url" was normalized to "git+https://github.com/celo-org/developer-tooling.git#master"
npm notice
npm notice 📦  @celo/metadata-claims@1.0.0-beta.1
npm notice === Tarball Contents ===
npm notice 57B    .eslintrc.js
npm notice 1.9kB  CHANGELOG.md
npm notice 18B    README.md
npm notice 52B    eslint.tsconfig.json
npm notice 319B   jest.config.js
npm notice 764B   lib/account.d.ts
npm notice 2.8kB  lib/account.js
npm notice 3.9kB  lib/claim.d.ts
npm notice 4.1kB  lib/claim.js
npm notice 78B    lib/index.d.ts
npm notice 1.0kB  lib/index.js
npm notice 892B   lib/keybase.d.ts
npm notice 3.7kB  lib/keybase.js
npm notice 3.2kB  lib/metadata.d.ts
npm notice 10.2kB lib/metadata.js
npm notice 1.0kB  lib/types.d.ts
npm notice 2.1kB  lib/types.js
npm notice 1.3kB  lib/verify.d.ts
npm notice 4.5kB  lib/verify.js
npm notice 1.4kB  package.json
npm notice 365B   typedoc.json
npm notice === Tarball Details ===
npm notice name:          @celo/metadata-claims
npm notice version:       1.0.0-beta.1
npm notice filename:      celo-metadata-claims-1.0.0-beta.1.tgz
npm notice package size:  9.5 kB
npm notice unpacked size: 43.7 kB
npm notice shasum:        1c0417f13644e6de013a17b8ef9d27e46b71a5e5
npm notice integrity:     sha512-eh2kNCjiE0roD[...]Z1NXVCtjg1NgA==
npm notice total files:   21
npm notice
npm WARN This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
+ @celo/metadata-claims@1.0.0-beta.1
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the package configuration for `@celo/metadata-claims` to publish the compiled library instead of the source files, ensuring that unnecessary files are excluded from the package.

### Detailed summary
- Updated the package `@celo/metadata-claims` to a patch version.
- Modified `.npmignore` to exclude:
  - `node_modules`
  - `coverage`
  - `tsconfig.json`
  - `test`
  - `src`
  - All `*.map` and `*.ts` files.
- Included `*.d.ts` files from the `lib` directory.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->