### PR TITLE
--useMultiSig flag support for governance:withdraw

### DIFF
--- a/.changeset/serious-ads-allow.md
+++ b/.changeset/serious-ads-allow.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+--useMultiSig support for governance:withdraw command

--- a/docs/command-line-interface/governance.md
+++ b/docs/command-line-interface/governance.md
@@ -1406,7 +1406,8 @@ USAGE
   $ celocli governance:withdraw --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
     <value> | --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
-    [--ledgerLiveMode ] [--globalHelp]
+    [--ledgerLiveMode ] [--globalHelp] [--for 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+    --useMultiSig]
 
 FLAGS
   -k, --privateKey=<value>
@@ -1414,6 +1415,9 @@ FLAGS
 
   -n, --node=<value>
       URL of the node to run commands against or an alias
+
+  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      Address of the multi-sig contract
 
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       (required) Proposer's address
@@ -1436,6 +1440,9 @@ FLAGS
 
   --useLedger
       Set it to use a ledger wallet
+
+  --useMultiSig
+      True means the request will be sent through multisig.
 
 DESCRIPTION
   Withdraw refunded governance proposal deposits.

--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -6,6 +6,7 @@ import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { displaySendTx, printValueMapRecursive } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
+import { MultiSigFlags } from '../../utils/flags'
 import {
   addExistingProposalIDToBuilder,
   addExistingProposalJSONFileToBuilder,
@@ -16,6 +17,7 @@ export default class Propose extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flags,
+    ...MultiSigFlags,
     jsonTransactions: Flags.string({
       required: true,
       description: 'Path to json transactions',
@@ -25,13 +27,6 @@ export default class Propose extends BaseCommand {
       description: 'Amount of Celo to attach to proposal',
     }),
     from: CustomFlags.address({ required: true, description: "Proposer's address" }),
-    useMultiSig: Flags.boolean({
-      description: 'True means the request will be sent through multisig.',
-    }),
-    for: CustomFlags.address({
-      dependsOn: ['useMultiSig'],
-      description: 'Address of the multi-sig contract',
-    }),
     force: Flags.boolean({ description: 'Skip execution check', default: false }),
     noInfo: Flags.boolean({ description: 'Skip printing the proposal info', default: false }),
     descriptionURL: CustomFlags.url({

--- a/packages/cli/src/commands/governance/withdraw-l2.test.ts
+++ b/packages/cli/src/commands/governance/withdraw-l2.test.ts
@@ -10,13 +10,16 @@ import { timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import { ProposalBuilder } from '@celo/governance'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import Withdraw from './withdraw'
 
 process.env.NO_SYNCCHECK = 'true'
 
 testWithAnvilL2('governance:withdraw', (web3: Web3) => {
+  let logMock = jest.spyOn(console, 'log')
+  let errorMock = jest.spyOn(console, 'error')
+
   let minDeposit: string
   const kit = newKitFromWeb3(web3)
 
@@ -24,6 +27,9 @@ testWithAnvilL2('governance:withdraw', (web3: Web3) => {
   let governance: GovernanceWrapper
 
   beforeEach(async () => {
+    logMock.mockClear().mockImplementation()
+    errorMock.mockClear().mockImplementation()
+
     accounts = (await web3.eth.getAccounts()) as StrongAddress[]
     kit.defaultAccount = accounts[0]
     governance = await kit.contracts.getGovernance()
@@ -57,46 +63,134 @@ testWithAnvilL2('governance:withdraw', (web3: Web3) => {
       .plus(latestTransactionReceipt.effectiveGasPrice * latestTransactionReceipt.gasUsed)
 
     expect(difference.toFixed()).toEqual(minDeposit)
+
+    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "Running Checks:",
+        ],
+        [
+          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 has refunded governance deposits ",
+        ],
+        [
+          "All checks passed",
+        ],
+        [
+          "SendTransaction: withdraw",
+        ],
+        [
+          "txHash: 0xtxhash",
+        ],
+      ]
+    `)
+    expect(stripAnsiCodesFromNestedArray(errorMock.mock.calls)).toMatchInlineSnapshot(`[]`)
   })
 
-  it('can withdraw using --useMultiSig', async () => {
-    const [multisigOwner] = (await web3.eth.getAccounts()) as StrongAddress[]
-    const multisigAddress = await createMultisig(kit, [multisigOwner], 1, 1)
-    const multisigBalance = new BigNumber(minDeposit)
-    const proposal: Proposal = await new ProposalBuilder(kit).build()
+  describe('multisig', () => {
+    let multisigAddress: StrongAddress
+    let multisigOwner: StrongAddress
 
-    await withImpersonatedAccount(
-      web3,
-      multisigAddress,
-      async () => {
-        await governance
-          .propose(proposal, 'http://example.com/proposal.json')
-          .sendAndWaitForReceipt({ from: multisigAddress, value: minDeposit })
+    beforeEach(async () => {
+      multisigOwner = accounts[0]
+      multisigAddress = await createMultisig(kit, [multisigOwner], 1, 1)
+
+      await withImpersonatedAccount(
+        web3,
+        multisigAddress,
+        async () => {
+          await governance
+            .propose(await new ProposalBuilder(kit).build(), 'http://example.com/proposal.json')
+            .sendAndWaitForReceipt({ from: multisigAddress, value: minDeposit })
+        },
         // make sure the multisig contract has enough balance to perform the transaction
-      },
-      multisigBalance.multipliedBy(2)
-    )
+        new BigNumber(minDeposit).multipliedBy(2)
+      )
 
-    // Zero out the balance for easier testing
-    await setBalance(web3, multisigAddress, 0)
+      // Zero out the balance for easier testing
+      await setBalance(web3, multisigAddress, 0)
 
-    // Safety check
-    expect(await kit.connection.getBalance(multisigAddress)).toEqual('0')
+      // Dequeue so the proposal can be refunded
+      const dequeueFrequency = (await governance.dequeueFrequency()).toNumber()
+      await timeTravel(dequeueFrequency + 1, web3)
+      await governance.dequeueProposalsIfReady().sendAndWaitForReceipt()
+    })
 
-    // Dequeue so it can be refunded
-    const dequeueFrequency = (await governance.dequeueFrequency()).toNumber()
-    await timeTravel(dequeueFrequency + 1, web3)
-    await governance.dequeueProposalsIfReady().sendAndWaitForReceipt()
+    it('can withdraw using --useMultiSig', async () => {
+      // Safety check
+      expect(await kit.connection.getBalance(multisigAddress)).toEqual('0')
 
-    await testLocallyWithWeb3Node(
-      Withdraw,
-      ['--useMultiSig', '--for', multisigAddress, '--from', multisigOwner],
-      web3
-    )
+      await testLocallyWithWeb3Node(
+        Withdraw,
+        ['--useMultiSig', '--for', multisigAddress, '--from', multisigOwner],
+        web3
+      )
 
-    // After withdrawing the refunded deposit should be the minDeposit (as we zeroed out the balance before)
-    expect(await kit.connection.getBalance(multisigAddress)).toEqual(minDeposit)
+      // After withdrawing the refunded deposit should be the minDeposit (as we zeroed out the balance before)
+      expect(await kit.connection.getBalance(multisigAddress)).toEqual(minDeposit)
+
+      expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+        [
+          [
+            "Running Checks:",
+          ],
+          [
+            "   ✔  0x871DD7C2B4b25E1Aa18728e9D5f2Af4C4e431f5c has refunded governance deposits ",
+          ],
+          [
+            "   ✔  The provided address is an owner of the multisig ",
+          ],
+          [
+            "All checks passed",
+          ],
+          [
+            "SendTransaction: withdraw",
+          ],
+          [
+            "txHash: 0xtxhash",
+          ],
+          [
+            "Deposit:",
+          ],
+          [
+            "sender: 0x2EB25B5eb9d5A4f61deb1e4F846343F862eB67D9
+        value: 100000000000000000000",
+          ],
+        ]
+      `)
+      expect(stripAnsiCodesFromNestedArray(errorMock.mock.calls)).toMatchInlineSnapshot(`[]`)
+    })
+
+    it('fails if trying to withdraw using --useMultiSig not as a signatory', async () => {
+      const otherAccount = accounts[1]
+
+      // Safety check
+      expect(await kit.connection.getBalance(multisigAddress)).toEqual('0')
+
+      await expect(
+        testLocallyWithWeb3Node(
+          Withdraw,
+          ['--useMultiSig', '--for', multisigAddress, '--from', otherAccount],
+          web3
+        )
+      ).rejects.toMatchInlineSnapshot(`[Error: Some checks didn't pass!]`)
+
+      // After failing to withdraw the deposit, the balance should still be zero
+      expect(await kit.connection.getBalance(multisigAddress)).toEqual('0')
+
+      expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+        [
+          [
+            "Running Checks:",
+          ],
+          [
+            "   ✔  0x871DD7C2B4b25E1Aa18728e9D5f2Af4C4e431f5c has refunded governance deposits ",
+          ],
+          [
+            "   ✘  The provided address is an owner of the multisig ",
+          ],
+        ]
+      `)
+      expect(stripAnsiCodesFromNestedArray(errorMock.mock.calls)).toMatchInlineSnapshot(`[]`)
+    })
   })
-
-  it.todo('fails if trying to withdraw using --useMultiSig not as a signatory')
 })

--- a/packages/cli/src/utils/flags.ts
+++ b/packages/cli/src/utils/flags.ts
@@ -1,4 +1,6 @@
+import { Flags } from '@oclif/core'
 import { BaseCommand } from '../base'
+import { CustomFlags } from './command'
 
 export const ViewCommmandFlags = {
   ...BaseCommand.flags,
@@ -26,4 +28,14 @@ export const ViewCommmandFlags = {
     ...BaseCommand.flags.privateKey,
     hidden: true,
   },
+}
+
+export const MultiSigFlags = {
+  useMultiSig: Flags.boolean({
+    description: 'True means the request will be sent through multisig.',
+  }),
+  for: CustomFlags.address({
+    dependsOn: ['useMultiSig'],
+    description: 'Address of the multi-sig contract',
+  }),
 }


### PR DESCRIPTION
### Description

This PR adds `--useMultiSig` flag support for `governance:withdraw` command analogically to `governance:propose`.

#### Other changes

None although will refactor to DRY the multisig flags.

### Tested

Introduced new unit test, one still TBD.

### How to QA

TBD.

### Related issues

- Fixes https://github.com/celo-org/developer-tooling/issues/502

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for a multi-signature (`useMultiSig`) feature in the governance commands of the CLI, allowing requests to be processed through a multi-signature contract. It enhances the `withdraw` functionality to support this feature and updates related documentation.

### Detailed summary
- Added `useMultiSig` and `for` flags to the governance commands.
- Updated `MultiSigFlags` in `flags.ts` to include multi-signature options.
- Enhanced `Withdraw` command to handle multi-signature transactions.
- Updated documentation to reflect new command-line options.
- Added tests for multi-signature withdrawal scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->