### PR TITLE
new global cli flag ledgerLiveMode, and new config derivationPath

### DIFF
--- a/.changeset/healthy-days-reply.md
+++ b/.changeset/healthy-days-reply.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+add --derivationPath to config:set for setting global deriviationPath. Usefull when using ledger devices and when generated new accounts.

--- a/.changeset/kind-cups-reflect.md
+++ b/.changeset/kind-cups-reflect.md
@@ -1,0 +1,6 @@
+---
+'@celo/wallet-ledger': minor
+---
+
+It is now possible to iterate over both the change and address indexes to look thru more bip44 paths for addresses. just pass changeIndexes into LedgerWallet.  
+

--- a/.changeset/nasty-feet-clean.md
+++ b/.changeset/nasty-feet-clean.md
@@ -2,4 +2,41 @@
 '@celo/wallet-ledger': major
 ---
 
-Interfaces for newLedgerWalletWithSetup and LedgerWallet constructor have changed
+Interfaces for newLedgerWalletWithSetup and LedgerWallet constructor have changed.
+
+`newLedgerWalletWithSetup` replaced positional arguments for named arguments and added changeIndexes
+
+```diff
+  newLedgerWalletWithSetup(
+    transport: any,
+-    derivationPathIndexes?: number[],
+-    baseDerivationPath?: string,
+-    ledgerAddressValidation?: AddressValidation,
+-    isCel2?: boolean
++    options: LedgerWalletSetup
+  )
+
++ interface LedgerWalletSetup {
++   derivationPathIndexes?: number[]
++   changeIndexes?: number[]
++   baseDerivationPath?: string
++   ledgerAddressValidation?: AddressValidation
++   isCel2?: boolean
++ }
+
+```
+
+`new LedgerWallet` moved transport to first position and added changeIndexes in 4th
+
+
+```diff
+new LedgerWallet(
++    transport,
+    derivationPathIndexes,
+    baseDerivationPath,
+-    transport,
++    changeIndexes,
+    ledgerAddressValidation,
+    isCel2
+  )
+```

--- a/.changeset/nasty-feet-clean.md
+++ b/.changeset/nasty-feet-clean.md
@@ -1,0 +1,5 @@
+---
+'@celo/wallet-ledger': major
+---
+
+Interfaces for newLedgerWalletWithSetup and LedgerWallet constructor have changed

--- a/.changeset/neat-seahorses-admire.md
+++ b/.changeset/neat-seahorses-admire.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+Add --ledgerLiveMode flag for use with --useLedger flag. This is useful for using same addresses on celocli as LedgerLive uses.

--- a/.changeset/yellow-cameras-talk.md
+++ b/.changeset/yellow-cameras-talk.md
@@ -1,0 +1,5 @@
+---
+'@celo/base': patch
+---
+
+New export type DerivationPath. Useful for when a value Must match first part of BIP44

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,7 @@ jobs:
       - name: Test that it prints out alfajores contracts
         run: |
           celocli network:info --node alfajores
+          celocli account:new
 
   cli-tests-anvil:
     name: CeloCli Tests (Anvil)

--- a/docs/command-line-interface/account.md
+++ b/docs/command-line-interface/account.md
@@ -125,23 +125,18 @@ View Celo Stables and CELO balances for an address
 
 ```
 USAGE
-  $ celocli account:balance ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--erc20Address 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
+  $ celocli account:balance ARG1 [-n <value>] [--globalHelp] [--erc20Address
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
 
 FLAGS
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --erc20Address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-      Address of generic ERC-20 token to also check balance for
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerLiveMode
-      When set, the 4th postion of the derivation path will be iterated over instead of
-      the 5th. This is useful to use same address on you Ledger with celocli as you do on
-      Ledger Live
+  -n, --node=<value>                                             URL of the node to run
+                                                                 commands against or an
+                                                                 alias
+      --erc20Address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Address of generic
+                                                                 ERC-20 token to also
+                                                                 check balance for
+      --globalHelp                                               View all available
+                                                                 global flags
 
 DESCRIPTION
   View Celo Stables and CELO balances for an address
@@ -1048,10 +1043,10 @@ Creates a new account locally using the Celo Derivation Path (m/44'/52752'/0/cha
 
 ```
 USAGE
-  $ celocli account:new [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--passphrasePath <value>] [--changeIndex <value>] [--addressIndex <value>]
-    [--language chinese_simplified|chinese_traditional|english|french|italian|japanese|k
-    orean|spanish] [--mnemonicPath <value>] [--derivationPath <value>]
+  $ celocli account:new [-n <value>] [--globalHelp] [--passphrasePath <value>]
+    [--changeIndex <value>] [--addressIndex <value>] [--language chinese_simplified|chin
+    ese_traditional|english|french|italian|japanese|korean|spanish] [--mnemonicPath
+    <value>] [--derivationPath <value>]
 
 FLAGS
   -n, --node=<value>
@@ -1074,11 +1069,6 @@ FLAGS
       wallets don't support other languages
       <options: chinese_simplified|chinese_traditional|english|french|italian|japanese|kor
       ean|spanish>
-
-  --ledgerLiveMode
-      When set, the 4th postion of the derivation path will be iterated over instead of
-      the 5th. This is useful to use same address on you Ledger with celocli as you do on
-      Ledger Live
 
   --mnemonicPath=<value>
       Instead of generating a new mnemonic (seed phrase), use the user-supplied mnemonic
@@ -1783,14 +1773,11 @@ Show information for an account, including name, authorized vote, validator, and
 
 ```
 USAGE
-  $ celocli account:show ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+  $ celocli account:show ARG1 [-n <value>] [--globalHelp]
 
 FLAGS
-  -n, --node=<value>    URL of the node to run commands against or an alias
-      --globalHelp      View all available global flags
-      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
-                        iterated over instead of the 5th. This is useful to use same
-                        address on you Ledger with celocli as you do on Ledger Live
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   Show information for an account, including name, authorized vote, validator, and
@@ -1875,9 +1862,9 @@ Show the data in a local metadata file
 
 ```
 USAGE
-  $ celocli account:show-metadata ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
-    [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli account:show-metadata ARG1 [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 ARGUMENTS
   ARG1  Path of the metadata file
@@ -1889,9 +1876,6 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
-      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
-                         iterated over instead of the 5th. This is useful to use same
-                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format

--- a/docs/command-line-interface/account.md
+++ b/docs/command-line-interface/account.md
@@ -44,7 +44,8 @@ USAGE
     vote|validator|attestation --signature 0x --signer
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp] [--blsKey 0x --blsPop 0x]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp] [--blsKey 0x
+    --blsPop 0x]
 
 FLAGS
   -k, --privateKey=<value>
@@ -78,6 +79,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --signature=0x
       (required) Signature (a.k.a proof-of-possession) of the signer key
@@ -119,18 +125,23 @@ View Celo Stables and CELO balances for an address
 
 ```
 USAGE
-  $ celocli account:balance ARG1 [-n <value>] [--globalHelp] [--erc20Address
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
+  $ celocli account:balance ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--erc20Address 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
 
 FLAGS
-  -n, --node=<value>                                             URL of the node to run
-                                                                 commands against or an
-                                                                 alias
-      --erc20Address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Address of generic
-                                                                 ERC-20 token to also
-                                                                 check balance for
-      --globalHelp                                               View all available
-                                                                 global flags
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --erc20Address=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Address of generic ERC-20 token to also check balance for
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
 DESCRIPTION
   View Celo Stables and CELO balances for an address
@@ -162,7 +173,7 @@ USAGE
   $ celocli account:claim-account ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --address <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--publicKey <value>]
+    [--ledgerLiveMode ] [--globalHelp] [--publicKey <value>]
 
 ARGUMENTS
   ARG1  Path of the metadata file
@@ -191,6 +202,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --publicKey=<value>
       The public key of the account that others may use to send you encrypted messages
@@ -227,7 +243,7 @@ USAGE
   $ celocli account:claim-domain ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --domain <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
@@ -256,6 +272,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -288,7 +309,7 @@ USAGE
   $ celocli account:claim-keybase ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --username <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
@@ -314,6 +335,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -349,7 +375,7 @@ USAGE
   $ celocli account:claim-name ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --name <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
@@ -375,6 +401,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --name=<value>
       (required) The name you want to claim
@@ -410,7 +441,7 @@ USAGE
   $ celocli account:claim-rpc-url ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --rpcUrl https://www.celo.org [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp]
+    <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
@@ -436,6 +467,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --rpcUrl=https://www.celo.org
       (required) The RPC URL to claim
@@ -471,7 +507,7 @@ USAGE
   $ celocli account:claim-storage ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --url https://www.celo.org [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  Path of the metadata file
@@ -497,6 +533,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --url=https://www.celo.org
       (required) The URL of the storage root you want to claim
@@ -532,7 +573,7 @@ USAGE
   $ celocli account:create-metadata ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  Path where the metadata should be saved
@@ -558,6 +599,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -593,7 +639,7 @@ USAGE
     attestation --signer 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> |
     --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -619,6 +665,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Account Address
@@ -654,7 +705,7 @@ USAGE
   $ celocli account:delete-payment-delegation --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -676,6 +727,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -707,8 +763,9 @@ Show information about an address. Retrieves the metadata URL for an account fro
 USAGE
   $ celocli account:get-metadata ARG1 [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header |
-    [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+    <value> ] [--ledgerLiveMode ] [--globalHelp] [--columns <value> | -x] [--filter
+    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
+    [--sort <value>]
 
 ARGUMENTS
   ARG1  Address to get metadata for
@@ -742,6 +799,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --no-header
       hide table header from output
@@ -788,8 +850,9 @@ USAGE
   $ celocli account:get-payment-delegation --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+    [--ledgerLiveMode ] [--globalHelp] [--columns <value> | -x] [--filter <value>]
+    [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort
+    <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -823,6 +886,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --no-header
       hide table header from output
@@ -868,7 +936,7 @@ List the addresses from the node and the local instance
 USAGE
   $ celocli account:list [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--local]
+    [--ledgerLiveMode ] [--globalHelp] [--local]
 
 FLAGS
   -k, --privateKey=<value>
@@ -887,6 +955,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --[no-]local
       If set, only show local and hardware wallet accounts. Use no-local to only show
@@ -919,7 +992,7 @@ Lock an account which was previously unlocked
 USAGE
   $ celocli account:lock ARG1 [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp]
+    <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  Account address
@@ -941,6 +1014,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -970,10 +1048,10 @@ Creates a new account locally using the Celo Derivation Path (m/44'/52752'/0/cha
 
 ```
 USAGE
-  $ celocli account:new [-n <value>] [--globalHelp] [--passphrasePath <value>]
-    [--changeIndex <value>] [--addressIndex <value>] [--language chinese_simplified|chin
-    ese_traditional|english|french|italian|japanese|korean|spanish] [--mnemonicPath
-    <value>] [--derivationPath <value>]
+  $ celocli account:new [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--passphrasePath <value>] [--changeIndex <value>] [--addressIndex <value>]
+    [--language chinese_simplified|chinese_traditional|english|french|italian|japanese|k
+    orean|spanish] [--mnemonicPath <value>] [--derivationPath <value>]
 
 FLAGS
   -n, --node=<value>
@@ -996,6 +1074,11 @@ FLAGS
       wallets don't support other languages
       <options: chinese_simplified|chinese_traditional|english|french|italian|japanese|kor
       ean|spanish>
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --mnemonicPath=<value>
       Instead of generating a new mnemonic (seed phrase), use the user-supplied mnemonic
@@ -1066,9 +1149,9 @@ DEV: Reads the name from offchain storage
 USAGE
   $ celocli account:offchain-read ARG1 [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp] [--directory <value>] [--bucket <value> --provider
-    git|aws|gcp] [--from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--privateDEK
-    <value>]
+    <value> ] [--ledgerLiveMode ] [--globalHelp] [--directory <value>] [--bucket <value>
+    --provider git|aws|gcp] [--from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
+    [--privateDEK <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1096,6 +1179,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --privateDEK=<value>
 
@@ -1135,8 +1223,9 @@ DEV: Writes a name to offchain storage
 USAGE
   $ celocli account:offchain-write --name <value> [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> (--useLedger
-    | --privateKey <value>)] [--globalHelp] [--directory <value>] [--bucket <value>
-    --provider git|aws|gcp] [--privateDEK <value>  --encryptTo <value>]
+    | --privateKey <value>)] [--ledgerLiveMode ] [--globalHelp] [--directory <value>]
+    [--bucket <value> --provider git|aws|gcp] [--privateDEK <value>  --encryptTo
+    <value>]
 
 FLAGS
   -n, --node=<value>
@@ -1160,6 +1249,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --name=<value>
       (required)
@@ -1206,7 +1300,7 @@ USAGE
   $ celocli account:proof-of-possession --signer 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ]
     [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1228,6 +1322,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --signer=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address of the signer key to prove possession of.
@@ -1264,7 +1363,7 @@ USAGE
   $ celocli account:register --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--name <value>]
