### PR TITLE
Upgrade devchain and ABIs

### DIFF
--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -32,7 +32,7 @@
     "web3-core-helpers": "1.10.4"
   },
   "devDependencies": {
-    "@celo/devchain-anvil": "12.0.0-canary.39",
+    "@celo/devchain-anvil": "12.0.0-canary.54",
     "@celo/typescript": "workspace:^",
     "@tsconfig/recommended": "^1.0.3",
     "@types/fs-extra": "^8.1.0",

--- a/packages/sdk/contractkit/package.json
+++ b/packages/sdk/contractkit/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@celo/abis": "11.0.0",
-    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.76",
+    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.82",
     "@celo/base": "^7.0.0",
     "@celo/connect": "^6.1.0",
     "@celo/utils": "^8.0.0",


### PR DESCRIPTION
### Description

An ongoing attempt to keep devchain and ABIs up to date.

#### Other changes

None.

### Tested

Tests on CI are passsing.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version numbers of certain dependencies in the `package.json` files of the `dev-utils` and `contractkit` packages.

### Detailed summary
- Updated `@celo/devchain-anvil` from `12.0.0-canary.39` to `12.0.0-canary.54` in `packages/dev-utils/package.json`.
- Updated `@celo/abis-12` from `npm:@celo/abis@12.0.0-canary.76` to `npm:@celo/abis@12.0.0-canary.82` in `packages/sdk/contractkit/package.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->