### PR TITLE
chore: add changeset

### DIFF
--- a/.changeset/lemon-squids-report.md
+++ b/.changeset/lemon-squids-report.md
@@ -1,0 +1,7 @@
+---
+'@celo/wallet-ledger': minor
+'@celo/viem-account-ledger': minor
+---
+
+Add support for signTypedData in @celo/viem-account-ledger and @celo/wallet-ledger
+when using with the `ethereum` ledger app.

--- a/.changeset/lemon-squids-report.md
+++ b/.changeset/lemon-squids-report.md
@@ -3,5 +3,5 @@
 '@celo/viem-account-ledger': minor
 ---
 
-Add support for signTypedData in @celo/viem-account-ledger and @celo/wallet-ledger
+ Add  (Beta) support for signTypedData in @celo/viem-account-ledger and @celo/wallet-ledger when using with the `ethereum` ledger app.
 when using with the `ethereum` ledger app.


### PR DESCRIPTION
Big oopsie related to #513 no having changesets

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces beta support for `signTypedData` in the `@celo/viem-account-ledger` and `@celo/wallet-ledger` packages when used with the `ethereum` ledger app.

### Detailed summary
- Added beta support for `signTypedData` in `@celo/viem-account-ledger`.
- Added beta support for `signTypedData` in `@celo/wallet-ledger`.
- Support is specifically for use with the `ethereum` ledger app.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->