### PR TITLE
fix election:current for L1

### DIFF
--- a/.changeset/spotty-geese-shake.md
+++ b/.changeset/spotty-geese-shake.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Fixes EpochManager not available error for some L1 commands

--- a/packages/cli/src/commands/election/current.test.ts
+++ b/packages/cli/src/commands/election/current.test.ts
@@ -1,8 +1,9 @@
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newRegistry } from '@celo/abis/web3/Registry'
+import { newKitFromWeb3, NULL_ADDRESS, REGISTRY_CONTRACT_ADDRESS } from '@celo/contractkit'
 import { WrapperCache } from '@celo/contractkit/lib/contract-cache'
 import { ElectionWrapper } from '@celo/contractkit/lib/wrappers/Election'
 import { ValidatorsWrapper } from '@celo/contractkit/lib/wrappers/Validators'
-import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
+import { asCoreContractsOwner, testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
@@ -18,6 +19,14 @@ afterEach(async () => {
 })
 
 testWithAnvilL1('election:current cmd', async (web3: Web3) => {
+  beforeEach(async () => {
+    const registryContract = newRegistry(web3, REGISTRY_CONTRACT_ADDRESS)
+
+    await asCoreContractsOwner(web3, async (from) => {
+      await registryContract.methods.setAddressFor('EpochManager', NULL_ADDRESS).send({ from })
+    })
+  })
+
   it('shows list with no --valset provided', async () => {
     const kit = newKitFromWeb3(web3)
     const [

--- a/packages/cli/src/commands/epochs/send-validator-payment.ts
+++ b/packages/cli/src/commands/epochs/send-validator-payment.ts
@@ -29,12 +29,12 @@ export default class SendValidatorPayment extends BaseCommand {
     const kit = await this.getKit()
     const res = await this.parse(SendValidatorPayment)
 
-    const epochManager = await kit.contracts.getEpochManager()
-
     // TODO(L2): Remove once migrated to L2
     if (!(await this.isCel2())) {
       this.error('This command is only available on L2')
     }
+
+    const epochManager = await kit.contracts.getEpochManager()
 
     await newCheckBuilder(this).isValidator(res.flags.for).runChecks()
 


### PR DESCRIPTION
### Description

Fixes `election:current` command for L1 as it currently results in an error.

#### Other changes

None.

### Tested

Ran the tests locally, ran command from section below. 

### How to QA

Ran following command to make sure it works for L1:

`yarn workspace @celo/celocli run dev election:current --node mainnet`

and for L2:

`yarn workspace @celo/celocli run dev election:current --node alfajores`

In both cases it should output a table instead of an error.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `EpochManager` availability error for certain L1 commands and refactoring code related to fetching signers in the `ElectionCurrent` command.

### Detailed summary
- Fixed the `EpochManager` not available error in `send-validator-payment.ts`.
- Updated the `current.ts` command to use a new `getSigners` method for fetching signers.
- Refactored signers fetching logic for better clarity and separation of concerns in `current.ts`.
- Added a setup for testing `current.test.ts` to handle `EpochManager` address correctly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->