### PR TITLE
need to call epoch manger on l2.

### DIFF
--- a/packages/cli/src/commands/election/current-l2.test.ts
+++ b/packages/cli/src/commands/election/current-l2.test.ts
@@ -29,47 +29,11 @@ testWithAnvilL2('election:current cmd', async (web3: Web3) => {
       anotherValidatorAddress,
     ] = await web3.eth.getAccounts()
 
-    // we just need getCurrentValidatorSigners and it cannot be mocked directly
-    // on ElectionWrapper.prototype because of the fact that it's implemented as
-    // proxyCall and apparently jest cannot mock this type of function declaration
-    // which results in an error
-    const electionMock = {
-      getCurrentValidatorSigners: jest.fn().mockImplementation(async () => {
-        return [signerAddress, anotherSignerAddress]
-      }),
-    }
-    const getValidatorFromSignerMock = jest.spyOn(
-      ValidatorsWrapper.prototype,
-      'getValidatorFromSigner'
-    )
-
-    getValidatorFromSignerMock
-      .mockImplementationOnce(async () => ({
-        address: validatorAddress,
-        affiliation: groupAddress,
-        blsPublicKey: '0x-bls-public-key-1',
-        ecdsaPublicKey: '0x-ecdsa-public-key-1',
-        name: 'Validator #1',
-        score: new BigNumber(85),
-        signer: signerAddress,
-      }))
-      .mockImplementationOnce(async () => ({
-        address: anotherValidatorAddress,
-        affiliation: anotherGroupAddress,
-        blsPublicKey: '0x-bls-public-key-2',
-        ecdsaPublicKey: '0x-ecdsa-public-key-2',
-        name: 'Validator #2',
-        score: new BigNumber(100),
-        signer: anotherSignerAddress,
-      }))
     await setupGroupAndAffiliateValidator(kit, groupAddress, validatorAddress)
     await setupGroupAndAffiliateValidator(kit, anotherGroupAddress, anotherValidatorAddress)
 
     await registerAccount(kit, signerAddress)
     await registerAccount(kit, anotherSignerAddress)
-
-    const getElectionMock = jest.spyOn(WrapperCache.prototype, 'getElection')
-    getElectionMock.mockImplementation(async () => electionMock as any as ElectionWrapper)
 
     const logMock = jest.spyOn(console, 'log')
     const warnMock = jest.spyOn(console, 'warn')
@@ -84,11 +48,27 @@ testWithAnvilL2('election:current cmd', async (web3: Web3) => {
       ",
         ],
         [
-          "${validatorAddress},Validator #1,${groupAddress},85,0x-ecdsa-public-key-1,0x-bls-public-key-1,${signerAddress}
+          "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65,,0x70997970C51812dc3A010C7d01b50e0d17dc79C8,0,0xbf6ee64a8d2fdc551ec8bb9ef862ef6b4bcb1805cdc520c3aa5866c0575fd3b514c5562c3caae7aec5cd6f144b57135c75b6f6cea059c3d08d1f39a9c227219d,0x010101010101010101010101010101010101010101010101010101010101010202020202020202020202020202020202020202020202020202020202020202030303030303030303030303030303030303030303030303030303030303030304,0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65
       ",
         ],
         [
-          "${anotherValidatorAddress},Validator #2,${anotherGroupAddress},100,0x-ecdsa-public-key-2,0x-bls-public-key-2,${anotherSignerAddress}
+          "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc,,0x70997970C51812dc3A010C7d01b50e0d17dc79C8,0,0x37b84de6947b243626cc8b977bb1f1632610614842468dfa8f35dcbbc55a515e47f6fe259cffc671a719eaef444a0d689b16a90051985a13661840cf5e221503,0x010101010101010101010101010101010101010101010101010101010101010202020202020202020202020202020202020202020202020202020202020202030303030303030303030303030303030303030303030303030303030303030304,0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc
+      ",
+        ],
+        [
+          "0x976EA74026E726554dB657fA54763abd0C3a0aa9,,0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC,0,0x9a4ab212cb92775d227af4237c20b81f4221e9361d29007dfc16c79186b577cb6ba3f1b582ad0b5572c93f47e7506d66df7f2af05fa1828de0e511aac7b97828,0x010101010101010101010101010101010101010101010101010101010101010202020202020202020202020202020202020202020202020202020202020202030303030303030303030303030303030303030303030303030303030303030304,0x976EA74026E726554dB657fA54763abd0C3a0aa9
+      ",
+        ],
+        [
+          "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955,,0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC,0,0x01f2bf1fa920e77a43c7aec2587d0b3814093420cc59a9b3ad66dd5734dda7be6f8b7de790eac3a720fd8e4bcb9eae9434f843d3cec111d9e07adeddeae090f2,0x010101010101010101010101010101010101010101010101010101010101010202020202020202020202020202020202020202020202020202020202020202030303030303030303030303030303030303030303030303030303030303030304,0x14dC79964da2C08b23698B3D3cc7Ca32193d9955
+      ",
+        ],
+        [
+          "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,,0x90F79bf6EB2c4f870365E785982E1f101E93b906,0,0x931e7fda8da226f799f791eefc9afebcd7ae2b1b19a03c5eaa8d72122d9fe74d887a3962ff861190b531ab31ee82f0d7f255dfe3ab73ca627bd70ab3d1cbb417,0x010101010101010101010101010101010101010101010101010101010101010202020202020202020202020202020202020202020202020202020202020202030303030303030303030303030303030303030303030303030303030303030304,0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f
+      ",
+        ],
+        [
+          "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720,,0x90F79bf6EB2c4f870365E785982E1f101E93b906,0,0x3255458e24278e31d5940f304b16300fdff3f6efd3e2a030b5818310ac67af45e28d057e6a332d07e0c5ab09d6947fd4eed1a646edbf224e2d2fec6f49f90abc,0x010101010101010101010101010101010101010101010101010101010101010202020202020202020202020202020202020202020202020202020202020202030303030303030303030303030303030303030303030303030303030303030304,0xa0Ee7A142d267C1f36714E4a8F75612F20a79720
       ",
         ],
       ]
@@ -161,11 +141,27 @@ testWithAnvilL2('election:current cmd', async (web3: Web3) => {
       ",
         ],
         [
-          "${validatorAddress},Validator #1,${signerAddress},${signerAddress},no
+          "0x78dc5D2D739606d31509C31d654056A45185ECb6,Validator #1,0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65,0x5409ED021D9299bf6814279A6A1411A7e866A631,CHANGING
       ",
         ],
         [
-          "${anotherValidatorAddress},Validator #2,${anotherSignerAddress},${changingSignerAddress},CHANGING
+          "0xA8dDa8d7F5310E4A9E24F8eBA77E091Ac264f872,Validator #2,0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc,0x06cEf8E666768cC40Cc78CF93d9611019dDcB628,CHANGING
+      ",
+        ],
+        [
+          "0x976EA74026E726554dB657fA54763abd0C3a0aa9,,0x976EA74026E726554dB657fA54763abd0C3a0aa9,0x976EA74026E726554dB657fA54763abd0C3a0aa9,no
+      ",
+        ],
+        [
+          "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955,,0x14dC79964da2C08b23698B3D3cc7Ca32193d9955,0x14dC79964da2C08b23698B3D3cc7Ca32193d9955,no
+      ",
+        ],
+        [
+          "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,,0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,no
+      ",
+        ],
+        [
+          "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720,,0xa0Ee7A142d267C1f36714E4a8F75612F20a79720,0xa0Ee7A142d267C1f36714E4a8F75612F20a79720,no
       ",
         ],
       ]

--- a/packages/cli/src/commands/election/current.ts
+++ b/packages/cli/src/commands/election/current.ts
@@ -29,8 +29,13 @@ export default class ElectionCurrent extends BaseCommand {
     const res = await this.parse(ElectionCurrent)
     ux.action.start('Fetching currently elected Validators')
     const election = await kit.contracts.getElection()
+    const epochManagerWrapper = await kit.contracts.getEpochManager()
     const validators = await kit.contracts.getValidators()
-    const signers = await election.getCurrentValidatorSigners()
+    const isCel2 = await this.isCel2()
+
+    const signers = await (isCel2
+      ? epochManagerWrapper.getElectedSigners()
+      : election.getCurrentValidatorSigners())
     if (res.flags.valset) {
       const validatorList = await Promise.all(
         signers.map(async (addr) => {


### PR DESCRIPTION

### Description

function removed need to call alt

#### Other changes

no

### Tested

removed functions that mocked the calls 

### How to QA

run the election:current command against alfajores

### Related issues

- Fixes #520 


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the election command by integrating the `EpochManager` to fetch elected signers based on the environment (Cel2 or not), while also updating the tests to accommodate new data structures and mock implementations.

### Detailed summary
- Introduced `epochManagerWrapper` to fetch elected signers if `isCel2` is true.
- Updated the logic to retrieve signers based on the environment.
- Removed legacy mocking for `getCurrentValidatorSigners`.
- Enhanced test cases with new validator data and updated assertions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->