### PR TITLE
Add epochs:send-validator-payment command

### DIFF
--- a/.changeset/happy-lobsters-appear.md
+++ b/.changeset/happy-lobsters-appear.md
@@ -1,0 +1,5 @@
+---
+'@celo/contractkit': patch
+---
+
+Expose `systemAlreadyInitialized` and `sendValidatorPayment` methods for `EpochManager` contract wrapper

--- a/.changeset/slimy-beds-share.md
+++ b/.changeset/slimy-beds-share.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+Add `epochs:send-validator-payment` command to support sending validator, their group and delegation beneficiary allocated epoch payments

--- a/docs/command-line-interface/epochs.md
+++ b/docs/command-line-interface/epochs.md
@@ -4,6 +4,7 @@
 Finishes next epoch process.
 
 * [`celocli epochs:finish`](#celocli-epochsfinish)
+* [`celocli epochs:send-validator-payment`](#celocli-epochssend-validator-payment)
 * [`celocli epochs:start`](#celocli-epochsstart)
 * [`celocli epochs:switch`](#celocli-epochsswitch)
 
@@ -65,6 +66,69 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/epochs/finish.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/epochs/finish.ts)_
+
+## `celocli epochs:send-validator-payment`
+
+Sends the allocated epoch payment to a validator, their group, and delegation beneficiary.
+
+```
+USAGE
+  $ celocli epochs:send-validator-payment --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --for
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k <value> | --useLedger | ] [-n
+    <value>] [--gasCurrency 0x1234567890123456789012345678901234567890]
+    [--ledgerAddresses <value> ] [--ledgerLiveMode ] [--globalHelp]
+
+FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the validator to send the payment to
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Address of the sender
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
+
+  --useLedger
+      Set it to use a ledger wallet
+
+DESCRIPTION
+  Sends the allocated epoch payment to a validator, their group, and delegation
+  beneficiary.
+
+EXAMPLES
+  send-validator-payment --for 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
+```
+
+_See code: [src/commands/epochs/send-validator-payment.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/epochs/send-validator-payment.ts)_
 
 ## `celocli epochs:start`
 

--- a/docs/sdk/contractkit/classes/wrappers_EpochManager.EpochManagerWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_EpochManager.EpochManagerWrapper.md
@@ -35,7 +35,9 @@ Contract handling epoch management.
 - [isOnEpochProcess](wrappers_EpochManager.EpochManagerWrapper.md#isonepochprocess)
 - [isTimeForNextEpoch](wrappers_EpochManager.EpochManagerWrapper.md#istimefornextepoch)
 - [methodIds](wrappers_EpochManager.EpochManagerWrapper.md#methodids)
+- [sendValidatorPayment](wrappers_EpochManager.EpochManagerWrapper.md#sendvalidatorpayment)
 - [startNextEpochProcess](wrappers_EpochManager.EpochManagerWrapper.md#startnextepochprocess)
+- [systemAlreadyInitialized](wrappers_EpochManager.EpochManagerWrapper.md#systemalreadyinitialized)
 
 ### Accessors
 
@@ -164,7 +166,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:67](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L67)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:68](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L68)
 
 ___
 
@@ -308,7 +310,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:52](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L52)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:53](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L53)
 
 ___
 
@@ -422,6 +424,30 @@ ___
 
 ___
 
+### sendValidatorPayment
+
+• **sendValidatorPayment**: (...`args`: [validator: string]) => `CeloTransactionObject`\<`void`\>
+
+#### Type declaration
+
+▸ (`...args`): `CeloTransactionObject`\<`void`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [validator: string] |
+
+##### Returns
+
+`CeloTransactionObject`\<`void`\>
+
+#### Defined in
+
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:69](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L69)
+
+___
+
 ### startNextEpochProcess
 
 • **startNextEpochProcess**: (...`args`: []) => `CeloTransactionObject`\<`void`\>
@@ -442,7 +468,31 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:66](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L66)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:67](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L67)
+
+___
+
+### systemAlreadyInitialized
+
+• **systemAlreadyInitialized**: (...`args`: []) => `Promise`\<`boolean`\>
+
+#### Type declaration
+
+▸ (`...args`): `Promise`\<`boolean`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [] |
+
+##### Returns
+
+`Promise`\<`boolean`\>
+
+#### Defined in
+
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:52](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L52)
 
 ## Accessors
 
@@ -476,7 +526,7 @@ BaseWrapperForGoverning.address
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:69](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L69)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:71](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L71)
 
 ___
 
