### PR TITLE
Support delegation for vote signers

### DIFF
--- a/.changeset/quiet-deers-explode.md
+++ b/.changeset/quiet-deers-explode.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+Support delegation for vote signers

--- a/packages/cli/src/commands/lockedgold/delegate.test.ts
+++ b/packages/cli/src/commands/lockedgold/delegate.test.ts
@@ -1,8 +1,12 @@
+import { serializeSignature, StrongAddress } from '@celo/base'
 import { newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import Register from '../account/register'
+import Authorize from '../releasecelo/authorize'
+import CreateAccount from '../releasecelo/create-account'
 import Delegate from './delegate'
 import Lock from './lock'
 
@@ -32,5 +36,52 @@ testWithAnvilL1('lockedgold:delegate cmd', (web3: Web3) => {
 
     const account2VotingPower = await lockedGold.getAccountTotalGovernanceVotingPower(account2)
     expect(account2VotingPower.toFixed()).toBe('200')
+  })
+
+  it('can delegate as a vote signer for releasecelo contract', async () => {
+    const [beneficiary, owner, voteSigner, refundAddress, delegateeAddress] =
+      (await web3.eth.getAccounts()) as StrongAddress[]
+    const kit = newKitFromWeb3(web3)
+    const accountsWrapper = await kit.contracts.getAccounts()
+    const releaseGoldContractAddress = await deployReleaseGoldContract(
+      web3,
+      owner,
+      beneficiary,
+      owner,
+      refundAddress
+    )
+
+    await testLocallyWithWeb3Node(CreateAccount, ['--contract', releaseGoldContractAddress], web3)
+    await testLocallyWithWeb3Node(
+      Authorize,
+      [
+        '--contract',
+        releaseGoldContractAddress,
+        '--role',
+        'vote',
+        '--signer',
+        voteSigner,
+        '--signature',
+        serializeSignature(
+          await accountsWrapper.generateProofOfKeyPossession(releaseGoldContractAddress, voteSigner)
+        ),
+      ],
+      web3
+    )
+    await testLocallyWithWeb3Node(Lock, ['--from', beneficiary, '--value', '100'], web3)
+
+    const createAccountTx = await accountsWrapper.createAccount().send({ from: delegateeAddress })
+    await createAccountTx.waitReceipt()
+
+    await testLocallyWithWeb3Node(
+      Delegate,
+      ['--from', voteSigner, '--to', delegateeAddress, '--percent', '100'],
+      web3
+    )
+
+    const lockedGold = await kit.contracts.getLockedGold()
+    const delegateInfo = await lockedGold.getDelegateInfo(releaseGoldContractAddress)
+
+    expect(delegateInfo.delegatees).toContain(delegateeAddress)
   })
 })

--- a/packages/cli/src/commands/lockedgold/delegate.ts
+++ b/packages/cli/src/commands/lockedgold/delegate.ts
@@ -37,9 +37,9 @@ export default class Delegate extends BaseCommand {
     const percent = new BigNumber(res.flags.percent).div(100)
     const percentFixed = toFixed(percent)
 
-    await newCheckBuilder(this)
+    await newCheckBuilder(this, address)
       .addCheck(`Value [${percentFixed}] is > 0 and <=100`, () => percent.gt(0) && percent.lte(100))
-      .isAccount(address)
+      .isVoteSignerOrAccount()
       .isAccount(to)
       .runChecks()
 


### PR DESCRIPTION
### Description

This PR adds support for delegating locked gold as a vote signer. 

#### Other changes

Added a test that covers a case when vote signer is authorized for a `ReleaseGold` contract instance.

### Tested

Ran tests locally.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for delegation in the voting process for vote signers within the `lockedgold` command of the CLI, enhancing governance capabilities.

### Detailed summary
- Updated the `delegate.ts` file to include `address` in the `newCheckBuilder`.
- Changed validation from `.isAccount(address)` to `.isVoteSignerOrAccount()`.
- Added a new test case in `delegate.test.ts` for delegating as a vote signer.
- Included deployment of a `releaseGoldContract` in the test setup.
- Verified delegation functionality and ensured the `delegateeAddress` is recorded correctly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->