+    [--ledgerLiveMode ] [--globalHelp] [--name <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1286,6 +1385,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --name=<value>
 
@@ -1324,7 +1428,7 @@ USAGE
   $ celocli account:register-data-encryption-key --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --publicKey <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1346,6 +1450,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --publicKey=<value>
       (required) The public key you want to register
@@ -1382,8 +1491,9 @@ USAGE
   $ celocli account:register-metadata --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --url
     <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--force] [--columns <value> | -x] [--filter <value>] [--no-header |
-    [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+    [--ledgerLiveMode ] [--globalHelp] [--force] [--columns <value> | -x] [--filter
+    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
+    [--sort <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1420,6 +1530,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --no-header
       hide table header from output
@@ -1469,7 +1584,7 @@ USAGE
   $ celocli account:set-name --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --name <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1491,6 +1606,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --name=<value>
       (required)
@@ -1528,7 +1648,7 @@ USAGE
     --beneficiary 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --fraction <value> [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1556,6 +1676,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -1589,8 +1714,8 @@ USAGE
   $ celocli account:set-wallet --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --wallet 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ]
     [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp] [--signature 0x] [--signer
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp] [--signature 0x]
+    [--signer 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1612,6 +1737,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --signature=0x
       Signature (a.k.a. proof-of-possession) of the signer key
@@ -1653,11 +1783,14 @@ Show information for an account, including name, authorized vote, validator, and
 
 ```
 USAGE
-  $ celocli account:show ARG1 [-n <value>] [--globalHelp]
+  $ celocli account:show ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
-  -n, --node=<value>  URL of the node to run commands against or an alias
-      --globalHelp    View all available global flags
+  -n, --node=<value>    URL of the node to run commands against or an alias
+      --globalHelp      View all available global flags
+      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
+                        iterated over instead of the 5th. This is useful to use same
+                        address on you Ledger with celocli as you do on Ledger Live
 
 DESCRIPTION
   Show information for an account, including name, authorized vote, validator, and
@@ -1689,7 +1822,7 @@ Show information about claimed accounts
 USAGE
   $ celocli account:show-claimed-accounts ARG1 [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp]
+    <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1708,6 +1841,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -1737,9 +1875,9 @@ Show the data in a local metadata file
 
 ```
 USAGE
-  $ celocli account:show-metadata ARG1 [-n <value>] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli account:show-metadata ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
+    [--output csv|json|yaml |  | ] [--sort <value>]
 
 ARGUMENTS
   ARG1  Path of the metadata file
@@ -1751,6 +1889,9 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
+      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
+                         iterated over instead of the 5th. This is useful to use same
+                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format
@@ -1784,7 +1925,8 @@ Unlock an account address to send transactions or validate blocks
 USAGE
   $ celocli account:unlock ARG1 [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp] [--password <value>] [--duration <value>]
+    <value> ] [--ledgerLiveMode ] [--globalHelp] [--password <value>] [--duration
+    <value>]
 
 ARGUMENTS
   ARG1  Account address
@@ -1810,6 +1952,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --password=<value>
       Password used to unlock the account. If not specified, you will be prompted for a
@@ -1849,7 +1996,7 @@ USAGE
     --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --signature 0x [-k <value> |
     --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1871,6 +2018,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --signature=0x
       (required) Signature (a.k.a. proof-of-possession) of the signer key

--- a/docs/command-line-interface/config.md
+++ b/docs/command-line-interface/config.md
@@ -12,14 +12,11 @@ Output network node configuration
 
 ```
 USAGE
-  $ celocli config:get [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+  $ celocli config:get [-n <value>] [--globalHelp]
 
 FLAGS
-  -n, --node=<value>    URL of the node to run commands against or an alias
-      --globalHelp      View all available global flags
-      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
-                        iterated over instead of the 5th. This is useful to use same
-                        address on you Ledger with celocli as you do on Ledger Live
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   Output network node configuration
@@ -43,8 +40,7 @@ Configure running node information for propagating transactions to network
 
 ```
 USAGE
-  $ celocli config:set [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--derivationPath <value>]
+  $ celocli config:set [-n <value>] [--globalHelp] [--derivationPath <value>]
 
 FLAGS
   -n, --node=<value>            URL of the node to run commands against or an alias
@@ -52,10 +48,6 @@ FLAGS
                                 when using --useLedger flag. Options: 'eth',
                                 'celoLegacy', or a custom derivation path
       --globalHelp              View all available global flags
-      --ledgerLiveMode          When set, the 4th postion of the derivation path will be
-                                iterated over instead of the 5th. This is useful to use
-                                same address on you Ledger with celocli as you do on
-                                Ledger Live
 
 DESCRIPTION
   Configure running node information for propagating transactions to network

--- a/docs/command-line-interface/config.md
+++ b/docs/command-line-interface/config.md
@@ -12,11 +12,14 @@ Output network node configuration
 
 ```
 USAGE
-  $ celocli config:get [-n <value>] [--globalHelp]
+  $ celocli config:get [-n <value>] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
-  -n, --node=<value>  URL of the node to run commands against or an alias
-      --globalHelp    View all available global flags
+  -n, --node=<value>    URL of the node to run commands against or an alias
+      --globalHelp      View all available global flags
+      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
+                        iterated over instead of the 5th. This is useful to use same
+                        address on you Ledger with celocli as you do on Ledger Live
 
 DESCRIPTION
   Output network node configuration
@@ -40,11 +43,19 @@ Configure running node information for propagating transactions to network
 
 ```
 USAGE
-  $ celocli config:set [-n <value>] [--globalHelp]
+  $ celocli config:set [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--derivationPath <value>]
 
 FLAGS
-  -n, --node=<value>  URL of the node to run commands against or an alias
-      --globalHelp    View all available global flags
+  -n, --node=<value>            URL of the node to run commands against or an alias
+      --derivationPath=<value>  Set the default derivation path used by account:new and
+                                when using --useLedger flag. Options: 'eth',
+                                'celoLegacy', or a custom derivation path
+      --globalHelp              View all available global flags
+      --ledgerLiveMode          When set, the 4th postion of the derivation path will be
+                                iterated over instead of the 5th. This is useful to use
+                                same address on you Ledger with celocli as you do on
+                                Ledger Live
 
 DESCRIPTION
   Configure running node information for propagating transactions to network
@@ -65,6 +76,12 @@ EXAMPLES
   set --node ws://localhost:2500
 
   set --node <geth-location>/geth.ipc
+
+  set --derivationPath "m/44'/52752'/0'/0"
+
+  set --derivationPath eth
+
+  set --derivationPath celoLegacy
 
 FLAG DESCRIPTIONS
   -n, --node=<value>  URL of the node to run commands against or an alias

--- a/docs/command-line-interface/dkg.md
+++ b/docs/command-line-interface/dkg.md
@@ -20,7 +20,7 @@ USAGE
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --from
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -45,6 +45,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --participantAddress=<value>
       (required) Address of the participant to allowlist
@@ -77,7 +82,7 @@ USAGE
   $ celocli dkg:deploy --phaseDuration <value> --threshold <value> --from
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -99,6 +104,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --phaseDuration=<value>
       (required) Duration of each DKG phase in blocks
@@ -135,7 +145,7 @@ USAGE
     shares|responses|justifications|participants|phase|group --address
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -157,6 +167,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --method=<option>
       (required) Getter method to call
@@ -191,7 +206,7 @@ USAGE
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --from
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -219,6 +234,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -249,7 +269,7 @@ USAGE
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --from
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -277,6 +297,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -306,7 +331,7 @@ USAGE
   $ celocli dkg:start --address 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -331,6 +356,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet

--- a/docs/command-line-interface/election.md
+++ b/docs/command-line-interface/election.md
@@ -20,7 +20,8 @@ USAGE
   $ celocli election:activate --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--for 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--wait]
+    [--ledgerLiveMode ] [--globalHelp] [--for
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--wait]
 
 FLAGS
   -k, --privateKey=<value>
@@ -45,6 +46,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -85,8 +91,9 @@ Outputs the set of validators currently participating in BFT to create blocks. A
 USAGE
   $ celocli election:current [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--valset] [--columns <value> | -x] [--filter <value>] [--no-header |
-    [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+    [--ledgerLiveMode ] [--globalHelp] [--valset] [--columns <value> | -x] [--filter
+    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
+    [--sort <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -117,6 +124,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --no-header
       hide table header from output
@@ -161,9 +173,9 @@ Prints the list of validator groups, the number of votes they have received, the
 
 ```
 USAGE
-  $ celocli election:list [-n <value>] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli election:list [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
+    [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
   -n, --node=<value>     URL of the node to run commands against or an alias
@@ -172,6 +184,9 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
+      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
+                         iterated over instead of the 5th. This is useful to use same
+                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format
@@ -208,7 +223,7 @@ USAGE
   $ celocli election:revoke --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --for
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
     | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -233,6 +248,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -265,9 +285,9 @@ Runs a "mock" election and prints out the validators that would be elected if th
 
 ```
 USAGE
-  $ celocli election:run [-n <value>] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli election:run [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
+    [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
   -n, --node=<value>     URL of the node to run commands against or an alias
@@ -276,6 +296,9 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
+      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
+                         iterated over instead of the 5th. This is useful to use same
+                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format
@@ -305,16 +328,20 @@ Show election information about a voter or registered Validator Group
 
 ```
 USAGE
-  $ celocli election:show ARG1 [-n <value>] [--globalHelp] [--voter | --group]
+  $ celocli election:show ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--voter | --group]
 
 ARGUMENTS
   ARG1  Voter or Validator Groups's address
 
 FLAGS
-  -n, --node=<value>  URL of the node to run commands against or an alias
-      --globalHelp    View all available global flags
-      --group         Show information about a group running in Validator elections
-      --voter         Show information about an account voting in Validator elections
+  -n, --node=<value>    URL of the node to run commands against or an alias
+      --globalHelp      View all available global flags
+      --group           Show information about a group running in Validator elections
+      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
+                        iterated over instead of the 5th. This is useful to use same
+                        address on you Ledger with celocli as you do on Ledger Live
+      --voter           Show information about an account voting in Validator elections
 
 DESCRIPTION
   Show election information about a voter or registered Validator Group
@@ -346,7 +373,7 @@ USAGE
   $ celocli election:vote --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --for
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
     | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -371,6 +398,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet

--- a/docs/command-line-interface/election.md
+++ b/docs/command-line-interface/election.md
@@ -173,9 +173,9 @@ Prints the list of validator groups, the number of votes they have received, the
 
 ```
 USAGE
-  $ celocli election:list [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
-    [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli election:list [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 FLAGS
   -n, --node=<value>     URL of the node to run commands against or an alias
@@ -184,9 +184,6 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
-      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
-                         iterated over instead of the 5th. This is useful to use same
-                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format
@@ -285,9 +282,9 @@ Runs a "mock" election and prints out the validators that would be elected if th
 
 ```
 USAGE
-  $ celocli election:run [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
-    [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli election:run [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 FLAGS
   -n, --node=<value>     URL of the node to run commands against or an alias
@@ -296,9 +293,6 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
-      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
-                         iterated over instead of the 5th. This is useful to use same
-                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format
@@ -328,20 +322,16 @@ Show election information about a voter or registered Validator Group
 
 ```
 USAGE
-  $ celocli election:show ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--voter | --group]
+  $ celocli election:show ARG1 [-n <value>] [--globalHelp] [--voter | --group]
 
 ARGUMENTS
   ARG1  Voter or Validator Groups's address
 
 FLAGS
-  -n, --node=<value>    URL of the node to run commands against or an alias
-      --globalHelp      View all available global flags
-      --group           Show information about a group running in Validator elections
-      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
-                        iterated over instead of the 5th. This is useful to use same
-                        address on you Ledger with celocli as you do on Ledger Live
-      --voter           Show information about an account voting in Validator elections
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
+      --group         Show information about a group running in Validator elections
+      --voter         Show information about an account voting in Validator elections
 
 DESCRIPTION
   Show election information about a voter or registered Validator Group

--- a/docs/command-line-interface/epochs.md
+++ b/docs/command-line-interface/epochs.md
@@ -16,7 +16,7 @@ USAGE
   $ celocli epochs:finish --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -38,6 +38,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -70,7 +75,7 @@ USAGE
   $ celocli epochs:start --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -92,6 +97,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -124,7 +134,7 @@ USAGE
   $ celocli epochs:switch --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -146,6 +156,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet

--- a/docs/command-line-interface/exchange.md
+++ b/docs/command-line-interface/exchange.md
@@ -19,8 +19,8 @@ USAGE
   $ celocli exchange:celo --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
     10000000000000000000000 [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--forAtLeast 10000000000000000000000] [--stableToken
-    cUSD|cusd|cEUR|ceur|cREAL|creal]
+    [--ledgerLiveMode ] [--globalHelp] [--forAtLeast 10000000000000000000000]
+    [--stableToken cUSD|cusd|cEUR|ceur|cREAL|creal]
 
 FLAGS
   -k, --privateKey=<value>
@@ -45,6 +45,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --stableToken=<option>
       [default: cusd] Name of the stable to receive
@@ -87,7 +92,7 @@ USAGE
   $ celocli exchange:dollars --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
     10000000000000000000000 [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--forAtLeast 10000000000000000000000]
+    [--ledgerLiveMode ] [--globalHelp] [--forAtLeast 10000000000000000000000]
 
 FLAGS
   -k, --privateKey=<value>
@@ -112,6 +117,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -149,7 +159,7 @@ USAGE
   $ celocli exchange:euros --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
     10000000000000000000000 [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--forAtLeast 10000000000000000000000]
+    [--ledgerLiveMode ] [--globalHelp] [--forAtLeast 10000000000000000000000]
 
 FLAGS
   -k, --privateKey=<value>
@@ -174,6 +184,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -211,7 +226,7 @@ USAGE
   $ celocli exchange:reals --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
     10000000000000000000000 [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--forAtLeast 10000000000000000000000]
+    [--ledgerLiveMode ] [--globalHelp] [--forAtLeast 10000000000000000000000]
 
 FLAGS
   -k, --privateKey=<value>
@@ -236,6 +251,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -272,7 +292,7 @@ Show the current exchange rates offered by the Broker
 USAGE
   $ celocli exchange:show [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--amount <value>]
+    [--ledgerLiveMode ] [--globalHelp] [--amount <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -295,6 +315,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -327,8 +352,8 @@ USAGE
   $ celocli exchange:stable --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
     10000000000000000000000 [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--forAtLeast 10000000000000000000000] [--stableToken
-    cUSD|cusd|cEUR|ceur|cREAL|creal]
+    [--ledgerLiveMode ] [--globalHelp] [--forAtLeast 10000000000000000000000]
+    [--stableToken cUSD|cusd|cEUR|ceur|cREAL|creal]
 
 FLAGS
   -k, --privateKey=<value>
@@ -353,6 +378,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --stableToken=<option>
       Name of the stable token to be transferred

--- a/docs/command-line-interface/governance.md
+++ b/docs/command-line-interface/governance.md
@@ -725,10 +725,10 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:show [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
-    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
-    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:show [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
+    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
+    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
   -n, --node=<value>                    URL of the node to run commands against or an
@@ -741,10 +741,6 @@ FLAGS
       --globalHelp                      View all available global flags
       --hotfix=<value>                  Hash of hotfix proposal
       --jsonTransactions=<value>        Output proposal JSON to provided file
-      --ledgerLiveMode                  When set, the 4th postion of the derivation path
-                                        will be iterated over instead of the 5th. This
-                                        is useful to use same address on you Ledger with
-                                        celocli as you do on Ledger Live
       --nonwhitelisters                 If set, displays validators that have not
                                         whitelisted the hotfix.(will be removed when L2
                                         launches
@@ -800,10 +796,10 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:showaccount [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
-    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
-    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:showaccount [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
+    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
+    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
   -n, --node=<value>                    URL of the node to run commands against or an
@@ -816,10 +812,6 @@ FLAGS
       --globalHelp                      View all available global flags
       --hotfix=<value>                  Hash of hotfix proposal
       --jsonTransactions=<value>        Output proposal JSON to provided file
-      --ledgerLiveMode                  When set, the 4th postion of the derivation path
-                                        will be iterated over instead of the 5th. This
-                                        is useful to use same address on you Ledger with
-                                        celocli as you do on Ledger Live
       --nonwhitelisters                 If set, displays validators that have not
                                         whitelisted the hotfix.(will be removed when L2
                                         launches
@@ -873,10 +865,10 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:showhotfix [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
-    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
-    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:showhotfix [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
+    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
+    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
   -n, --node=<value>                    URL of the node to run commands against or an
@@ -889,10 +881,6 @@ FLAGS
       --globalHelp                      View all available global flags
       --hotfix=<value>                  Hash of hotfix proposal
       --jsonTransactions=<value>        Output proposal JSON to provided file
-      --ledgerLiveMode                  When set, the 4th postion of the derivation path
-                                        will be iterated over instead of the 5th. This
-                                        is useful to use same address on you Ledger with
-                                        celocli as you do on Ledger Live
       --nonwhitelisters                 If set, displays validators that have not
                                         whitelisted the hotfix.(will be removed when L2
                                         launches
@@ -1008,10 +996,10 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:view [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
-    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
-    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:view [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
+    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
+    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
   -n, --node=<value>                    URL of the node to run commands against or an
@@ -1024,10 +1012,6 @@ FLAGS
       --globalHelp                      View all available global flags
       --hotfix=<value>                  Hash of hotfix proposal
       --jsonTransactions=<value>        Output proposal JSON to provided file
-      --ledgerLiveMode                  When set, the 4th postion of the derivation path
-                                        will be iterated over instead of the 5th. This
-                                        is useful to use same address on you Ledger with
-                                        celocli as you do on Ledger Live
       --nonwhitelisters                 If set, displays validators that have not
                                         whitelisted the hotfix.(will be removed when L2
                                         launches
@@ -1081,10 +1065,10 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:viewaccount [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
-    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
-    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:viewaccount [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
+    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
+    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
   -n, --node=<value>                    URL of the node to run commands against or an
@@ -1097,10 +1081,6 @@ FLAGS
       --globalHelp                      View all available global flags
       --hotfix=<value>                  Hash of hotfix proposal
       --jsonTransactions=<value>        Output proposal JSON to provided file
-      --ledgerLiveMode                  When set, the 4th postion of the derivation path
-                                        will be iterated over instead of the 5th. This
-                                        is useful to use same address on you Ledger with
-                                        celocli as you do on Ledger Live
       --nonwhitelisters                 If set, displays validators that have not
                                         whitelisted the hotfix.(will be removed when L2
                                         launches
@@ -1154,10 +1134,10 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:viewhotfix [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
-    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
-    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
-    [--afterExecutingProposal <value> | --afterExecutingID <value>]
+  $ celocli governance:viewhotfix [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
+    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
+    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
   -n, --node=<value>                    URL of the node to run commands against or an
@@ -1170,10 +1150,6 @@ FLAGS
       --globalHelp                      View all available global flags
       --hotfix=<value>                  Hash of hotfix proposal
       --jsonTransactions=<value>        Output proposal JSON to provided file
-      --ledgerLiveMode                  When set, the 4th postion of the derivation path
-                                        will be iterated over instead of the 5th. This
-                                        is useful to use same address on you Ledger with
-                                        celocli as you do on Ledger Live
       --nonwhitelisters                 If set, displays validators that have not
                                         whitelisted the hotfix.(will be removed when L2
                                         launches

--- a/docs/command-line-interface/governance.md
+++ b/docs/command-line-interface/governance.md
@@ -34,8 +34,8 @@ USAGE
   $ celocli governance:approvehotfix --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--proposalID <value> | --hotfix <value>] [--useMultiSig | --useSafe]
-    [--type approver|securityCouncil ]
+    [--ledgerLiveMode ] [--globalHelp] [--proposalID <value> | --hotfix <value>]
+    [--useMultiSig | --useSafe] [--type approver|securityCouncil ]
 
 FLAGS
   -k, --privateKey=<value>
@@ -60,6 +60,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --proposalID=<value>
       UUID of proposal to approve
@@ -112,8 +117,8 @@ Interactively build a governance proposal
 USAGE
   $ celocli governance:build-proposal [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--output <value>] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+    [--ledgerLiveMode ] [--globalHelp] [--output <value>] [--afterExecutingProposal
+    <value> | --afterExecutingID <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -138,6 +143,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --output=<value>
       [default: proposalTransactions.json] Path to output
@@ -173,7 +183,7 @@ USAGE
   $ celocli governance:dequeue --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -195,6 +205,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -227,7 +242,7 @@ USAGE
   $ celocli governance:execute --proposalID <value> --from
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -249,6 +264,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --proposalID=<value>
       (required) UUID of proposal to execute
@@ -284,7 +304,7 @@ USAGE
   $ celocli governance:executehotfix --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --jsonTransactions <value> --salt <value> [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp]
+    <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -309,6 +329,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --salt=<value>
       (required) Secret salt associated with hotfix
@@ -344,7 +369,7 @@ USAGE
   $ celocli governance:hashhotfix --jsonTransactions <value> --salt <value> [-k <value> |
     --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--force]
+    [--ledgerLiveMode ] [--globalHelp] [--force]
 
 FLAGS
   -k, --privateKey=<value>
@@ -369,6 +394,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --salt=<value>
       (required) Secret salt associated with hotfix
@@ -403,8 +433,9 @@ List live governance proposals (queued and ongoing)
 USAGE
   $ celocli governance:list [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+    [--ledgerLiveMode ] [--globalHelp] [--columns <value> | -x] [--filter <value>]
+    [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort
+    <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -435,6 +466,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --no-header
       hide table header from output
@@ -480,7 +516,7 @@ USAGE
   $ celocli governance:preparehotfix --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --hash
     <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -505,6 +541,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -538,8 +579,9 @@ USAGE
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --descriptionURL https://www.celo.org [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--for 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --useMultiSig]
-    [--force] [--noInfo] [--afterExecutingProposal <value> | --afterExecutingID <value>]
+    [--ledgerLiveMode ] [--globalHelp] [--for 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+    --useMultiSig] [--force] [--noInfo] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -583,6 +625,11 @@ FLAGS
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
 
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
+
   --noInfo
       Skip printing the proposal info
 
@@ -622,7 +669,7 @@ USAGE
   $ celocli governance:revokeupvote --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -644,6 +691,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -673,10 +725,10 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:show [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
-    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
-    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+  $ celocli governance:show [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
+    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
+    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
+    [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
   -n, --node=<value>                    URL of the node to run commands against or an
@@ -689,6 +741,10 @@ FLAGS
       --globalHelp                      View all available global flags
       --hotfix=<value>                  Hash of hotfix proposal
       --jsonTransactions=<value>        Output proposal JSON to provided file
+      --ledgerLiveMode                  When set, the 4th postion of the derivation path
+                                        will be iterated over instead of the 5th. This
+                                        is useful to use same address on you Ledger with
+                                        celocli as you do on Ledger Live
       --nonwhitelisters                 If set, displays validators that have not
                                         whitelisted the hotfix.(will be removed when L2
                                         launches
@@ -744,10 +800,10 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:showaccount [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
-    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
-    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+  $ celocli governance:showaccount [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
+    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
+    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
+    [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
   -n, --node=<value>                    URL of the node to run commands against or an
@@ -760,6 +816,10 @@ FLAGS
       --globalHelp                      View all available global flags
       --hotfix=<value>                  Hash of hotfix proposal
       --jsonTransactions=<value>        Output proposal JSON to provided file
+      --ledgerLiveMode                  When set, the 4th postion of the derivation path
+                                        will be iterated over instead of the 5th. This
+                                        is useful to use same address on you Ledger with
+                                        celocli as you do on Ledger Live
       --nonwhitelisters                 If set, displays validators that have not
                                         whitelisted the hotfix.(will be removed when L2
                                         launches
@@ -813,10 +873,10 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:showhotfix [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
-    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
-    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+  $ celocli governance:showhotfix [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
+    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
+    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
+    [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
   -n, --node=<value>                    URL of the node to run commands against or an
@@ -829,6 +889,10 @@ FLAGS
       --globalHelp                      View all available global flags
       --hotfix=<value>                  Hash of hotfix proposal
       --jsonTransactions=<value>        Output proposal JSON to provided file
+      --ledgerLiveMode                  When set, the 4th postion of the derivation path
+                                        will be iterated over instead of the 5th. This
+                                        is useful to use same address on you Ledger with
+                                        celocli as you do on Ledger Live
       --nonwhitelisters                 If set, displays validators that have not
                                         whitelisted the hotfix.(will be removed when L2
                                         launches
@@ -885,7 +949,7 @@ USAGE
   $ celocli governance:upvote --proposalID <value> --from
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -907,6 +971,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --proposalID=<value>
       (required) UUID of proposal to upvote
@@ -939,10 +1008,10 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:view [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
-    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
-    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+  $ celocli governance:view [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
+    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
+    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
+    [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
   -n, --node=<value>                    URL of the node to run commands against or an
@@ -955,6 +1024,10 @@ FLAGS
       --globalHelp                      View all available global flags
       --hotfix=<value>                  Hash of hotfix proposal
       --jsonTransactions=<value>        Output proposal JSON to provided file
+      --ledgerLiveMode                  When set, the 4th postion of the derivation path
+                                        will be iterated over instead of the 5th. This
+                                        is useful to use same address on you Ledger with
+                                        celocli as you do on Ledger Live
       --nonwhitelisters                 If set, displays validators that have not
                                         whitelisted the hotfix.(will be removed when L2
                                         launches
@@ -1008,10 +1081,10 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:viewaccount [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
-    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
-    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+  $ celocli governance:viewaccount [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
+    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
+    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
+    [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
   -n, --node=<value>                    URL of the node to run commands against or an
@@ -1024,6 +1097,10 @@ FLAGS
       --globalHelp                      View all available global flags
       --hotfix=<value>                  Hash of hotfix proposal
       --jsonTransactions=<value>        Output proposal JSON to provided file
+      --ledgerLiveMode                  When set, the 4th postion of the derivation path
+                                        will be iterated over instead of the 5th. This
+                                        is useful to use same address on you Ledger with
+                                        celocli as you do on Ledger Live
       --nonwhitelisters                 If set, displays validators that have not
                                         whitelisted the hotfix.(will be removed when L2
                                         launches
@@ -1077,10 +1154,10 @@ Show information about a governance proposal, hotfix, or account.
 
 ```
 USAGE
-  $ celocli governance:viewhotfix [-n <value>] [--globalHelp] [--raw] [--jsonTransactions
-    <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters |  | [--proposalID
-    <value> | --account <value> | --hotfix <value>]] [--afterExecutingProposal <value> |
-    --afterExecutingID <value>]
+  $ celocli governance:viewhotfix [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
+    [--jsonTransactions <value>] [--notwhitelisted] [--whitelisters | --nonwhitelisters
+    |  | [--proposalID <value> | --account <value> | --hotfix <value>]]
+    [--afterExecutingProposal <value> | --afterExecutingID <value>]
 
 FLAGS
   -n, --node=<value>                    URL of the node to run commands against or an
@@ -1093,6 +1170,10 @@ FLAGS
       --globalHelp                      View all available global flags
       --hotfix=<value>                  Hash of hotfix proposal
       --jsonTransactions=<value>        Output proposal JSON to provided file
+      --ledgerLiveMode                  When set, the 4th postion of the derivation path
+                                        will be iterated over instead of the 5th. This
+                                        is useful to use same address on you Ledger with
+                                        celocli as you do on Ledger Live
       --nonwhitelisters                 If set, displays validators that have not
                                         whitelisted the hotfix.(will be removed when L2
                                         launches
@@ -1149,7 +1230,7 @@ USAGE
   $ celocli governance:vote --proposalID <value> --value Abstain|No|Yes --from
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1171,6 +1252,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --proposalID=<value>
       (required) UUID of proposal to vote on
@@ -1210,8 +1296,8 @@ USAGE
   $ celocli governance:votePartially --proposalID <value> --from
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp] [--yes <value>] [--no <value>]
-    [--abstain <value>]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp] [--yes <value>]
+    [--no <value>] [--abstain <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1236,6 +1322,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --no=<value>
       No votes
@@ -1277,7 +1368,7 @@ USAGE
   $ celocli governance:whitelisthotfix --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --hash
     <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1302,6 +1393,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -1334,7 +1430,7 @@ USAGE
   $ celocli governance:withdraw --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1356,6 +1452,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet

--- a/docs/command-line-interface/identity.md
+++ b/docs/command-line-interface/identity.md
@@ -14,7 +14,8 @@ USAGE
   $ celocli identity:withdraw-attestation-rewards --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--tokenAddress 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
+    [--ledgerLiveMode ] [--globalHelp] [--tokenAddress
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
 
 FLAGS
   -k, --privateKey=<value>
@@ -37,6 +38,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --tokenAddress=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       The address of the token that will be withdrawn. Defaults to cUSD

--- a/docs/command-line-interface/lockedgold.md
+++ b/docs/command-line-interface/lockedgold.md
@@ -23,7 +23,7 @@ USAGE
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --percent <value> [-k <value> |
     --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -45,6 +45,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --percent=<value>
       (required) 1-100% of locked celo to be delegated
@@ -83,7 +88,7 @@ USAGE
   $ celocli lockedgold:delegate-info --account 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -105,6 +110,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -137,7 +147,7 @@ USAGE
   $ celocli lockedgold:lock --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
     <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -159,6 +169,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -193,7 +208,7 @@ Returns the maximum number of delegates allowed per account.
 USAGE
   $ celocli lockedgold:max-delegatees-count [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -212,6 +227,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -245,7 +265,7 @@ USAGE
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --percent <value> [-k <value> |
     --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -267,6 +287,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --percent=<value>
       (required) 1-100% of locked celo to be revoked from currently delegated amount
@@ -302,11 +327,14 @@ Show Locked Gold information for a given account. This includes the total amount
 
 ```
 USAGE
-  $ celocli lockedgold:show ARG1 [-n <value>] [--globalHelp]
+  $ celocli lockedgold:show ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
-  -n, --node=<value>  URL of the node to run commands against or an alias
-      --globalHelp    View all available global flags
+  -n, --node=<value>    URL of the node to run commands against or an alias
+      --globalHelp      View all available global flags
+      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
+                        iterated over instead of the 5th. This is useful to use same
+                        address on you Ledger with celocli as you do on Ledger Live
 
 DESCRIPTION
   Show Locked Gold information for a given account. This includes the total amount of
@@ -340,7 +368,7 @@ USAGE
   $ celocli lockedgold:unlock --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value
     <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -362,6 +390,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -399,7 +432,7 @@ USAGE
   $ celocli lockedgold:update-delegated-amount --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -421,6 +454,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Account Address
@@ -458,7 +496,7 @@ USAGE
   $ celocli lockedgold:withdraw --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -480,6 +518,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet

--- a/docs/command-line-interface/lockedgold.md
+++ b/docs/command-line-interface/lockedgold.md
@@ -327,14 +327,11 @@ Show Locked Gold information for a given account. This includes the total amount
 
 ```
 USAGE
-  $ celocli lockedgold:show ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+  $ celocli lockedgold:show ARG1 [-n <value>] [--globalHelp]
 
 FLAGS
-  -n, --node=<value>    URL of the node to run commands against or an alias
-      --globalHelp      View all available global flags
-      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
-                        iterated over instead of the 5th. This is useful to use same
-                        address on you Ledger with celocli as you do on Ledger Live
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   Show Locked Gold information for a given account. This includes the total amount of

--- a/docs/command-line-interface/multisig.md
+++ b/docs/command-line-interface/multisig.md
@@ -78,18 +78,15 @@ Shows information about multi-sig contract
 
 ```
 USAGE
-  $ celocli multisig:show ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--tx <value>] [--all] [--raw]
+  $ celocli multisig:show ARG1 [-n <value>] [--globalHelp] [--tx <value>] [--all]
+    [--raw]
 
 FLAGS
-  -n, --node=<value>    URL of the node to run commands against or an alias
-      --all             Show info about all transactions
-      --globalHelp      View all available global flags
-      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
-                        iterated over instead of the 5th. This is useful to use same
-                        address on you Ledger with celocli as you do on Ledger Live
-      --raw             Do not attempt to parse transactions
-      --tx=<value>      Show info for a transaction
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --all           Show info about all transactions
+      --globalHelp    View all available global flags
+      --raw           Do not attempt to parse transactions
+      --tx=<value>    Show info for a transaction
 
 DESCRIPTION
   Shows information about multi-sig contract

--- a/docs/command-line-interface/multisig.md
+++ b/docs/command-line-interface/multisig.md
@@ -16,7 +16,7 @@ USAGE
   $ celocli multisig:approve --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --for
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --tx <value> [-k <value> | --useLedger |
     ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -41,6 +41,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --tx=<value>
       (required) Transaction to approve
@@ -73,15 +78,18 @@ Shows information about multi-sig contract
 
 ```
 USAGE
-  $ celocli multisig:show ARG1 [-n <value>] [--globalHelp] [--tx <value>] [--all]
-    [--raw]
+  $ celocli multisig:show ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--tx <value>] [--all] [--raw]
 
 FLAGS
-  -n, --node=<value>  URL of the node to run commands against or an alias
-      --all           Show info about all transactions
-      --globalHelp    View all available global flags
-      --raw           Do not attempt to parse transactions
-      --tx=<value>    Show info for a transaction
+  -n, --node=<value>    URL of the node to run commands against or an alias
+      --all             Show info about all transactions
+      --globalHelp      View all available global flags
+      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
+                        iterated over instead of the 5th. This is useful to use same
+                        address on you Ledger with celocli as you do on Ledger Live
+      --raw             Do not attempt to parse transactions
+      --tx=<value>      Show info for a transaction
 
 DESCRIPTION
   Shows information about multi-sig contract
@@ -116,7 +124,7 @@ USAGE
     --amount <value> --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> |
     --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--transferFrom] [--sender
+    [--ledgerLiveMode ] [--globalHelp] [--transferFrom] [--sender
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d]
 
 FLAGS
@@ -142,6 +150,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --sender=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       Identify sender if performing transferFrom

--- a/docs/command-line-interface/network.md
+++ b/docs/command-line-interface/network.md
@@ -14,9 +14,9 @@ Lists Celo core contracts and their addresses.
 
 ```
 USAGE
-  $ celocli network:contracts [-n <value>] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli network:contracts [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
+    [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
   -n, --node=<value>     URL of the node to run commands against or an alias
@@ -25,6 +25,9 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
+      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
+                         iterated over instead of the 5th. This is useful to use same
+                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format
@@ -53,12 +56,16 @@ View general network information such as the current block number
 
 ```
 USAGE
-  $ celocli network:info [-n <value>] [--globalHelp] [--lastN <value>]
+  $ celocli network:info [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--lastN
+    <value>]
 
 FLAGS
-  -n, --node=<value>   URL of the node to run commands against or an alias
-      --globalHelp     View all available global flags
-      --lastN=<value>  [default: 1] Fetch info about the last n epochs
+  -n, --node=<value>    URL of the node to run commands against or an alias
+      --globalHelp      View all available global flags
+      --lastN=<value>   [default: 1] Fetch info about the last n epochs
+      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
+                        iterated over instead of the 5th. This is useful to use same
+                        address on you Ledger with celocli as you do on Ledger Live
 
 DESCRIPTION
   View general network information such as the current block number
@@ -82,12 +89,15 @@ View parameters of the network, including but not limited to configuration for t
 
 ```
 USAGE
-  $ celocli network:parameters [-n <value>] [--globalHelp] [--raw]
+  $ celocli network:parameters [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
 
 FLAGS
-  -n, --node=<value>  URL of the node to run commands against or an alias
-      --globalHelp    View all available global flags
-      --raw           Display raw numerical configuration
+  -n, --node=<value>    URL of the node to run commands against or an alias
+      --globalHelp      View all available global flags
+      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
+                        iterated over instead of the 5th. This is useful to use same
+                        address on you Ledger with celocli as you do on Ledger Live
+      --raw             Display raw numerical configuration
 
 DESCRIPTION
   View parameters of the network, including but not limited to configuration for the
@@ -112,9 +122,9 @@ List the whitelisted fee currencies
 
 ```
 USAGE
-  $ celocli network:whitelist [-n <value>] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli network:whitelist [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
+    [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
   -n, --node=<value>     URL of the node to run commands against or an alias
@@ -123,6 +133,9 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
+      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
+                         iterated over instead of the 5th. This is useful to use same
+                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format

--- a/docs/command-line-interface/network.md
+++ b/docs/command-line-interface/network.md
@@ -14,9 +14,9 @@ Lists Celo core contracts and their addresses.
 
 ```
 USAGE
-  $ celocli network:contracts [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
-    [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli network:contracts [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 FLAGS
   -n, --node=<value>     URL of the node to run commands against or an alias
@@ -25,9 +25,6 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
-      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
-                         iterated over instead of the 5th. This is useful to use same
-                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format
@@ -56,16 +53,12 @@ View general network information such as the current block number
 
 ```
 USAGE
-  $ celocli network:info [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--lastN
-    <value>]
+  $ celocli network:info [-n <value>] [--globalHelp] [--lastN <value>]
 
 FLAGS
-  -n, --node=<value>    URL of the node to run commands against or an alias
-      --globalHelp      View all available global flags
-      --lastN=<value>   [default: 1] Fetch info about the last n epochs
-      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
-                        iterated over instead of the 5th. This is useful to use same
-                        address on you Ledger with celocli as you do on Ledger Live
+  -n, --node=<value>   URL of the node to run commands against or an alias
+      --globalHelp     View all available global flags
+      --lastN=<value>  [default: 1] Fetch info about the last n epochs
 
 DESCRIPTION
   View general network information such as the current block number
@@ -89,15 +82,12 @@ View parameters of the network, including but not limited to configuration for t
 
 ```
 USAGE
-  $ celocli network:parameters [-n <value>] [--ledgerLiveMode ] [--globalHelp] [--raw]
+  $ celocli network:parameters [-n <value>] [--globalHelp] [--raw]
 
 FLAGS
-  -n, --node=<value>    URL of the node to run commands against or an alias
-      --globalHelp      View all available global flags
-      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
-                        iterated over instead of the 5th. This is useful to use same
-                        address on you Ledger with celocli as you do on Ledger Live
-      --raw             Display raw numerical configuration
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
+      --raw           Display raw numerical configuration
 
 DESCRIPTION
   View parameters of the network, including but not limited to configuration for the
@@ -122,9 +112,9 @@ List the whitelisted fee currencies
 
 ```
 USAGE
-  $ celocli network:whitelist [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
-    [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli network:whitelist [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 FLAGS
   -n, --node=<value>     URL of the node to run commands against or an alias
@@ -133,9 +123,6 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
-      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
-                         iterated over instead of the 5th. This is useful to use same
-                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format

--- a/docs/command-line-interface/node.md
+++ b/docs/command-line-interface/node.md
@@ -14,7 +14,7 @@ List the addresses that this node has the private keys for.
 USAGE
   $ celocli node:accounts [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -33,6 +33,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -61,7 +66,7 @@ Check if the node is synced
 USAGE
   $ celocli node:synced [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--verbose]
+    [--ledgerLiveMode ] [--globalHelp] [--verbose]
 
 FLAGS
   -k, --privateKey=<value>
@@ -80,6 +85,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet

--- a/docs/command-line-interface/oracle.md
+++ b/docs/command-line-interface/oracle.md
@@ -14,17 +14,14 @@ List oracle addresses for a given token
 
 ```
 USAGE
-  $ celocli oracle:list ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+  $ celocli oracle:list ARG1 [-n <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to list the oracles for
 
 FLAGS
-  -n, --node=<value>    URL of the node to run commands against or an alias
-      --globalHelp      View all available global flags
-      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
-                        iterated over instead of the 5th. This is useful to use same
-                        address on you Ledger with celocli as you do on Ledger Live
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   List oracle addresses for a given token

--- a/docs/command-line-interface/oracle.md
+++ b/docs/command-line-interface/oracle.md
@@ -14,14 +14,17 @@ List oracle addresses for a given token
 
 ```
 USAGE
-  $ celocli oracle:list ARG1 [-n <value>] [--globalHelp]
+  $ celocli oracle:list ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to list the oracles for
 
 FLAGS
-  -n, --node=<value>  URL of the node to run commands against or an alias
-      --globalHelp    View all available global flags
+  -n, --node=<value>    URL of the node to run commands against or an alias
+      --globalHelp      View all available global flags
+      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
+                        iterated over instead of the 5th. This is useful to use same
+                        address on you Ledger with celocli as you do on Ledger Live
 
 DESCRIPTION
   List oracle addresses for a given token
@@ -55,7 +58,7 @@ USAGE
   $ celocli oracle:remove-expired-reports ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to remove expired reports for
@@ -80,6 +83,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -116,7 +124,7 @@ USAGE
   $ celocli oracle:report ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --value <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to report on
@@ -141,6 +149,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -179,8 +192,9 @@ List oracle reports for a given token
 USAGE
   $ celocli oracle:reports ARG1 [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp] [--columns <value> | -x] [--filter <value>] [--no-header |
-    [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+    <value> ] [--ledgerLiveMode ] [--globalHelp] [--columns <value> | -x] [--filter
+    <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ]
+    [--sort <value>]
 
 ARGUMENTS
   ARG1  [default: StableToken] Token to list the reports for
@@ -214,6 +228,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --no-header
       hide table header from output

--- a/docs/command-line-interface/releasecelo.md
+++ b/docs/command-line-interface/releasecelo.md
@@ -848,22 +848,16 @@ Show info on a ReleaseGold instance contract.
 ```
 USAGE
   $ celocli releasecelo:show --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-n
-    <value>] [--ledgerLiveMode ] [--globalHelp]
+    <value>] [--globalHelp]
 
 FLAGS
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-      (required) Address of the ReleaseGold Contract
-
-  --globalHelp
-      View all available global flags
-
-  --ledgerLiveMode
-      When set, the 4th postion of the derivation path will be iterated over instead of
-      the 5th. This is useful to use same address on you Ledger with celocli as you do on
-      Ledger Live
+  -n, --node=<value>                                         URL of the node to run
+                                                             commands against or an
+                                                             alias
+      --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
+                                                             ReleaseGold Contract
+      --globalHelp                                           View all available global
+                                                             flags
 
 DESCRIPTION
   Show info on a ReleaseGold instance contract.

--- a/docs/command-line-interface/releasecelo.md
+++ b/docs/command-line-interface/releasecelo.md
@@ -29,7 +29,8 @@ USAGE
     --role vote|validator|attestation --signer
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --signature 0x [-k <value> | --useLedger
     | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp] [--blsKey 0x --blsPop 0x]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp] [--blsKey 0x
+    --blsPop 0x]
 
 FLAGS
   -k, --privateKey=<value>
@@ -59,6 +60,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --role=<option>
       (required)
@@ -107,7 +113,7 @@ USAGE
   $ celocli releasecelo:create-account --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -129,6 +135,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -161,7 +172,7 @@ USAGE
   $ celocli releasecelo:locked-gold --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d -a
     lock|unlock|withdraw --value 10000000000000000000000 [-k <value> | --useLedger | ]
     [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp] [--yes]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp] [--yes]
 
 FLAGS
   -a, --action=<option>
@@ -187,6 +198,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -230,7 +246,7 @@ USAGE
   $ celocli releasecelo:refund-and-finalize --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -252,6 +268,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -285,7 +306,7 @@ USAGE
   $ celocli releasecelo:revoke --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--yesreally]
+    [--ledgerLiveMode ] [--globalHelp] [--yesreally]
 
 FLAGS
   -k, --privateKey=<value>
@@ -307,6 +328,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -345,8 +371,9 @@ USAGE
   $ celocli releasecelo:revoke-votes --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--group 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --allGroups]
-    [--votes <value> | --allVotes | ]
+    [--ledgerLiveMode ] [--globalHelp] [--group
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --allGroups] [--votes <value> |
+    --allVotes | ]
 
 FLAGS
   -k, --privateKey=<value>
@@ -377,6 +404,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -414,7 +446,7 @@ USAGE
   $ celocli releasecelo:set-account --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d -p
     name|dataEncryptionKey|metaURL -v <value> [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp]
+    <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -443,6 +475,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -480,7 +517,7 @@ USAGE
   $ celocli releasecelo:set-account-wallet-address --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --walletAddress 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger
     | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp] [--pop <value>]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp] [--pop <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -502,6 +539,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --pop=<value>
       ECDSA PoP for signer over contract's account
@@ -542,7 +584,7 @@ USAGE
     --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --beneficiary
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
     <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp] [--yesreally]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp] [--yesreally]
 
 FLAGS
   -k, --privateKey=<value>
@@ -570,6 +612,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -608,7 +655,7 @@ USAGE
   $ celocli releasecelo:set-can-expire --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --value true|false|True|False [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp] [--yesreally]
+    <value> ] [--ledgerLiveMode ] [--globalHelp] [--yesreally]
 
 FLAGS
   -k, --privateKey=<value>
@@ -630,6 +677,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -669,7 +721,7 @@ USAGE
   $ celocli releasecelo:set-liquidity-provision --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--yesreally]
+    [--ledgerLiveMode ] [--globalHelp] [--yesreally]
 
 FLAGS
   -k, --privateKey=<value>
@@ -691,6 +743,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -727,7 +784,7 @@ USAGE
   $ celocli releasecelo:set-max-distribution --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --distributionRatio <value> [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp] [--yesreally]
+    <value> ] [--ledgerLiveMode ] [--globalHelp] [--yesreally]
 
 FLAGS
   -k, --privateKey=<value>
@@ -753,6 +810,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -786,16 +848,22 @@ Show info on a ReleaseGold instance contract.
 ```
 USAGE
   $ celocli releasecelo:show --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-n
-    <value>] [--globalHelp]
+    <value>] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
-  -n, --node=<value>                                         URL of the node to run
-                                                             commands against or an
-                                                             alias
-      --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  (required) Address of the
-                                                             ReleaseGold Contract
-      --globalHelp                                           View all available global
-                                                             flags
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --contract=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the ReleaseGold Contract
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
 DESCRIPTION
   Show info on a ReleaseGold instance contract.
@@ -826,7 +894,7 @@ USAGE
     --to 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value 10000000000000000000000 [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -848,6 +916,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address of the recipient of Celo Dollars transfer
@@ -887,7 +960,7 @@ USAGE
   $ celocli releasecelo:withdraw --contract 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --value 10000000000000000000000 [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp]
+    <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -909,6 +982,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet

--- a/docs/command-line-interface/rewards.md
+++ b/docs/command-line-interface/rewards.md
@@ -11,67 +11,48 @@ Show rewards information about a voter, registered Validator, or Validator Group
 
 ```
 USAGE
-  $ celocli rewards:show [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--estimate] [--voter 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--validator
+  $ celocli rewards:show [-n <value>] [--globalHelp] [--estimate] [--voter
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--validator
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--group
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--slashing] [--epochs <value>]
     [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
     [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -n, --node=<value>
-      URL of the node to run commands against or an alias
-
-  -x, --extended
-      show extra columns
-
-  --columns=<value>
-      only show provided columns (comma-separated)
-
-  --csv
-      output is csv format [alias: --output=csv]
-
-  --epochs=<value>
-      [default: 1] Show results for the last N epochs
-
-  --estimate
-      Estimate voter rewards from current votes
-
-  --filter=<value>
-      filter property by partial string matching, ex: name=foo
-
-  --globalHelp
-      View all available global flags
-
-  --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-      Validator Group to show rewards for
-
-  --ledgerLiveMode
-      When set, the 4th postion of the derivation path will be iterated over instead of
-      the 5th. This is useful to use same address on you Ledger with celocli as you do on
-      Ledger Live
-
-  --no-header
-      hide table header from output
-
-  --no-truncate
-      do not truncate output to fit screen
-
-  --output=<option>
-      output in a more machine friendly format
-      <options: csv|json|yaml>
-
-  --slashing
-      Show rewards for slashing (will be removed in L2)
-
-  --sort=<value>
-      property to sort by (prepend '-' for descending)
-
-  --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-      Validator to show rewards for
-
-  --voter=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-      Voter to show rewards for
+  -n, --node=<value>                                          URL of the node to run
+                                                              commands against or an
+                                                              alias
+  -x, --extended                                              show extra columns
+      --columns=<value>                                       only show provided columns
+                                                              (comma-separated)
+      --csv                                                   output is csv format
+                                                              [alias: --output=csv]
+      --epochs=<value>                                        [default: 1] Show results
+                                                              for the last N epochs
+      --estimate                                              Estimate voter rewards
+                                                              from current votes
+      --filter=<value>                                        filter property by partial
+                                                              string matching, ex:
+                                                              name=foo
+      --globalHelp                                            View all available global
+                                                              flags
+      --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Validator Group to show
+                                                              rewards for
+      --no-header                                             hide table header from
+                                                              output
+      --no-truncate                                           do not truncate output to
+                                                              fit screen
+      --output=<option>                                       output in a more machine
+                                                              friendly format
+                                                              <options: csv|json|yaml>
+      --slashing                                              Show rewards for slashing
+                                                              (will be removed in L2)
+      --sort=<value>                                          property to sort by
+                                                              (prepend '-' for
+                                                              descending)
+      --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Validator to show rewards
+                                                              for
+      --voter=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Voter to show rewards for
 
 DESCRIPTION
   Show rewards information about a voter, registered Validator, or Validator Group

--- a/docs/command-line-interface/rewards.md
+++ b/docs/command-line-interface/rewards.md
@@ -11,48 +11,67 @@ Show rewards information about a voter, registered Validator, or Validator Group
 
 ```
 USAGE
-  $ celocli rewards:show [-n <value>] [--globalHelp] [--estimate] [--voter
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--validator
+  $ celocli rewards:show [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--estimate] [--voter 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--validator
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--group
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--slashing] [--epochs <value>]
     [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
     [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
-  -n, --node=<value>                                          URL of the node to run
-                                                              commands against or an
-                                                              alias
-  -x, --extended                                              show extra columns
-      --columns=<value>                                       only show provided columns
-                                                              (comma-separated)
-      --csv                                                   output is csv format
-                                                              [alias: --output=csv]
-      --epochs=<value>                                        [default: 1] Show results
-                                                              for the last N epochs
-      --estimate                                              Estimate voter rewards
-                                                              from current votes
-      --filter=<value>                                        filter property by partial
-                                                              string matching, ex:
-                                                              name=foo
-      --globalHelp                                            View all available global
-                                                              flags
-      --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Validator Group to show
-                                                              rewards for
-      --no-header                                             hide table header from
-                                                              output
-      --no-truncate                                           do not truncate output to
-                                                              fit screen
-      --output=<option>                                       output in a more machine
-                                                              friendly format
-                                                              <options: csv|json|yaml>
-      --slashing                                              Show rewards for slashing
-                                                              (will be removed in L2)
-      --sort=<value>                                          property to sort by
-                                                              (prepend '-' for
-                                                              descending)
-      --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d  Validator to show rewards
-                                                              for
-      --voter=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d      Voter to show rewards for
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  -x, --extended
+      show extra columns
+
+  --columns=<value>
+      only show provided columns (comma-separated)
+
+  --csv
+      output is csv format [alias: --output=csv]
+
+  --epochs=<value>
+      [default: 1] Show results for the last N epochs
+
+  --estimate
+      Estimate voter rewards from current votes
+
+  --filter=<value>
+      filter property by partial string matching, ex: name=foo
+
+  --globalHelp
+      View all available global flags
+
+  --group=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Validator Group to show rewards for
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
+
+  --no-header
+      hide table header from output
+
+  --no-truncate
+      do not truncate output to fit screen
+
+  --output=<option>
+      output in a more machine friendly format
+      <options: csv|json|yaml>
+
+  --slashing
+      Show rewards for slashing (will be removed in L2)
+
+  --sort=<value>
+      property to sort by (prepend '-' for descending)
+
+  --validator=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Validator to show rewards for
+
+  --voter=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Voter to show rewards for
 
 DESCRIPTION
   Show rewards information about a voter, registered Validator, or Validator Group

--- a/docs/command-line-interface/transfer.md
+++ b/docs/command-line-interface/transfer.md
@@ -19,7 +19,7 @@ USAGE
   $ celocli transfer:celo --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
     | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp] [--comment <value>]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp] [--comment <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -44,6 +44,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address of the receiver
@@ -83,7 +88,7 @@ USAGE
   $ celocli transfer:dollars --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
     | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp] [--comment <value>]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp] [--comment <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -108,6 +113,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address of the receiver
@@ -147,7 +157,7 @@ USAGE
     --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
     | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -172,6 +182,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address of the receiver
@@ -210,7 +225,7 @@ USAGE
   $ celocli transfer:euros --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
     | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp] [--comment <value>]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp] [--comment <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -235,6 +250,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address of the receiver
@@ -273,7 +293,7 @@ USAGE
   $ celocli transfer:reals --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
     | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp] [--comment <value>]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp] [--comment <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -298,6 +318,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Address of the receiver
@@ -336,8 +361,8 @@ USAGE
   $ celocli transfer:stable --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --to
     0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --value <value> [-k <value> | --useLedger
     | ] [-n <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
-    [--ledgerAddresses <value> ] [--globalHelp] [--comment <value>] [--stableToken
-    cUSD|cusd|cEUR|ceur|cREAL|creal]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp] [--comment <value>]
+    [--stableToken cUSD|cusd|cEUR|ceur|cREAL|creal]
 
 FLAGS
   -k, --privateKey=<value>
@@ -362,6 +387,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --stableToken=<option>
       Name of the stable to be transferred

--- a/docs/command-line-interface/validator.md
+++ b/docs/command-line-interface/validator.md
@@ -25,7 +25,7 @@ USAGE
   $ celocli validator:affiliate ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--yes]
+    [--ledgerLiveMode ] [--globalHelp] [--yes]
 
 ARGUMENTS
   ARG1  ValidatorGroup's address
@@ -50,6 +50,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -88,7 +93,7 @@ USAGE
   $ celocli validator:deaffiliate --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -110,6 +115,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -143,7 +153,7 @@ USAGE
   $ celocli validator:deregister --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -165,6 +175,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -201,8 +216,9 @@ USAGE
   $ celocli validator:downtime-slash --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--validator 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d |
-    --validators '["0xb7ef0985bdb4f19460A29d9829aA1514B181C4CD",
+    [--ledgerLiveMode ] [--globalHelp] [--validator
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --validators
+    '["0xb7ef0985bdb4f19460A29d9829aA1514B181C4CD",
     "0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95"]'] [--intervals '[0:1], [1:2]' |
     --beforeBlock <value>]
 
@@ -232,6 +248,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -270,9 +291,9 @@ List registered Validators, their name (if provided), affiliation, uptime score,
 
 ```
 USAGE
-  $ celocli validator:list [-n <value>] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli validator:list [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
+    [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
   -n, --node=<value>     URL of the node to run commands against or an alias
@@ -281,6 +302,9 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
+      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
+                         iterated over instead of the 5th. This is useful to use same
+                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format
@@ -316,7 +340,7 @@ USAGE
   $ celocli validator:register --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --ecdsaKey 0x [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--blsKey 0x] [--blsSignature 0x] [--yes]
+    [--ledgerLiveMode ] [--globalHelp] [--blsKey 0x] [--blsSignature 0x] [--yes]
 
 FLAGS
   -k, --privateKey=<value>
@@ -347,6 +371,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -381,7 +410,7 @@ List the Locked Gold requirements for registering a Validator. This consists of 
 USAGE
   $ celocli validator:requirements [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -400,6 +429,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -435,8 +469,8 @@ USAGE
   $ celocli validator:set-bitmaps --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--slashableDowntimeBeforeBlock <value> | --intervals '[0:1], [1:2]'
-    | --slashableDowntimeBeforeLatest]
+    [--ledgerLiveMode ] [--globalHelp] [--slashableDowntimeBeforeBlock <value> |
+    --intervals '[0:1], [1:2]' | --slashableDowntimeBeforeLatest]
 
 FLAGS
   -k, --privateKey=<value>
@@ -461,6 +495,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --slashableDowntimeBeforeBlock=<value>
       Set all bitmaps for slashable downtime window before provided block
@@ -498,14 +537,17 @@ Show information about a registered Validator.
 
 ```
 USAGE
-  $ celocli validator:show ARG1 [-n <value>] [--globalHelp]
+  $ celocli validator:show ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  Validator's address
 
 FLAGS
-  -n, --node=<value>  URL of the node to run commands against or an alias
-      --globalHelp    View all available global flags
+  -n, --node=<value>    URL of the node to run commands against or an alias
+      --globalHelp      View all available global flags
+      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
+                        iterated over instead of the 5th. This is useful to use same
+                        address on you Ledger with celocli as you do on Ledger Live
 
 DESCRIPTION
   Show information about a registered Validator.
@@ -534,7 +576,8 @@ Display a graph of blocks and whether the given signer's signature is included i
 USAGE
   $ celocli validator:signed-blocks [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--signer 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --signers
+    [--ledgerLiveMode ] [--globalHelp] [--signer
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --signers
     '["0xb7ef0985bdb4f19460A29d9829aA1514B181C4CD",
     "0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95"]'] [--wasDownWhileElected] [--at-block
     <value> | ] [--slashableDowntimeLookback | [--lookback <value> | ]] [--width
@@ -560,6 +603,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --lookback=<value>
       [default: 120] how many blocks to look back for signer activity
@@ -621,10 +669,11 @@ Shows the consensus status of a validator. This command will show whether a vali
 USAGE
   $ celocli validator:status [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--validator 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --all |
-    --signer 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--start <value>] [--end
-    <value>] [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+    [--ledgerLiveMode ] [--globalHelp] [--validator
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d | --all | --signer
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d] [--start <value>] [--end <value>]
+    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
+    [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -662,6 +711,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --no-header
       hide table header from output
@@ -724,7 +778,7 @@ USAGE
   $ celocli validator:update-bls-public-key --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --blsKey 0x --blsPop 0x [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -752,6 +806,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet

--- a/docs/command-line-interface/validator.md
+++ b/docs/command-line-interface/validator.md
@@ -291,9 +291,9 @@ List registered Validators, their name (if provided), affiliation, uptime score,
 
 ```
 USAGE
-  $ celocli validator:list [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
-    [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli validator:list [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 FLAGS
   -n, --node=<value>     URL of the node to run commands against or an alias
@@ -302,9 +302,6 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
-      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
-                         iterated over instead of the 5th. This is useful to use same
-                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format
@@ -537,17 +534,14 @@ Show information about a registered Validator.
 
 ```
 USAGE
-  $ celocli validator:show ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+  $ celocli validator:show ARG1 [-n <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  Validator's address
 
 FLAGS
-  -n, --node=<value>    URL of the node to run commands against or an alias
-      --globalHelp      View all available global flags
-      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
-                        iterated over instead of the 5th. This is useful to use same
-                        address on you Ledger with celocli as you do on Ledger Live
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   Show information about a registered Validator.

--- a/docs/command-line-interface/validatorgroup.md
+++ b/docs/command-line-interface/validatorgroup.md
@@ -151,9 +151,9 @@ List registered Validator Groups, their names (if provided), commission, and mem
 
 ```
 USAGE
-  $ celocli validatorgroup:list [-n <value>] [--ledgerLiveMode ] [--globalHelp]
-    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
-    [--output csv|json|yaml |  | ] [--sort <value>]
+  $ celocli validatorgroup:list [-n <value>] [--globalHelp] [--columns <value> | -x]
+    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
+    | ] [--sort <value>]
 
 FLAGS
   -n, --node=<value>     URL of the node to run commands against or an alias
@@ -162,9 +162,6 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
-      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
-                         iterated over instead of the 5th. This is useful to use same
-                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format
@@ -398,17 +395,14 @@ Show information about an existing Validator Group
 
 ```
 USAGE
-  $ celocli validatorgroup:show ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+  $ celocli validatorgroup:show ARG1 [-n <value>] [--globalHelp]
 
 ARGUMENTS
   ARG1  ValidatorGroup's address
 
 FLAGS
-  -n, --node=<value>    URL of the node to run commands against or an alias
-      --globalHelp      View all available global flags
-      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
-                        iterated over instead of the 5th. This is useful to use same
-                        address on you Ledger with celocli as you do on Ledger Live
+  -n, --node=<value>  URL of the node to run commands against or an alias
+      --globalHelp    View all available global flags
 
 DESCRIPTION
   Show information about an existing Validator Group

--- a/docs/command-line-interface/validatorgroup.md
+++ b/docs/command-line-interface/validatorgroup.md
@@ -20,7 +20,7 @@ USAGE
   $ celocli validatorgroup:commission --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--apply | --queue-update <value>]
+    [--ledgerLiveMode ] [--globalHelp] [--apply | --queue-update <value>]
 
 FLAGS
   -k, --privateKey=<value>
@@ -45,6 +45,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --queue-update=<value>
       Queues an update to the commission, which can be applied after the update delay.
@@ -87,7 +92,7 @@ USAGE
   $ celocli validatorgroup:deregister --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp]
 
 FLAGS
   -k, --privateKey=<value>
@@ -109,6 +114,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -141,9 +151,9 @@ List registered Validator Groups, their names (if provided), commission, and mem
 
 ```
 USAGE
-  $ celocli validatorgroup:list [-n <value>] [--globalHelp] [--columns <value> | -x]
-    [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |
-    | ] [--sort <value>]
+  $ celocli validatorgroup:list [-n <value>] [--ledgerLiveMode ] [--globalHelp]
+    [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]]
+    [--output csv|json|yaml |  | ] [--sort <value>]
 
 FLAGS
   -n, --node=<value>     URL of the node to run commands against or an alias
@@ -152,6 +162,9 @@ FLAGS
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --globalHelp       View all available global flags
+      --ledgerLiveMode   When set, the 4th postion of the derivation path will be
+                         iterated over instead of the 5th. This is useful to use same
+                         address on you Ledger with celocli as you do on Ledger Live
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
       --output=<option>  output in a more machine friendly format
@@ -186,7 +199,7 @@ USAGE
   $ celocli validatorgroup:member ARG1 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--yes] [--accept | --remove | --reorder <value>]
+    [--ledgerLiveMode ] [--globalHelp] [--yes] [--accept | --remove | --reorder <value>]
 
 ARGUMENTS
   ARG1  Validator's address
@@ -214,6 +227,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --remove
       Remove a validator from the members list
@@ -259,7 +277,7 @@ USAGE
   $ celocli validatorgroup:register --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     --commission <value> [-k <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--globalHelp] [--yes]
+    [--ledgerLiveMode ] [--globalHelp] [--yes]
 
 FLAGS
   -k, --privateKey=<value>
@@ -285,6 +303,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -319,7 +342,7 @@ Reset validator group slashing multiplier.
 USAGE
   $ celocli validatorgroup:reset-slashing-multiplier ARG1 [-k <value> | --useLedger | ] [-n <value>]
     [--gasCurrency 0x1234567890123456789012345678901234567890] [--ledgerAddresses
-    <value> ] [--globalHelp]
+    <value> ] [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  ValidatorGroup's address
@@ -341,6 +364,11 @@ FLAGS
   --ledgerAddresses=<value>
       [default: 1] If --useLedger is set, this will get the first N addresses for local
       signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
 
   --useLedger
       Set it to use a ledger wallet
@@ -370,14 +398,17 @@ Show information about an existing Validator Group
 
 ```
 USAGE
-  $ celocli validatorgroup:show ARG1 [-n <value>] [--globalHelp]
+  $ celocli validatorgroup:show ARG1 [-n <value>] [--ledgerLiveMode ] [--globalHelp]
 
 ARGUMENTS
   ARG1  ValidatorGroup's address
 
 FLAGS
-  -n, --node=<value>  URL of the node to run commands against or an alias
-      --globalHelp    View all available global flags
+  -n, --node=<value>    URL of the node to run commands against or an alias
+      --globalHelp      View all available global flags
+      --ledgerLiveMode  When set, the 4th postion of the derivation path will be
+                        iterated over instead of the 5th. This is useful to use same
+                        address on you Ledger with celocli as you do on Ledger Live
 
 DESCRIPTION
   Show information about an existing Validator Group

--- a/docs/sdk/base/enums/account.DerivationPathAliases.md
+++ b/docs/sdk/base/enums/account.DerivationPathAliases.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:7](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L7)
+[packages/sdk/base/src/account.ts:9](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L9)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:6](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L6)
+[packages/sdk/base/src/account.ts:8](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L8)

--- a/docs/sdk/base/enums/account.MnemonicLanguages.md
+++ b/docs/sdk/base/enums/account.MnemonicLanguages.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:16](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L16)
+[packages/sdk/base/src/account.ts:18](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L18)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:17](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L17)
+[packages/sdk/base/src/account.ts:19](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L19)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:18](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L18)
+[packages/sdk/base/src/account.ts:20](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L20)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:19](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L19)
+[packages/sdk/base/src/account.ts:21](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L21)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:20](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L20)
+[packages/sdk/base/src/account.ts:22](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L22)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:21](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L21)
+[packages/sdk/base/src/account.ts:23](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L23)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:22](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L22)
+[packages/sdk/base/src/account.ts:24](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L24)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:24](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L24)
+[packages/sdk/base/src/account.ts:26](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L26)
 
 ___
 
@@ -106,4 +106,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:23](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L23)
+[packages/sdk/base/src/account.ts:25](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L25)

--- a/docs/sdk/base/enums/account.MnemonicStrength.md
+++ b/docs/sdk/base/enums/account.MnemonicStrength.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:11](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L11)
+[packages/sdk/base/src/account.ts:13](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L13)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:12](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L12)
+[packages/sdk/base/src/account.ts:14](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L14)

--- a/docs/sdk/base/interfaces/account.Bip39.md
+++ b/docs/sdk/base/interfaces/account.Bip39.md
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:35](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L35)
+[packages/sdk/base/src/account.ts:37](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L37)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:34](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L34)
+[packages/sdk/base/src/account.ts:36](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L36)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:33](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L33)
+[packages/sdk/base/src/account.ts:35](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L35)
 
 ___
 
@@ -112,4 +112,4 @@ ___
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:40](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L40)
+[packages/sdk/base/src/account.ts:42](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L42)

--- a/docs/sdk/base/modules/account.md
+++ b/docs/sdk/base/modules/account.md
@@ -16,6 +16,7 @@
 
 ### Type Aliases
 
+- [DerivationPath](account.md#derivationpath)
 - [RandomNumberGenerator](account.md#randomnumbergenerator)
 
 ### Variables
@@ -24,6 +25,16 @@
 - [ETHEREUM\_DERIVATION\_PATH](account.md#ethereum_derivation_path)
 
 ## Type Aliases
+
+### DerivationPath
+
+Ƭ **DerivationPath**: \`m/44'/$\{string}'/$\{string}\`
+
+#### Defined in
+
+[packages/sdk/base/src/account.ts:5](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L5)
+
+___
 
 ### RandomNumberGenerator
 
@@ -46,7 +57,7 @@
 
 #### Defined in
 
-[packages/sdk/base/src/account.ts:27](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L27)
+[packages/sdk/base/src/account.ts:29](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/base/src/account.ts#L29)
 
 ## Variables
 

--- a/docs/sdk/base/modules/index.md
+++ b/docs/sdk/base/modules/index.md
@@ -14,6 +14,7 @@
 - [CELO\_DERIVATION\_PATH\_BASE](index.md#celo_derivation_path_base)
 - [CeloTokenType](index.md#celotokentype)
 - [Comparator](index.md#comparator)
+- [DerivationPath](index.md#derivationpath)
 - [DerivationPathAliases](index.md#derivationpathaliases)
 - [ETHEREUM\_DERIVATION\_PATH](index.md#ethereum_derivation_path)
 - [Err](index.md#err)
@@ -147,6 +148,12 @@ ___
 ### Comparator
 
 Re-exports [Comparator](collections.md#comparator)
+
+___
+
+### DerivationPath
+
+Re-exports [DerivationPath](account.md#derivationpath)
 
 ___
 

--- a/docs/sdk/cryptographic-utils/enums/account.MnemonicLanguages.md
+++ b/docs/sdk/cryptographic-utils/enums/account.MnemonicLanguages.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-base/lib/account.d.ts:13
+base/lib/account.d.ts:14
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-base/lib/account.d.ts:14
+base/lib/account.d.ts:15
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-base/lib/account.d.ts:15
+base/lib/account.d.ts:16
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-base/lib/account.d.ts:16
+base/lib/account.d.ts:17
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-base/lib/account.d.ts:17
+base/lib/account.d.ts:18
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-base/lib/account.d.ts:18
+base/lib/account.d.ts:19
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-base/lib/account.d.ts:19
+base/lib/account.d.ts:20
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-base/lib/account.d.ts:21
+base/lib/account.d.ts:22
 
 ___
 
@@ -106,4 +106,4 @@ ___
 
 #### Defined in
 
-base/lib/account.d.ts:20
+base/lib/account.d.ts:21

--- a/docs/sdk/cryptographic-utils/enums/account.MnemonicStrength.md
+++ b/docs/sdk/cryptographic-utils/enums/account.MnemonicStrength.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-base/lib/account.d.ts:9
+base/lib/account.d.ts:10
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-base/lib/account.d.ts:10
+base/lib/account.d.ts:11

--- a/docs/sdk/cryptographic-utils/interfaces/account.Bip39.md
+++ b/docs/sdk/cryptographic-utils/interfaces/account.Bip39.md
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-base/lib/account.d.ts:27
+base/lib/account.d.ts:28
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-base/lib/account.d.ts:26
+base/lib/account.d.ts:27
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-base/lib/account.d.ts:25
+base/lib/account.d.ts:26
 
 ___
 
@@ -112,4 +112,4 @@ ___
 
 #### Defined in
 
-base/lib/account.d.ts:28
+base/lib/account.d.ts:29

--- a/docs/sdk/cryptographic-utils/modules/account.md
+++ b/docs/sdk/cryptographic-utils/modules/account.md
@@ -62,7 +62,7 @@
 
 #### Defined in
 
-base/lib/account.d.ts:23
+base/lib/account.d.ts:24
 
 ## Variables
 

--- a/docs/sdk/wallet-ledger/classes/ledger_wallet.LedgerWallet.md
+++ b/docs/sdk/wallet-ledger/classes/ledger_wallet.LedgerWallet.md
@@ -23,6 +23,7 @@
 ### Properties
 
 - [baseDerivationPath](ledger_wallet.LedgerWallet.md#basederivationpath)
+- [changeIndexes](ledger_wallet.LedgerWallet.md#changeindexes)
 - [derivationPathIndexes](ledger_wallet.LedgerWallet.md#derivationpathindexes)
 - [isCel2](ledger_wallet.LedgerWallet.md#iscel2)
 - [isSetupFinished](ledger_wallet.LedgerWallet.md#issetupfinished)
@@ -50,16 +51,17 @@
 
 ### constructor
 
-• **new LedgerWallet**(`derivationPathIndexes?`, `baseDerivationPath?`, `transport?`, `ledgerAddressValidation?`, `isCel2?`): [`LedgerWallet`](ledger_wallet.LedgerWallet.md)
+• **new LedgerWallet**(`transport?`, `derivationPathIndexes?`, `baseDerivationPath?`, `changeIndexes?`, `ledgerAddressValidation?`, `isCel2?`): [`LedgerWallet`](ledger_wallet.LedgerWallet.md)
 
 #### Parameters
 
 | Name | Type | Default value | Description |
 | :------ | :------ | :------ | :------ |
-| `derivationPathIndexes` | `number`[] | `undefined` | number array of "address_index" for the base derivation path. Default: Array[0..9]. Example: [3, 99, 53] will retrieve the derivation paths of [`${baseDerivationPath}/3`, `${baseDerivationPath}/99`, `${baseDerivationPath}/53`] |
-| `baseDerivationPath` | `string` | `CELO_BASE_DERIVATION_PATH` | base derivation path. Default: "44'/52752'/0'/0" |
 | `transport` | `any` | `{}` | Transport to connect the ledger device |
-| `ledgerAddressValidation` | [`AddressValidation`](../enums/ledger_wallet.AddressValidation.md) | `AddressValidation.firstTransactionPerAddress` | - |
+| `derivationPathIndexes` | `number`[] | `undefined` | number array of "address_index" for the base derivation path. Default: Array[0..5]. Example: [3, 99, 53] will retrieve the derivation paths of [`${baseDerivationPath}/0/3`, `${baseDerivationPath}/0/99`, `${baseDerivationPath}/0/53`] |
+| `baseDerivationPath` | `string` | `CELO_BASE_DERIVATION_PATH` | base derivation path. Default: "44'/52752'/0'" |
+| `changeIndexes` | `number`[] | `undefined` | number array of "change" for the base derivation path. Default: [0]. Example: [0, 1] will retrieve the derivation paths of [`${baseDerivationPath}/0/${address_index}`, `${baseDerivationPath}/1/${address_index}`, `${baseDerivationPath}/2/${address_index}`] |
+| `ledgerAddressValidation` | [`AddressValidation`](../enums/ledger_wallet.AddressValidation.md) | `AddressValidation.firstTransactionPerAddress` | AddressValidation enum to validate addresses. Default: AddressValidation.firstTransactionPerAddress |
 | `isCel2?` | `boolean` | `undefined` | - |
 
 #### Returns
@@ -72,7 +74,7 @@ RemoteWallet\&lt;LedgerSigner\&gt;.constructor
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:69](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L69)
+[wallet-ledger/src/ledger-wallet.ts:88](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L88)
 
 ## Properties
 
@@ -80,11 +82,25 @@ RemoteWallet\&lt;LedgerSigner\&gt;.constructor
 
 • `Readonly` **baseDerivationPath**: `string` = `CELO_BASE_DERIVATION_PATH`
 
-base derivation path. Default: "44'/52752'/0'/0"
+base derivation path. Default: "44'/52752'/0'"
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:71](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L71)
+[wallet-ledger/src/ledger-wallet.ts:91](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L91)
+
+___
+
+### changeIndexes
+
+• `Readonly` **changeIndexes**: `number`[]
+
+number array of "change" for the base derivation path.
+Default: [0].
+Example: [0, 1] will retrieve the derivation paths of [`${baseDerivationPath}/0/${address_index}`, `${baseDerivationPath}/1/${address_index}`, `${baseDerivationPath}/2/${address_index}`]
+
+#### Defined in
+
+[wallet-ledger/src/ledger-wallet.ts:92](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L92)
 
 ___
 
@@ -93,13 +109,13 @@ ___
 • `Readonly` **derivationPathIndexes**: `number`[]
 
 number array of "address_index" for the base derivation path.
-Default: Array[0..9].
+Default: Array[0..5].
 Example: [3, 99, 53] will retrieve the derivation paths of
-[`${baseDerivationPath}/3`, `${baseDerivationPath}/99`, `${baseDerivationPath}/53`]
+[`${baseDerivationPath}/0/3`, `${baseDerivationPath}/0/99`, `${baseDerivationPath}/0/53`]
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:70](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L70)
+[wallet-ledger/src/ledger-wallet.ts:90](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L90)
 
 ___
 
@@ -109,7 +125,7 @@ ___
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:74](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L74)
+[wallet-ledger/src/ledger-wallet.ts:94](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L94)
 
 ___
 
@@ -141,7 +157,7 @@ ___
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:59](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L59)
+[wallet-ledger/src/ledger-wallet.ts:74](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L74)
 
 ___
 
@@ -149,9 +165,11 @@ ___
 
 • `Readonly` **ledgerAddressValidation**: [`AddressValidation`](../enums/ledger_wallet.AddressValidation.md) = `AddressValidation.firstTransactionPerAddress`
 
+AddressValidation enum to validate addresses. Default: AddressValidation.firstTransactionPerAddress
+
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:73](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L73)
+[wallet-ledger/src/ledger-wallet.ts:93](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L93)
 
 ___
 
@@ -163,7 +181,7 @@ Transport to connect the ledger device
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:72](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L72)
+[wallet-ledger/src/ledger-wallet.ts:89](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L89)
 
 ___
 
@@ -173,7 +191,7 @@ ___
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:58](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L58)
+[wallet-ledger/src/ledger-wallet.ts:73](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L73)
 
 ___
 
@@ -183,7 +201,7 @@ ___
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:56](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L56)
+[wallet-ledger/src/ledger-wallet.ts:71](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L71)
 
 ___
 
@@ -193,7 +211,7 @@ ___
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:57](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L57)
+[wallet-ledger/src/ledger-wallet.ts:72](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L72)
 
 ## Methods
 
@@ -378,7 +396,7 @@ ___
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:98](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L98)
+[wallet-ledger/src/ledger-wallet.ts:119](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L119)
 
 ___
 
@@ -437,7 +455,7 @@ RemoteWallet.signTransaction
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:85](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L85)
+[wallet-ledger/src/ledger-wallet.ts:106](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L106)
 
 ___
 

--- a/docs/sdk/wallet-ledger/enums/ledger_wallet.AddressValidation.md
+++ b/docs/sdk/wallet-ledger/enums/ledger_wallet.AddressValidation.md
@@ -21,7 +21,7 @@
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:28](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L28)
+[wallet-ledger/src/ledger-wallet.ts:31](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L31)
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:30](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L30)
+[wallet-ledger/src/ledger-wallet.ts:33](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L33)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:26](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L26)
+[wallet-ledger/src/ledger-wallet.ts:29](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L29)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:32](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L32)
+[wallet-ledger/src/ledger-wallet.ts:35](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L35)

--- a/docs/sdk/wallet-ledger/modules/ledger_wallet.md
+++ b/docs/sdk/wallet-ledger/modules/ledger_wallet.md
@@ -28,23 +28,20 @@
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:20](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L20)
+[wallet-ledger/src/ledger-wallet.ts:23](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L23)
 
 ## Functions
 
 ### newLedgerWalletWithSetup
 
-▸ **newLedgerWalletWithSetup**(`transport`, `derivationPathIndexes?`, `baseDerivationPath?`, `ledgerAddressValidation?`, `isCel2?`): `Promise`\<[`LedgerWallet`](../classes/ledger_wallet.LedgerWallet.md)\>
+▸ **newLedgerWalletWithSetup**(`transport`, `«destructured»`): `Promise`\<[`LedgerWallet`](../classes/ledger_wallet.LedgerWallet.md)\>
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `transport` | `any` |
-| `derivationPathIndexes?` | `number`[] |
-| `baseDerivationPath?` | `string` |
-| `ledgerAddressValidation?` | [`AddressValidation`](../enums/ledger_wallet.AddressValidation.md) |
-| `isCel2?` | `boolean` |
+| `«destructured»` | `LedgerWalletSetup` |
 
 #### Returns
 
@@ -52,4 +49,4 @@
 
 #### Defined in
 
-[wallet-ledger/src/ledger-wallet.ts:35](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L35)
+[wallet-ledger/src/ledger-wallet.ts:46](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts#L46)

--- a/packages/cli/src/base-l2.test.ts
+++ b/packages/cli/src/base-l2.test.ts
@@ -1,9 +1,9 @@
-import { ETHEREUM_DERIVATION_PATH } from '@celo/base'
 import { Connection } from '@celo/connect'
 import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import * as WalletLedgerExports from '@celo/wallet-ledger'
 import { Config, ux } from '@oclif/core'
 import { tmpdir } from 'os'
+import { join } from 'path'
 import Web3 from 'web3'
 import { BaseCommand } from './base'
 import Set from './commands/config/set'
@@ -75,9 +75,20 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
   })
 
   describe('with --useLedger', () => {
+    // prevent setting to affect other tests
     describe('derivationPath tests', () => {
+      let originalConfigDir: string
+      beforeEach(() => {
+        originalConfigDir = Set.prototype.config.configDir
+        Set.prototype.config.configDir = join(tmpdir(), 'test_only')
+      })
+      afterEach(() => {
+        Set.prototype.config.configDir = originalConfigDir
+      })
       it('uses default derivationPath from config', async () => {
         const storedDerivationPath = readConfig(tmpdir()).derivationPath
+        console.log('storedDerivationPath', storedDerivationPath)
+        expect(storedDerivationPath).not.toBe(undefined)
         await testLocallyWithWeb3Node(BasicCommand, ['--useLedger'], web3)
         expect(WalletLedgerExports.newLedgerWalletWithSetup).toHaveBeenCalledWith(
           expect.anything(),
@@ -87,7 +98,7 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
         )
       })
       it('uses custom derivationPath', async () => {
-        const customPath = ETHEREUM_DERIVATION_PATH
+        const customPath = "m/44'/9000'/0'/0/0 "
         await testLocallyWithWeb3Node(Set, ['--derivationPath', customPath], web3)
         await testLocallyWithWeb3Node(BasicCommand, ['--useLedger'], web3)
         expect(WalletLedgerExports.newLedgerWalletWithSetup).toHaveBeenCalledWith(

--- a/packages/cli/src/base-l2.test.ts
+++ b/packages/cli/src/base-l2.test.ts
@@ -3,7 +3,6 @@ import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import * as WalletLedgerExports from '@celo/wallet-ledger'
 import { Config, ux } from '@oclif/core'
 import { tmpdir } from 'os'
-import { join } from 'path'
 import Web3 from 'web3'
 import { BaseCommand } from './base'
 import Set from './commands/config/set'
@@ -75,19 +74,10 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
   })
 
   describe('with --useLedger', () => {
-    // prevent setting to affect other tests
     describe('derivationPath tests', () => {
-      let originalConfigDir: string
-      beforeEach(() => {
-        originalConfigDir = Set.prototype.config.configDir
-        Set.prototype.config.configDir = join(tmpdir(), 'test_only')
-      })
-      afterEach(() => {
-        Set.prototype.config.configDir = originalConfigDir
-      })
       it('uses default derivationPath from config', async () => {
         const storedDerivationPath = readConfig(tmpdir()).derivationPath
-        console.log('storedDerivationPath', storedDerivationPath)
+        console.info('storedDerivationPath', storedDerivationPath)
         expect(storedDerivationPath).not.toBe(undefined)
         await testLocallyWithWeb3Node(BasicCommand, ['--useLedger'], web3)
         expect(WalletLedgerExports.newLedgerWalletWithSetup).toHaveBeenCalledWith(
@@ -98,7 +88,8 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
         )
       })
       it('uses custom derivationPath', async () => {
-        const customPath = "m/44'/9000'/0'/0/0 "
+        const storedDerivationPath = readConfig(tmpdir()).derivationPath
+        const customPath = "m/44'/9000'/0'"
         await testLocallyWithWeb3Node(Set, ['--derivationPath', customPath], web3)
         await testLocallyWithWeb3Node(BasicCommand, ['--useLedger'], web3)
         expect(WalletLedgerExports.newLedgerWalletWithSetup).toHaveBeenCalledWith(
@@ -107,6 +98,7 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
             baseDerivationPath: customPath,
           })
         )
+        await testLocallyWithWeb3Node(Set, ['--derivationPath', storedDerivationPath], web3)
       })
     })
 

--- a/packages/cli/src/base-l2.test.ts
+++ b/packages/cli/src/base-l2.test.ts
@@ -1,22 +1,39 @@
+import { ETHEREUM_DERIVATION_PATH } from '@celo/base'
 import { Connection } from '@celo/connect'
 import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import * as WalletLedgerExports from '@celo/wallet-ledger'
 import { Config, ux } from '@oclif/core'
+import { tmpdir } from 'os'
 import Web3 from 'web3'
 import { BaseCommand } from './base'
+import Set from './commands/config/set'
 import CustomHelp from './help'
 import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from './test-utils/cliUtils'
+import { readConfig } from './utils/config'
 
 process.env.NO_SYNCCHECK = 'true'
 
+jest.mock('@ledgerhq/hw-transport-node-hid')
+
+jest.mock('@celo/wallet-ledger', () => {
+  const originalModule = jest.requireActual('@celo/wallet-ledger')
+  originalModule.LedgerWallet.prototype.signTransaction = jest.fn()
+  return {
+    __esModule: true,
+    ...originalModule,
+    newLedgerWalletWithSetup: jest.fn(),
+  }
+})
+class BasicCommand extends BaseCommand {
+  async run() {
+    // just parsing flags nothing to see
+  }
+}
 // doesnt use anvil because we are testing the connection to chain
 // doesnt use testLocally because that messes with the node connection
 describe('flags', () => {
   let config: Config
-  class BasicCommand extends BaseCommand {
-    async run() {
-      console.log('Hello, world!')
-    }
-  }
+
   beforeEach(async () => {
     // copied from Commaand.run to load config
     config = await Config.load(require.main?.filename || __dirname)
@@ -39,7 +56,7 @@ describe('flags', () => {
   })
   describe('--help', () => {
     it('it shows help', async () => {
-      const writeSpy = jest.spyOn(ux.write, 'stdout')
+      const writeSpy = jest.spyOn(ux.write, 'stdout').mockImplementation()
       const help = new CustomHelp(config)
       // transfer:celo could be ANY command --help is the important part
       await help.showHelp(['transfer:celo', '--help'])
@@ -52,6 +69,153 @@ describe('flags', () => {
 })
 
 testWithAnvilL2('BaseCommand', (web3: Web3) => {
+  const logSpy = jest.spyOn(console, 'log').mockImplementation()
+  beforeEach(() => {
+    logSpy.mockClear()
+  })
+
+  describe('with --useLedger', () => {
+    describe('derivationPath tests', () => {
+      it('uses default derivationPath from config', async () => {
+        const storedDerivationPath = readConfig(tmpdir()).derivationPath
+        await testLocallyWithWeb3Node(BasicCommand, ['--useLedger'], web3)
+        expect(WalletLedgerExports.newLedgerWalletWithSetup).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            baseDerivationPath: storedDerivationPath,
+          })
+        )
+      })
+      it('uses custom derivationPath', async () => {
+        const customPath = ETHEREUM_DERIVATION_PATH
+        await testLocallyWithWeb3Node(Set, ['--derivationPath', customPath], web3)
+        await testLocallyWithWeb3Node(BasicCommand, ['--useLedger'], web3)
+        expect(WalletLedgerExports.newLedgerWalletWithSetup).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            baseDerivationPath: customPath,
+          })
+        )
+      })
+    })
+
+    it('--ledgerAddresses passes derivationPathIndexes to LedgerWallet', async () => {
+      await testLocallyWithWeb3Node(BasicCommand, ['--useLedger', '--ledgerAddresses', '5'], web3)
+
+      expect(WalletLedgerExports.newLedgerWalletWithSetup).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          changeIndexes: [0],
+          derivationPathIndexes: [0, 1, 2, 3, 4],
+        })
+      )
+      expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+        [
+          [
+            "Retrieving derivation Paths",
+            [
+              0,
+              1,
+              2,
+              3,
+              4,
+            ],
+          ],
+        ]
+      `)
+    })
+
+    describe('with --ledgerLiveMode', () => {
+      it('--ledgerAddresses passes changeIndexes to LedgerWallet', async () => {
+        await testLocallyWithWeb3Node(
+          BasicCommand,
+          ['--useLedger', '--ledgerLiveMode', '--ledgerAddresses', '5'],
+          web3
+        )
+
+        expect(WalletLedgerExports.newLedgerWalletWithSetup).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            changeIndexes: [0, 1, 2, 3, 4],
+            derivationPathIndexes: [0],
+          })
+        )
+        expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+          [
+            [
+              "Retrieving derivation Paths",
+              [
+                0,
+                1,
+                2,
+                3,
+                4,
+              ],
+            ],
+          ]
+        `)
+      })
+      describe('with --ledgerCustomAddresses', () => {
+        it('passes custom changeIndexes to LedgerWallet', async () => {
+          await testLocallyWithWeb3Node(
+            BasicCommand,
+            ['--useLedger', '--ledgerLiveMode', '--ledgerCustomAddresses', '[1,8,9]'],
+            web3
+          )
+
+          expect(WalletLedgerExports.newLedgerWalletWithSetup).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+              changeIndexes: [1, 8, 9],
+              derivationPathIndexes: [0],
+            })
+          )
+          expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+            [
+              [
+                "Retrieving derivation Paths",
+                [
+                  1,
+                  8,
+                  9,
+                ],
+              ],
+            ]
+          `)
+        })
+      })
+    })
+    describe('with --ledgerCustomAddresses', () => {
+      it('passes custom derivationPathIndexes to LedgerWallet', async () => {
+        await testLocallyWithWeb3Node(
+          BasicCommand,
+          ['--useLedger', '--ledgerCustomAddresses', '[1,8,9]'],
+          web3
+        )
+
+        expect(WalletLedgerExports.newLedgerWalletWithSetup).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            changeIndexes: [0],
+            derivationPathIndexes: [1, 8, 9],
+          })
+        )
+        expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+          [
+            [
+              "Retrieving derivation Paths",
+              [
+                1,
+                8,
+                9,
+              ],
+            ],
+          ]
+        `)
+      })
+    })
+  })
+
   it('logs command execution error', async () => {
     class TestErrorCommand extends BaseCommand {
       async run() {
@@ -59,9 +223,11 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
       }
     }
 
-    const errorSpy = jest.spyOn(console, 'error')
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation()
 
-    await expect(testLocallyWithWeb3Node(TestErrorCommand, [], web3)).rejects.toThrow()
+    await expect(
+      testLocallyWithWeb3Node(TestErrorCommand, [], web3)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"test error"`)
 
     expect(errorSpy.mock.calls).toMatchInlineSnapshot(`
       [
@@ -85,9 +251,9 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
       }
     }
 
-    const writeMock = jest.spyOn(ux.write, 'stdout')
-    const logSpy = jest.spyOn(console, 'log')
-    const errorSpy = jest.spyOn(console, 'error')
+    const writeMock = jest.spyOn(ux.write, 'stdout').mockImplementation()
+    const logSpy = jest.spyOn(console, 'log').mockImplementation()
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation()
 
     jest.spyOn(Connection.prototype, 'stop').mockImplementation(() => {
       throw new Error('Mock connection stop error')

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -69,6 +69,12 @@ export abstract class BaseCommand extends Command {
       exclusive: ['ledgerCustomAddresses'],
       description: 'If --useLedger is set, this will get the first N addresses for local signing',
     }),
+    ledgerLiveMode: Flags.boolean({
+      dependsOn: ['useLedger'],
+      default: false,
+      description:
+        'When set, the 4th postion of the derivation path will be iterated over instead of the 5th. This is useful to use same address on you Ledger with celocli as you do on Ledger Live',
+    }),
     ledgerCustomAddresses: Flags.string({
       dependsOn: ['useLedger'],
       default: '[0]',
@@ -185,13 +191,11 @@ export abstract class BaseCommand extends Command {
         if (res.flags.ledgerConfirmAddress) {
           ledgerConfirmation = AddressValidation.everyTransaction
         }
-        this._wallet = await newLedgerWalletWithSetup(
-          transport,
+        this._wallet = await newLedgerWalletWithSetup(transport, {
           derivationPathIndexes,
-          undefined,
-          ledgerConfirmation,
-          await this.isCel2()
-        )
+          ledgerAddressValidation: ledgerConfirmation,
+          isCel2: await this.isCel2(),
+        })
       } catch (err) {
         console.log('Check if the ledger is connected and logged.')
         throw err

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -12,7 +12,7 @@ import chalk from 'chalk'
 import net from 'net'
 import Web3 from 'web3'
 import { CustomFlags } from './utils/command'
-import { getNodeUrl } from './utils/config'
+import { getDefaultDerivationPath, getNodeUrl } from './utils/config'
 import { getFeeCurrencyContractWrapper } from './utils/fee-currency'
 import { requireNodeIsSynced } from './utils/helpers'
 
@@ -175,24 +175,27 @@ export abstract class BaseCommand extends Command {
 
     if (res.flags.useLedger) {
       try {
+        const isLedgerLiveMode = res.flags.ledgerLiveMode
         // types seem to be suggesting 2 defaults but js is otherwise for TransportNodeHid
         const TransportNodeHid: typeof _TransportNodeHid =
           // @ts-expect-error
           _TransportNodeHid.default || _TransportNodeHid
         const transport = await TransportNodeHid.open('')
-        const derivationPathIndexes = res.raw.some(
+        const indicesToIterateOver: number[] = res.raw.some(
           (value) => (value as any).flag === 'ledgerCustomAddresses'
         )
           ? JSON.parse(res.flags.ledgerCustomAddresses)
           : Array.from(Array(res.flags.ledgerAddresses).keys())
 
-        console.log('Retrieving derivation Paths', derivationPathIndexes)
+        console.log('Retrieving derivation Paths', indicesToIterateOver)
         let ledgerConfirmation = AddressValidation.never
         if (res.flags.ledgerConfirmAddress) {
           ledgerConfirmation = AddressValidation.everyTransaction
         }
         this._wallet = await newLedgerWalletWithSetup(transport, {
-          derivationPathIndexes,
+          baseDerivationPath: getDefaultDerivationPath(this.config.configDir),
+          derivationPathIndexes: isLedgerLiveMode ? [0] : indicesToIterateOver,
+          changeIndexes: isLedgerLiveMode ? indicesToIterateOver : [0],
           ledgerAddressValidation: ledgerConfirmation,
           isCel2: await this.isCel2(),
         })

--- a/packages/cli/src/commands/account/new.test.ts
+++ b/packages/cli/src/commands/account/new.test.ts
@@ -27,6 +27,7 @@ testWithAnvilL2('account:new cmd', (web3: Web3) => {
         [
           "
       Using celoLegacy path (m/44'/52752'/0') for derivation. This will default to eth derivation path (m/44'/60'/0') next major version.
+       use "config:set --derivationPath <path>" to set your preffered default
       ",
         ],
         [

--- a/packages/cli/src/commands/account/new.ts
+++ b/packages/cli/src/commands/account/new.ts
@@ -15,11 +15,13 @@ import { ViewCommmandFlags } from '../../utils/flags'
 
 import {
   CELO_DERIVATION_PATH_BASE,
+  DerivationPath,
   DerivationPathAliases,
   ETHEREUM_DERIVATION_PATH,
   MnemonicLanguages,
   MnemonicStrength,
 } from '@celo/base'
+import { getDefaultDerivationPath } from '../../utils/config'
 
 export default class NewAccount extends BaseCommand {
   static description =
@@ -93,7 +95,7 @@ export default class NewAccount extends BaseCommand {
     return undefined
   }
 
-  static sanitizeDerivationPath(derivationPath?: string) {
+  static sanitizeDerivationPath(derivationPath?: string): DerivationPath {
     if (derivationPath) {
       derivationPath = derivationPath.endsWith('/') ? derivationPath.slice(0, -1) : derivationPath
     }
@@ -106,7 +108,7 @@ export default class NewAccount extends BaseCommand {
 
     // if it is a valid BIP 44 it will be returned
     if (derivationPath && /^m\/44'\/\d+'\/\d+'(?:\/\d+)*$/.test(derivationPath)) {
-      return derivationPath
+      return derivationPath as DerivationPath
     }
 
     throw new Error(
@@ -144,7 +146,7 @@ export default class NewAccount extends BaseCommand {
       )
     }
     const derivationPath = NewAccount.sanitizeDerivationPath(
-      res.flags.derivationPath ?? CELO_DERIVATION_PATH_BASE
+      res.flags.derivationPath ?? getDefaultDerivationPath(this.config.configDir)
     )
     const passphrase = NewAccount.readFile(res.flags.passphrasePath)
     const keys = await generateKeys(
@@ -160,7 +162,7 @@ export default class NewAccount extends BaseCommand {
     if (derivationPath === CELO_DERIVATION_PATH_BASE) {
       this.log(
         chalk.magenta(
-          `\nUsing celoLegacy path (${CELO_DERIVATION_PATH_BASE}) for derivation. This will default to eth derivation path (${ETHEREUM_DERIVATION_PATH}) next major version.\n`
+          `\nUsing celoLegacy path (${CELO_DERIVATION_PATH_BASE}) for derivation. This will default to eth derivation path (${ETHEREUM_DERIVATION_PATH}) next major version.\n use "config:set --derivationPath <path>" to set your preffered default\n`
         )
       )
     }

--- a/packages/cli/src/commands/config/get.test.ts
+++ b/packages/cli/src/commands/config/get.test.ts
@@ -1,0 +1,26 @@
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import Web3 from 'web3'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import Get from './get'
+
+process.env.NO_SYNCCHECK = 'true'
+
+afterEach(async () => {
+  jest.clearAllMocks()
+  jest.restoreAllMocks()
+})
+
+testWithAnvilL2('config:get cmd', (web3: Web3) => {
+  it('shows the config', async () => {
+    const logMock = jest.spyOn(console, 'log').mockImplementation()
+    await testLocallyWithWeb3Node(Get, [], web3)
+    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "node: http://127.0.0.1:8617
+      derivationPath: m/44'/52752'/0'",
+        ],
+      ]
+    `)
+  })
+})

--- a/packages/cli/src/commands/config/get.test.ts
+++ b/packages/cli/src/commands/config/get.test.ts
@@ -17,8 +17,8 @@ testWithAnvilL2('config:get cmd', (web3: Web3) => {
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
       [
         [
-          "node: http://127.0.0.1:8617
-      derivationPath: m/44'/52752'/0'",
+          "node: http://127.0.0.1:8620
+      derivationPath: m/44'/60'/0'",
         ],
       ]
     `)

--- a/packages/cli/src/commands/config/get.test.ts
+++ b/packages/cli/src/commands/config/get.test.ts
@@ -1,6 +1,6 @@
 import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import Get from './get'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -14,13 +14,10 @@ testWithAnvilL2('config:get cmd', (web3: Web3) => {
   it('shows the config', async () => {
     const logMock = jest.spyOn(console, 'log').mockImplementation()
     await testLocallyWithWeb3Node(Get, [], web3)
-    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
-      [
-        [
-          "node: http://127.0.0.1:8620
-      derivationPath: m/44'/60'/0'",
-        ],
-      ]
+    expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[0][0].replace(/:\d\d\d\d/, ':PORT')))
+      .toMatchInlineSnapshot(`
+      "node: http://127.0.0.1:PORT
+      derivationPath: m/44'/52752'/0'"
     `)
   })
 })

--- a/packages/cli/src/commands/config/set.test.ts
+++ b/packages/cli/src/commands/config/set.test.ts
@@ -2,11 +2,7 @@ import { newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import Web3 from 'web3'
-import {
-  extractHostFromWeb3,
-  stripAnsiCodesFromNestedArray,
-  testLocallyWithWeb3Node,
-} from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import * as config from '../../utils/config'
 import Set from './set'
 
@@ -18,6 +14,60 @@ afterEach(async () => {
 })
 
 testWithAnvilL1('config:set cmd', (web3: Web3) => {
+  describe('--derivationPath', () => {
+    beforeEach
+    it('sets with bip44 path', async () => {
+      const writeMock = jest.spyOn(config, 'writeConfig')
+      await testLocallyWithWeb3Node(Set, ['--derivationPath', "m/44'/52752'/0'/0/0"], web3)
+      expect(writeMock.mock.calls[0][1]).toMatchInlineSnapshot(`
+        {
+          "derivationPath": "m/44'/52752'/0'/0/0",
+          "node": "http://127.0.0.1:8638",
+        }
+      `)
+    })
+    it('sets with eth', async () => {
+      const writeMock = jest.spyOn(config, 'writeConfig')
+
+      await testLocallyWithWeb3Node(Set, ['--derivationPath', 'eth'], web3)
+      expect(writeMock.mock.calls[0][1]).toMatchInlineSnapshot(`
+        {
+          "derivationPath": "m/44'/60'/0'",
+          "node": "http://127.0.0.1:8638",
+        }
+      `)
+    })
+    it('sets with celoLegacy ', async () => {
+      const writeMock = jest.spyOn(config, 'writeConfig')
+
+      await testLocallyWithWeb3Node(Set, ['--derivationPath', 'celoLegacy'], web3)
+      expect(writeMock.mock.calls[0][1]).toMatchInlineSnapshot(`
+        {
+          "derivationPath": "m/44'/52752'/0'",
+          "node": "http://127.0.0.1:8638",
+        }
+      `)
+    })
+    describe('with bad data', () => {
+      beforeEach(() => jest.spyOn(console, 'error').mockImplementation())
+      it('fails with solana ', async () => {
+        await expect(testLocallyWithWeb3Node(Set, ['--derivationPath', 'solana'], web3)).rejects
+          .toThrowErrorMatchingInlineSnapshot(`
+          "Parsing --derivationPath 
+          	Invalid derivationPath: solana
+          See more help with --help"
+        `)
+      })
+      it('fails with invalid path', async () => {
+        await expect(testLocallyWithWeb3Node(Set, ['--derivationPath', "m/44'/256'/0"], web3))
+          .rejects.toThrowErrorMatchingInlineSnapshot(`
+          "Parsing --derivationPath 
+          	Invalid derivationPath: m/44'/256'/0
+          See more help with --help"
+        `)
+      })
+    })
+  })
   it('shows a warning if gasCurrency is passed', async () => {
     const kit = newKitFromWeb3(web3)
     const feeCurrencyDirectory = await kit.contracts.getFeeCurrencyDirectory()
@@ -39,10 +89,14 @@ testWithAnvilL1('config:set cmd', (web3: Web3) => {
         ],
       ]
     `)
-    expect(writeMock.mock.calls[0][1]).toMatchInlineSnapshot(`
-      {
-        "node": "${extractHostFromWeb3(web3)}",
-      }
+    expect(writeMock.mock.calls[0]).toMatchInlineSnapshot(`
+      [
+        "/Users/aaronderuvo/.config/@celo/celocli",
+        {
+          "derivationPath": "m/44'/52752'/0'",
+          "node": "http://127.0.0.1:8638",
+        },
+      ]
     `)
   })
 })

--- a/packages/cli/src/commands/config/set.test.ts
+++ b/packages/cli/src/commands/config/set.test.ts
@@ -15,38 +15,28 @@ afterEach(async () => {
 
 testWithAnvilL1('config:set cmd', (web3: Web3) => {
   describe('--derivationPath', () => {
-    beforeEach
     it('sets with bip44 path', async () => {
       const writeMock = jest.spyOn(config, 'writeConfig')
       await testLocallyWithWeb3Node(Set, ['--derivationPath', "m/44'/52752'/0'/0/0"], web3)
-      expect(writeMock.mock.calls[0][1]).toMatchInlineSnapshot(`
-        {
-          "derivationPath": "m/44'/52752'/0'/0/0",
-          "node": "http://127.0.0.1:8638",
-        }
-      `)
+      expect(writeMock.mock.calls[0][1]).toEqual(
+        expect.objectContaining({ derivationPath: "m/44'/52752'/0'/0/0" })
+      )
     })
     it('sets with eth', async () => {
       const writeMock = jest.spyOn(config, 'writeConfig')
 
       await testLocallyWithWeb3Node(Set, ['--derivationPath', 'eth'], web3)
-      expect(writeMock.mock.calls[0][1]).toMatchInlineSnapshot(`
-        {
-          "derivationPath": "m/44'/60'/0'",
-          "node": "http://127.0.0.1:8638",
-        }
-      `)
+      expect(writeMock.mock.calls[0][1]).toEqual(
+        expect.objectContaining({ derivationPath: "m/44'/60'/0'" })
+      )
     })
     it('sets with celoLegacy ', async () => {
       const writeMock = jest.spyOn(config, 'writeConfig')
 
       await testLocallyWithWeb3Node(Set, ['--derivationPath', 'celoLegacy'], web3)
-      expect(writeMock.mock.calls[0][1]).toMatchInlineSnapshot(`
-        {
-          "derivationPath": "m/44'/52752'/0'",
-          "node": "http://127.0.0.1:8638",
-        }
-      `)
+      expect(writeMock.mock.calls[0][1]).toEqual(
+        expect.objectContaining({ derivationPath: "m/44'/52752'/0'" })
+      )
     })
     describe('with bad data', () => {
       beforeEach(() => jest.spyOn(console, 'error').mockImplementation())
@@ -54,7 +44,7 @@ testWithAnvilL1('config:set cmd', (web3: Web3) => {
         await expect(testLocallyWithWeb3Node(Set, ['--derivationPath', 'solana'], web3)).rejects
           .toThrowErrorMatchingInlineSnapshot(`
           "Parsing --derivationPath 
-          	Invalid derivationPath: solana
+          	Invalid derivationPath: solana. should be in format  "m / 44' / coin_type' / account'"
           See more help with --help"
         `)
       })
@@ -62,7 +52,7 @@ testWithAnvilL1('config:set cmd', (web3: Web3) => {
         await expect(testLocallyWithWeb3Node(Set, ['--derivationPath', "m/44'/256'/0"], web3))
           .rejects.toThrowErrorMatchingInlineSnapshot(`
           "Parsing --derivationPath 
-          	Invalid derivationPath: m/44'/256'/0
+          	Invalid derivationPath: m/44'/256'/0. should be in format  "m / 44' / coin_type' / account'"
           See more help with --help"
         `)
       })
@@ -89,14 +79,9 @@ testWithAnvilL1('config:set cmd', (web3: Web3) => {
         ],
       ]
     `)
-    expect(writeMock.mock.calls[0]).toMatchInlineSnapshot(`
-      [
-        "/Users/aaronderuvo/.config/@celo/celocli",
-        {
-          "derivationPath": "m/44'/52752'/0'",
-          "node": "http://127.0.0.1:8638",
-        },
-      ]
-    `)
+    expect(writeMock).toHaveBeenCalledTimes(1)
+    expect(writeMock.mock.calls[0][0]).toMatch('.config/@celo/celocli')
+    expect(writeMock.mock.calls[0][1]).toMatchObject({ derivationPath: "m/44'/52752'/0'" })
+    expect(writeMock.mock.calls[0][1]).not.toHaveProperty('gasCurrency')
   })
 })

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -1,8 +1,9 @@
-import { ux } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import chalk from 'chalk'
 import { BaseCommand } from '../../base'
 import { CeloConfig, readConfig, writeConfig } from '../../utils/config'
 import { ViewCommmandFlags } from '../../utils/flags'
+import NewAccount from '../account/new'
 export default class Set extends BaseCommand {
   static description = 'Configure running node information for propagating transactions to network'
 
@@ -12,6 +13,13 @@ export default class Set extends BaseCommand {
       ...BaseCommand.flags.node,
       hidden: false,
     },
+    derivationPath: Flags.string({
+      parse: async (input: string) => {
+        return NewAccount.sanitizeDerivationPath(input)
+      },
+      description:
+        "Set the default derivation path used by account:new and when using --useLedger flag. Options: 'eth', 'celoLegacy', or a custom derivation path",
+    }),
   }
 
   static examples = [
@@ -23,6 +31,9 @@ export default class Set extends BaseCommand {
     'set --node local # alias for http://localhost:8545',
     'set --node ws://localhost:2500',
     'set --node <geth-location>/geth.ipc',
+    "set --derivationPath \"m/44'/52752'/0'/0\"",
+    'set --derivationPath eth',
+    'set --derivationPath celoLegacy',
   ]
 
   requireSynced = false
@@ -31,6 +42,7 @@ export default class Set extends BaseCommand {
     const res = await this.parse(Set)
     const curr = readConfig(this.config.configDir)
     const node = res.flags.node ?? curr.node
+    const derivationPath = res.flags.derivationPath ?? curr.derivationPath
     const gasCurrency = res.flags.gasCurrency
 
     if (gasCurrency) {
@@ -43,6 +55,7 @@ export default class Set extends BaseCommand {
 
     await writeConfig(this.config.configDir, {
       node,
+      derivationPath,
     } as CeloConfig)
   }
 }

--- a/packages/cli/src/utils/config.test.ts
+++ b/packages/cli/src/utils/config.test.ts
@@ -27,19 +27,21 @@ describe('writeConfig', () => {
     expect(spy.mock.calls[0]).toHaveLength(2)
     expect(spy.mock.calls[0][0]).toEqual(file)
     expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
-        {
-          "node": "http://localhost:8545",
-        }
-      `)
+      {
+        "derivationPath": "m/44'/52752'/0'",
+        "node": "http://localhost:8545",
+      }
+    `)
   })
   it('accepts node', async () => {
     const [dir] = getPaths()
-    await writeConfig(dir, { node: 'SOME_URL' })
+    await writeConfig(dir, { node: 'SOME_URL', derivationPath: "m/44'/52752'/0'/0/0" })
     expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
-        {
-          "node": "SOME_URL",
-        }
-      `)
+      {
+        "derivationPath": "m/44'/52752'/0'/0/0",
+        "node": "SOME_URL",
+      }
+    `)
   })
 })
 
@@ -49,6 +51,7 @@ describe('readConfig', () => {
     fs.writeJsonSync(file, { foo: 'bar' })
     expect(readConfig(dir)).toMatchInlineSnapshot(`
       {
+        "derivationPath": "m/44'/52752'/0'",
         "foo": "bar",
         "node": "http://localhost:8545",
       }
@@ -59,6 +62,7 @@ describe('readConfig', () => {
     fs.writeJsonSync(file, { nodeUrl: 'bar' })
     expect(readConfig(dir)).toMatchInlineSnapshot(`
       {
+        "derivationPath": "m/44'/52752'/0'",
         "node": "bar",
       }
     `)
@@ -68,6 +72,7 @@ describe('readConfig', () => {
     fs.writeJsonSync(file, { gasCurrency: 'CELO' })
     expect(readConfig(dir)).toMatchInlineSnapshot(`
       {
+        "derivationPath": "m/44'/52752'/0'",
         "node": "http://localhost:8545",
       }
     `)

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -1,8 +1,10 @@
+import { CELO_DERIVATION_PATH_BASE } from '@celo/base'
 import * as fs from 'fs-extra'
 import * as path from 'path'
 
 export interface CeloConfig {
   node: string
+  derivationPath: string
 }
 
 // NOTE: this mapping should stay updated as CeloConfig evolves
@@ -13,6 +15,7 @@ const LEGACY_MAPPING: Record<string, keyof CeloConfig | undefined> = {
 
 export const defaultConfig: CeloConfig = {
   node: 'http://localhost:8545',
+  derivationPath: CELO_DERIVATION_PATH_BASE,
 }
 
 const configFile = 'config.json'
@@ -44,8 +47,15 @@ export function getNodeUrl(configDir: string): string {
   return readConfig(configDir).node
 }
 
+export function getDefaultDerivationPath(configDir: string): string {
+  return readConfig(configDir).derivationPath
+}
+
 export async function writeConfig(configDir: string, configObj: CeloConfig) {
   const config = { ...defaultConfig, ...configObj }
 
-  fs.outputJSONSync(configPath(configDir), config)
+  fs.outputJSONSync(configPath(configDir), {
+    node: config.node,
+    derivationPath: config.derivationPath,
+  })
 }

--- a/packages/cli/src/utils/flags.ts
+++ b/packages/cli/src/utils/flags.ts
@@ -10,6 +10,10 @@ export const ViewCommmandFlags = {
     ...BaseCommand.flags.useLedger,
     hidden: true,
   },
+  ledgerLiveMode: {
+    ...BaseCommand.flags.ledgerLiveMode,
+    hidden: true,
+  },
   ledgerAddresses: {
     ...BaseCommand.flags.ledgerAddresses,
     hidden: true,

--- a/packages/sdk/base/src/account.ts
+++ b/packages/sdk/base/src/account.ts
@@ -2,6 +2,8 @@ export const CELO_DERIVATION_PATH_BASE = "m/44'/52752'/0'"
 
 export const ETHEREUM_DERIVATION_PATH = "m/44'/60'/0'"
 
+export type DerivationPath = `m/44'/${string}'/${string}`
+
 export enum DerivationPathAliases {
   eth = ETHEREUM_DERIVATION_PATH,
   celoLegacy = CELO_DERIVATION_PATH_BASE,

--- a/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts
+++ b/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts
@@ -17,7 +17,10 @@ import { SemVer } from 'semver'
 import { LedgerSigner } from './ledger-signer'
 import { meetsVersionRequirements, transportErrorFriendlyMessage } from './ledger-utils'
 
-export const CELO_BASE_DERIVATION_PATH = CELO_DERIVATION_PATH_BASE.slice(2)
+/*
+ * @deprecated this constant hardcodes the change index to 0. However we actually ignore that.
+ */
+export const CELO_BASE_DERIVATION_PATH = `${CELO_DERIVATION_PATH_BASE.slice(2)}/0`
 const ADDRESS_QTY = 5
 
 // Validates an address using the Ledger

--- a/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts
+++ b/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts
@@ -1,6 +1,7 @@
 import { CELO_DERIVATION_PATH_BASE } from '@celo/base/lib/account'
 import { zeroRange } from '@celo/base/lib/collections'
 import { Address, CeloTx, EncodedTransaction, ReadOnlyWallet, isPresent } from '@celo/connect'
+import Ledger from '@celo/hw-app-eth'
 import {
   chainIdTransformationForSigning,
   encodeTransaction,
@@ -11,13 +12,12 @@ import {
 } from '@celo/wallet-base'
 import { RemoteWallet } from '@celo/wallet-remote'
 import { TransportError, TransportStatusError } from '@ledgerhq/errors'
-import Ledger from '@celo/hw-app-eth'
 import debugFactory from 'debug'
 import { SemVer } from 'semver'
 import { LedgerSigner } from './ledger-signer'
 import { meetsVersionRequirements, transportErrorFriendlyMessage } from './ledger-utils'
 
-export const CELO_BASE_DERIVATION_PATH = `${CELO_DERIVATION_PATH_BASE.slice(2)}/0`
+export const CELO_BASE_DERIVATION_PATH = CELO_DERIVATION_PATH_BASE.slice(2)
 const ADDRESS_QTY = 5
 
 // Validates an address using the Ledger
@@ -32,17 +32,29 @@ export enum AddressValidation {
   never,
 }
 
+interface LedgerWalletSetup {
+  derivationPathIndexes?: number[]
+  changeIndexes?: number[]
+  baseDerivationPath?: string
+  ledgerAddressValidation?: AddressValidation
+  isCel2?: boolean
+}
+
 export async function newLedgerWalletWithSetup(
   transport: any,
-  derivationPathIndexes?: number[],
-  baseDerivationPath?: string,
-  ledgerAddressValidation?: AddressValidation,
-  isCel2?: boolean
-): Promise<LedgerWallet> {
-  const wallet = new LedgerWallet(
+  {
     derivationPathIndexes,
     baseDerivationPath,
+    ledgerAddressValidation,
+    changeIndexes,
+    isCel2,
+  }: LedgerWalletSetup
+): Promise<LedgerWallet> {
+  const wallet = new LedgerWallet(
     transport,
+    derivationPathIndexes,
+    baseDerivationPath,
+    changeIndexes,
     ledgerAddressValidation,
     isCel2
   )
@@ -59,27 +71,33 @@ export class LedgerWallet extends RemoteWallet<LedgerSigner> implements ReadOnly
   ledger: Ledger | undefined
 
   /**
-   * @param derivationPathIndexes number array of "address_index" for the base derivation path.
-   * Default: Array[0..9].
-   * Example: [3, 99, 53] will retrieve the derivation paths of
-   * [`${baseDerivationPath}/3`, `${baseDerivationPath}/99`, `${baseDerivationPath}/53`]
-   * @param baseDerivationPath base derivation path. Default: "44'/52752'/0'/0"
    * @param transport Transport to connect the ledger device
+   * @param derivationPathIndexes number array of "address_index" for the base derivation path.
+   * Default: Array[0..5].
+   * Example: [3, 99, 53] will retrieve the derivation paths of
+   * [`${baseDerivationPath}/0/3`, `${baseDerivationPath}/0/99`, `${baseDerivationPath}/0/53`]
+   * @param baseDerivationPath base derivation path. Default: "44'/52752'/0'"
+   * @param changeIndexes number array of "change" for the base derivation path.
+   * Default: [0].
+   * Example: [0, 1] will retrieve the derivation paths of [`${baseDerivationPath}/0/${address_index}`, `${baseDerivationPath}/1/${address_index}`, `${baseDerivationPath}/2/${address_index}`]
+   * @param ledgerAddressValidation AddressValidation enum to validate addresses. Default: AddressValidation.firstTransactionPerAddress
    */
   constructor(
+    readonly transport: any = {},
     readonly derivationPathIndexes: number[] = zeroRange(ADDRESS_QTY),
     readonly baseDerivationPath: string = CELO_BASE_DERIVATION_PATH,
-    readonly transport: any = {},
+    readonly changeIndexes: number[] = [0],
     readonly ledgerAddressValidation: AddressValidation = AddressValidation.firstTransactionPerAddress,
     readonly isCel2?: boolean
   ) {
     super()
-    const invalidDPs = derivationPathIndexes.some(
-      (value) => !(Number.isInteger(value) && value >= 0)
-    )
-    if (invalidDPs) {
-      throw new Error('ledger-wallet: Invalid address index')
-    }
+
+    validateIndexes(derivationPathIndexes, 'address index')
+    validateIndexes(changeIndexes, 'change index')
+    // Remove the 'm/' prefix if it exists since we dont expect it here but that is how derivaiton path is used in the rest of the code
+    this.baseDerivationPath = baseDerivationPath.startsWith('m/')
+      ? baseDerivationPath.slice(2)
+      : baseDerivationPath
   }
 
   async signTransaction(txParams: CeloTx): Promise<EncodedTransaction> {
@@ -175,20 +193,24 @@ export class LedgerWallet extends RemoteWallet<LedgerSigner> implements ReadOnly
     const addressToSigner = new Map<Address, LedgerSigner>()
     const appConfiguration = await this.retrieveAppConfiguration()
     const validationRequired = this.ledgerAddressValidation === AddressValidation.initializationOnly
-
+    // https://trezor.io/learn/a/what-is-bip44
+    const [purpose, coinType, account] = this.baseDerivationPath.split('/')
     // Each address must be retrieved synchronously, (ledger lock)
-    for (const value of this.derivationPathIndexes) {
-      const derivationPath = `${this.baseDerivationPath}/${value}`
-      const addressInfo = await this.ledger!.getAddress(derivationPath, validationRequired)
-      addressToSigner.set(
-        addressInfo.address!,
-        new LedgerSigner(
-          this.ledger!,
-          derivationPath,
-          this.ledgerAddressValidation,
-          appConfiguration
+    for (const changeIndex of this.changeIndexes) {
+      for (const addressIndex of this.derivationPathIndexes) {
+        const derivationPath = `${purpose}/${coinType}/${account}/${changeIndex}/${addressIndex}`
+        console.info(`Fetching address for derivation path ${derivationPath}`)
+        const addressInfo = await this.ledger!.getAddress(derivationPath, validationRequired)
+        addressToSigner.set(
+          addressInfo.address!,
+          new LedgerSigner(
+            this.ledger!,
+            derivationPath,
+            this.ledgerAddressValidation,
+            appConfiguration
+          )
         )
-      )
+      }
     }
     return addressToSigner
   }
@@ -209,5 +231,15 @@ export class LedgerWallet extends RemoteWallet<LedgerSigner> implements ReadOnly
       )
     }
     return appConfiguration
+  }
+}
+function validateIndexes(indexes: number[], label: string = 'address index') {
+  if (indexes.length === 0) {
+    throw new Error(`ledger-wallet: No ${label} provided`)
+  }
+
+  const invalidDPs = indexes.some((value) => !(Number.isInteger(value) && value >= 0))
+  if (invalidDPs) {
+    throw new Error(`ledger-wallet: Invalid ${label} provided`)
   }
 }


### PR DESCRIPTION
### Description

allowing users to set a default base derivation path allows users to continue to use celo path as default but for new user of cli to use eth path. 

ledger live option makes it easy to for users to use same accounts on ledger live as they use in cli. otherwise ledger live would be the only place to access them which was a bit scary at the worst and inconvenient at best.

#### Other changes

breaking. refactor newLedgerWalletWithSetup to take an options object as we are passing about 5 params. 
passing in array of changeIndexes to iterate over while searching for addresses on ledger

### QA

try out setting the config, then calling account:new, then using useLedger flag, also try --useLedger with --ledgerLiveMode. 

### Related issues 

fixes #448

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the handling of derivation paths in the Celo CLI and wallet functionalities, particularly for Ledger devices. It adds new flags, improves documentation, and modifies related interfaces and commands.

### Detailed summary
- Added `--ledgerLiveMode` flag to iterate over derivation paths for Ledger.
- Introduced `DerivationPath` type in `packages/sdk/base/src/account.ts`.
- Updated `config:set` command to support `--derivationPath` option.
- Enhanced documentation for derivation paths and CLI commands.
- Modified `newLedgerWalletWithSetup` and `LedgerWallet` interfaces to accommodate new options.
- Added tests for `--derivationPath` handling in `Set` command.
- Updated multiple CLI commands to include `--ledgerLiveMode` and `--derivationPath`.

> The following files were skipped due to too many changes: `packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts`, `packages/cli/src/base-l2.test.ts`, `packages/sdk/wallets/wallet-ledger/src/ledger-wallet.test.ts`, `docs/sdk/wallet-ledger/classes/ledger_wallet.LedgerWallet.md`, `docs/command-line-interface/validator.md`, `docs/command-line-interface/releasecelo.md`, `docs/command-line-interface/governance.md`, `docs/command-line-interface/account.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->