@@ -490,7 +540,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:131](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L131)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:133](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L133)
 
 ___
 
@@ -510,7 +560,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:82](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L82)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:84](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L84)
 
 ___
 

--- a/docs/sdk/contractkit/modules/wrappers_EpochManager.md
+++ b/docs/sdk/contractkit/modules/wrappers_EpochManager.md
@@ -29,4 +29,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:144](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L144)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:146](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L146)

--- a/packages/cli/src/commands/epochs/send-validator-payment-l2.test.ts
+++ b/packages/cli/src/commands/epochs/send-validator-payment-l2.test.ts
@@ -1,0 +1,91 @@
+import { newKitFromWeb3 } from '@celo/contractkit'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import { activateAllValidatorGroupsVotes } from '../../test-utils/chain-setup'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import SendValidatorPayment from './send-validator-payment'
+
+process.env.NO_SYNCCHECK = 'true'
+
+testWithAnvilL2('epochs:send-validator-payment cmd', (web3) => {
+  let logMock = jest.spyOn(console, 'log')
+  let errorMock = jest.spyOn(console, 'error')
+
+  beforeEach(async () => {
+    logMock.mockClear()
+    errorMock.mockClear()
+
+    await activateAllValidatorGroupsVotes(newKitFromWeb3(web3))
+  })
+
+  it('successfuly sends the payments', async () => {
+    const kit = newKitFromWeb3(web3)
+    const [sender] = await web3.eth.getAccounts()
+    const epochManagerWrapper = await kit.contracts.getEpochManager()
+    const validatorsWrapper = await kit.contracts.getValidators()
+    const electedValidators = await epochManagerWrapper.getElectedAccounts()
+    const validatorAddress = electedValidators[0]
+    const groupAddress = await validatorsWrapper.getValidatorsGroup(validatorAddress)
+    const validatorBalanceBefore = (await kit.getTotalBalance(validatorAddress)).cUSD!
+    const groupBalanceBefore = (await kit.getTotalBalance(groupAddress)).cUSD!
+
+    await testLocallyWithWeb3Node(
+      SendValidatorPayment,
+      ['--for', validatorAddress, '--from', sender],
+      web3
+    )
+
+    // TODO as the numbers are not deterministic, we can't assert the exact values, so it's tested separately
+    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls.slice(0, -1))).toMatchInlineSnapshot(`
+      [
+        [
+          "Running Checks:",
+        ],
+        [
+          "   ✔  0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65 is Validator ",
+        ],
+        [
+          "All checks passed",
+        ],
+        [
+          "SendTransaction: sendValidatorPayment",
+        ],
+        [
+          "txHash: 0xtxhash",
+        ],
+        [
+          "ValidatorEpochPaymentDistributed:",
+        ],
+      ]
+    `)
+
+    const validatorBalanceAfter = (await kit.getTotalBalance(validatorAddress)).cUSD!
+    const groupBalanceAfter = (await kit.getTotalBalance(groupAddress)).cUSD!
+
+    expect(validatorBalanceAfter.gt(validatorBalanceBefore)).toBe(true)
+    expect(groupBalanceAfter.gt(groupBalanceBefore)).toBe(true)
+  })
+
+  it('fails if not a validator', async () => {
+    const [nonValidatorAccount, sender] = await web3.eth.getAccounts()
+
+    await expect(
+      testLocallyWithWeb3Node(
+        SendValidatorPayment,
+        ['--for', nonValidatorAccount, '--from', sender],
+        web3
+      )
+    ).rejects.toMatchInlineSnapshot(`[Error: Some checks didn't pass!]`)
+
+    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "Running Checks:",
+        ],
+        [
+          "   ✘  0x5409ED021D9299bf6814279A6A1411A7e866A631 is Validator ",
+        ],
+      ]
+    `)
+    expect(stripAnsiCodesFromNestedArray(errorMock.mock.calls)).toMatchInlineSnapshot(`[]`)
+  })
+})

--- a/packages/cli/src/commands/epochs/send-validator-payment.test.ts
+++ b/packages/cli/src/commands/epochs/send-validator-payment.test.ts
@@ -1,0 +1,26 @@
+import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import SendValidatorPayment from './send-validator-payment'
+
+process.env.NO_SYNCCHECK = 'true'
+
+testWithAnvilL1('epochs:send-validator-payment cmd', (web3) => {
+  let logMock = jest.spyOn(console, 'log')
+  let errorMock = jest.spyOn(console, 'error')
+
+  beforeEach(() => {
+    logMock.mockClear().mockImplementation()
+    errorMock.mockClear().mockImplementation()
+  })
+
+  it('fails if not on L2', async () => {
+    const [sender, validator] = await web3.eth.getAccounts()
+
+    await expect(
+      testLocallyWithWeb3Node(SendValidatorPayment, ['--for', validator, '--from', sender], web3)
+    ).rejects.toMatchInlineSnapshot(`[Error: This command is only available on L2]`)
+
+    expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`[]`)
+    expect(stripAnsiCodesFromNestedArray(errorMock.mock.calls)).toMatchInlineSnapshot(`[]`)
+  })
+})

--- a/packages/cli/src/commands/epochs/send-validator-payment.ts
+++ b/packages/cli/src/commands/epochs/send-validator-payment.ts
@@ -1,0 +1,43 @@
+import { BaseCommand } from '../../base'
+import { newCheckBuilder } from '../../utils/checks'
+import { displaySendTx } from '../../utils/cli'
+import { CustomFlags } from '../../utils/command'
+
+export default class SendValidatorPayment extends BaseCommand {
+  static description =
+    'Sends the allocated epoch payment to a validator, their group, and delegation beneficiary.'
+
+  static flags = {
+    ...BaseCommand.flags,
+    from: CustomFlags.address({
+      description: 'Address of the sender',
+      required: true,
+    }),
+    for: CustomFlags.address({
+      description: 'Address of the validator to send the payment to',
+      required: true,
+    }),
+  }
+
+  static args = {}
+
+  static examples = ['send-validator-payment --for 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95']
+
+  async run() {
+    const kit = await this.getKit()
+    const res = await this.parse(SendValidatorPayment)
+
+    const epochManager = await kit.contracts.getEpochManager()
+
+    // TODO(L2): Remove once migrated to L2
+    if (!(await epochManager.systemAlreadyInitialized())) {
+      this.error('This command is only available on L2')
+    }
+
+    await newCheckBuilder(this).isValidator(res.flags.for).runChecks()
+
+    const tx = epochManager.sendValidatorPayment(res.flags.for)
+
+    await displaySendTx('sendValidatorPayment', tx, {}, 'ValidatorEpochPaymentDistributed')
+  }
+}

--- a/packages/sdk/contractkit/src/wrappers/EpochManager.ts
+++ b/packages/sdk/contractkit/src/wrappers/EpochManager.ts
@@ -49,6 +49,7 @@ export class EpochManagerWrapper extends BaseWrapperForGoverning<EpochManager> {
   isTimeForNextEpoch = proxyCall(this.contract.methods.isTimeForNextEpoch)
   getElectedAccounts = proxyCall(this.contract.methods.getElectedAccounts)
   getElectedSigners = proxyCall(this.contract.methods.getElectedSigners)
+  systemAlreadyInitialized = proxyCall(this.contract.methods.systemAlreadyInitialized)
   getEpochProcessingStatus = proxyCall(
     this.contract.methods.epochProcessing,
     undefined,
@@ -65,6 +66,7 @@ export class EpochManagerWrapper extends BaseWrapperForGoverning<EpochManager> {
 
   startNextEpochProcess = proxySend(this.connection, this.contract.methods.startNextEpochProcess)
   finishNextEpochProcess = proxySend(this.connection, this.contract.methods.finishNextEpochProcess)
+  sendValidatorPayment = proxySend(this.connection, this.contract.methods.sendValidatorPayment)
 
   finishNextEpochProcessTx = async () => {
     const elected = await this.getElectedAccounts()


### PR DESCRIPTION
### Description

This PR adds `epochs:send-validator-payment` command to distribute validator epoch payments.

#### Other changes

Exposed needed contract methods on `EpochManager` wrapper.

### Tested

Ran tests locally.

### How to QA

TBD test on alfajores?

### Related issues

- Fixes #500 
