### PR TITLE
Update github actions upload-artfiact to version 4 due to EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
             -ip \
             run test --coverage
       - name: Upload Jest Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Jest Test Results
           path: test-results/jest


### PR DESCRIPTION
### Description

Github is setting actions/upload-artifact version 3 to EOL and workflows will fail because of it

#### Other changes

none
### Tested

We've used version 4 in other workflows and haven't had any issues.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflow for continuous integration by changing the version of the `actions/upload-artifact` from `v3` to `v4`.

### Detailed summary
- Updated the `actions/upload-artifact` from `v3` to `v4` in the `.github/workflows/ci.yml` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->