### PR TITLE
true release mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@celo/celocli": "6.0.0",


### PR DESCRIPTION
merging will create a version packages PR

<!-- start pr-codex -->

---

## PR-Codex overview
This PR changes the mode setting in the `.changeset/pre.json` file from `pre` to `exit`, indicating a shift in the release process.

### Detailed summary
- Changed `"mode"` from `"pre"` to `"exit"` in `.changeset/pre.json` 
- The `"tag"` remains as `"beta"` 
- The initial version for `@celo/celocli` is set to `"6.0.0"`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->