### PR TITLE
Upgrade ABIs and devchain-anvil

### DIFF
--- a/packages/cli/src/commands/network/__snapshots__/contracts-l2.test.ts.snap
+++ b/packages/cli/src/commands/network/__snapshots__/contracts-l2.test.ts.snap
@@ -37,7 +37,7 @@ exports[`network:contracts when version can be obtained runs 2`] = `
   {
     "contract": "Election",
     "proxy": "0xcB4E4A207DC1C220bd54B2A983E32e923c32E544",
-    "implementation": "0x6710D9980C55D7963B4dA671A159523BB5b4F6d1",
+    "implementation": "0x5343E67178598d1157Aa7f3F2f7Fe6977bD1EC21",
     "version": "1.1.4.0"
   },
   {
@@ -55,7 +55,7 @@ exports[`network:contracts when version can be obtained runs 2`] = `
   {
     "contract": "EpochRewards",
     "proxy": "0x535D5EbB846832A2d876380dBccCb84eE5521d3f",
-    "implementation": "0xB4C3e97Ee2acaeb7D840Fde692465903239f213E",
+    "implementation": "0xB8B08E2c2C1582D678bfe68E27DA8360eAc3E1aA",
     "version": "1.1.2.0"
   },
   {
@@ -109,7 +109,7 @@ exports[`network:contracts when version can be obtained runs 2`] = `
   {
     "contract": "Governance",
     "proxy": "0x2EB25B5eb9d5A4f61deb1e4F846343F862eB67D9",
-    "implementation": "0x063BDb2e9A86e8aD2ad9fc488e9E45Dc2a845c3a",
+    "implementation": "0x91175ff600759122459c80b907b6980261D71BE7",
     "version": "1.4.2.0"
   },
   {
@@ -239,7 +239,7 @@ exports[`network:contracts when version cant be obtained still prints rest of co
   {
     "contract": "Election",
     "proxy": "0xcB4E4A207DC1C220bd54B2A983E32e923c32E544",
-    "implementation": "0x6710D9980C55D7963B4dA671A159523BB5b4F6d1",
+    "implementation": "0x5343E67178598d1157Aa7f3F2f7Fe6977bD1EC21",
     "version": "1.2.3.4"
   },
   {
@@ -257,7 +257,7 @@ exports[`network:contracts when version cant be obtained still prints rest of co
   {
     "contract": "EpochRewards",
     "proxy": "0x535D5EbB846832A2d876380dBccCb84eE5521d3f",
-    "implementation": "0xB4C3e97Ee2acaeb7D840Fde692465903239f213E",
+    "implementation": "0xB8B08E2c2C1582D678bfe68E27DA8360eAc3E1aA",
     "version": "1.2.3.4"
   },
   {
@@ -311,7 +311,7 @@ exports[`network:contracts when version cant be obtained still prints rest of co
   {
     "contract": "Governance",
     "proxy": "0x2EB25B5eb9d5A4f61deb1e4F846343F862eB67D9",
-    "implementation": "0x063BDb2e9A86e8aD2ad9fc488e9E45Dc2a845c3a",
+    "implementation": "0x91175ff600759122459c80b907b6980261D71BE7",
     "version": "1.2.3.4"
   },
   {

--- a/packages/cli/src/commands/network/__snapshots__/contracts.test.ts.snap
+++ b/packages/cli/src/commands/network/__snapshots__/contracts.test.ts.snap
@@ -37,7 +37,7 @@ exports[`network:contracts runs 1`] = `
   {
     "contract": "Election",
     "proxy": "0xcB4E4A207DC1C220bd54B2A983E32e923c32E544",
-    "implementation": "0x6710D9980C55D7963B4dA671A159523BB5b4F6d1",
+    "implementation": "0x5343E67178598d1157Aa7f3F2f7Fe6977bD1EC21",
     "version": "1.1.4.0"
   },
   {
@@ -55,7 +55,7 @@ exports[`network:contracts runs 1`] = `
   {
     "contract": "EpochRewards",
     "proxy": "0x535D5EbB846832A2d876380dBccCb84eE5521d3f",
-    "implementation": "0xB4C3e97Ee2acaeb7D840Fde692465903239f213E",
+    "implementation": "0xB8B08E2c2C1582D678bfe68E27DA8360eAc3E1aA",
     "version": "1.1.2.0"
   },
   {
@@ -109,7 +109,7 @@ exports[`network:contracts runs 1`] = `
   {
     "contract": "Governance",
     "proxy": "0x2EB25B5eb9d5A4f61deb1e4F846343F862eB67D9",
-    "implementation": "0x063BDb2e9A86e8aD2ad9fc488e9E45Dc2a845c3a",
+    "implementation": "0x91175ff600759122459c80b907b6980261D71BE7",
     "version": "1.4.2.0"
   },
   {

--- a/packages/cli/src/commands/network/parameters-l2.test.ts
+++ b/packages/cli/src/commands/network/parameters-l2.test.ts
@@ -52,7 +52,7 @@ testWithAnvilL2('network:parameters', (web3) => {
       Reserve: 
         frozenReserveGoldDays: 0 
         frozenReserveGoldStartBalance: 0 
-        frozenReserveGoldStartDay: 20077 (~2.008e+4)
+        frozenReserveGoldStartDay: 20122 (~2.012e+4)
         otherReserveAddresses: 
 
         tobinTaxStalenessThreshold: 3153600000 (~3.154e+9)

--- a/packages/cli/src/commands/network/parameters.test.ts
+++ b/packages/cli/src/commands/network/parameters.test.ts
@@ -67,7 +67,7 @@ testWithAnvilL1('network:parameters', (web3: Web3) => {
       Reserve: 
         frozenReserveGoldDays: 0 
         frozenReserveGoldStartBalance: 0 
-        frozenReserveGoldStartDay: 20077 (~2.008e+4)
+        frozenReserveGoldStartDay: 20122 (~2.012e+4)
         otherReserveAddresses: 
 
         tobinTaxStalenessThreshold: 3153600000 (~3.154e+9)

--- a/packages/cli/src/commands/validatorgroup/deregister.test.ts
+++ b/packages/cli/src/commands/validatorgroup/deregister.test.ts
@@ -106,7 +106,7 @@ testWithAnvilL2('validatorgroup:deregister cmd', (web3: Web3) => {
           ]
         `)
         const validators = await kit.contracts.getValidators()
-        expect(validators.isValidatorGroup(groupAddress)).resolves.toBe(true)
+        await expect(validators.isValidatorGroup(groupAddress)).resolves.toBe(true)
       })
     })
     describe('when wait duration for unlocking is over', () => {

--- a/packages/cli/src/commands/validatorgroup/member.test.ts
+++ b/packages/cli/src/commands/validatorgroup/member.test.ts
@@ -140,7 +140,7 @@ testWithAnvilL2('validatorgroup:member cmd', (web3: Web3) => {
             "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
             "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
           ],
-          "membersUpdated": 1734702082,
+          "membersUpdated": 1738619402,
           "name": "cLabs",
           "nextCommission": "0",
           "nextCommissionBlock": "0",

--- a/packages/cli/src/commands/validatorgroup/show.test.ts
+++ b/packages/cli/src/commands/validatorgroup/show.test.ts
@@ -35,7 +35,7 @@ testWithAnvilL2('validatorgroup:show cmd', (web3: Web3) => {
       commission: 0.1
       nextCommission: 0
       nextCommissionBlock: 0
-      membersUpdated: 1734702082
+      membersUpdated: 1738619402
       affiliates: 
       slashingMultiplier: 1
       lastSlashed: 0",

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -32,7 +32,7 @@
     "web3-core-helpers": "1.10.4"
   },
   "devDependencies": {
-    "@celo/devchain-anvil": "12.0.0-canary.54",
+    "@celo/devchain-anvil": "12.0.0-canary.59",
     "@celo/typescript": "workspace:^",
     "@tsconfig/recommended": "^1.0.3",
     "@types/fs-extra": "^8.1.0",

--- a/packages/sdk/contractkit/package.json
+++ b/packages/sdk/contractkit/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@celo/abis": "11.0.0",
-    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.86",
+    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.87",
     "@celo/base": "^7.0.1-beta.0",
     "@celo/connect": "^6.1.1-beta.0",
     "@celo/utils": "^8.0.1-beta.0",

--- a/packages/sdk/governance/package.json
+++ b/packages/sdk/governance/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@celo/abis": "11.0.0",
-    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.86",
+    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.87",
     "@celo/base": "^7.0.1-beta.0",
     "@celo/connect": "^6.1.1-beta.0",
     "@celo/contractkit": "^9.0.1-beta.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1606,10 +1606,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@celo/abis-12@npm:@celo/abis@12.0.0-canary.86":
-  version: 12.0.0-canary.86
-  resolution: "@celo/abis@npm:12.0.0-canary.86"
-  checksum: f3fa23c00b822e6897a8636bba3e68b1f8b1c8283a9d0cf378c2c8d7d724a5728058158da1a19f8e4e61f4cc6809961d88551cfdaf5e3bf2f8678c6daa724280
+"@celo/abis-12@npm:@celo/abis@12.0.0-canary.87":
+  version: 12.0.0-canary.87
+  resolution: "@celo/abis@npm:12.0.0-canary.87"
+  checksum: 87f1ee1cd99bd143fb69b1f65d72e26e408c4295816c18965d584a3d26ce2125769c259151ef249a8cdb18bf22f4408edec65c7d912c9979cb479a6405643f48
   languageName: node
   linkType: hard
 
@@ -1809,7 +1809,7 @@ __metadata:
   resolution: "@celo/contractkit@workspace:packages/sdk/contractkit"
   dependencies:
     "@celo/abis": "npm:11.0.0"
-    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.86"
+    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.87"
     "@celo/base": "npm:^7.0.1-beta.0"
     "@celo/celo-devchain": "npm:^7.0.0"
     "@celo/connect": "npm:^6.1.1-beta.0"
@@ -1861,7 +1861,7 @@ __metadata:
   dependencies:
     "@celo/abis": "npm:^11.0.0"
     "@celo/connect": "npm:^6.1.1-beta.0"
-    "@celo/devchain-anvil": "npm:12.0.0-canary.54"
+    "@celo/devchain-anvil": "npm:12.0.0-canary.59"
     "@celo/typescript": "workspace:^"
     "@tsconfig/recommended": "npm:^1.0.3"
     "@types/fs-extra": "npm:^8.1.0"
@@ -1877,10 +1877,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@celo/devchain-anvil@npm:12.0.0-canary.54":
-  version: 12.0.0-canary.54
-  resolution: "@celo/devchain-anvil@npm:12.0.0-canary.54"
-  checksum: 13e3c8c022e5f4b33ed46fae4a8de735b15b03bdd40cf904e71396db1916f25b09dabd742527f032e46ae5bff4e6a120f16cc93d05b026804b5a59af38fb6de6
+"@celo/devchain-anvil@npm:12.0.0-canary.59":
+  version: 12.0.0-canary.59
+  resolution: "@celo/devchain-anvil@npm:12.0.0-canary.59"
+  checksum: 38aabc49dfd13933d0c52fe06ae7fc3c7da1ba0161e837e96871c70d2c5292a8f0636f58ec94164f800206c5a16306efaad61f589504b572780167987afa44d0
   languageName: node
   linkType: hard
 
@@ -1908,7 +1908,7 @@ __metadata:
   resolution: "@celo/governance@workspace:packages/sdk/governance"
   dependencies:
     "@celo/abis": "npm:11.0.0"
-    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.86"
+    "@celo/abis-12": "npm:@celo/abis@12.0.0-canary.87"
     "@celo/base": "npm:^7.0.1-beta.0"
     "@celo/connect": "npm:^6.1.1-beta.0"
     "@celo/contractkit": "npm:^9.0.1-beta.2"


### PR DESCRIPTION
### Description

This PR bumps up devchain and ABIs version to the latest ones.

#### Other changes

None.

### Tested

Ran tests locally and on CI.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating various configurations, including dependency versions and state variables across multiple test files and snapshots in the `cli` and `sdk` packages.

### Detailed summary
- Updated `membersUpdated` value in `show.test.ts` and `member.test.ts`.
- Changed `frozenReserveGoldStartDay` from `20077` to `20122` in `parameters.test.ts` and `parameters-l2.test.ts`.
- Updated `@celo/devchain-anvil` version from `12.0.0-canary.54` to `12.0.0-canary.59` in `package.json` files.
- Updated `@celo/abis-12` version from `12.0.0-canary.86` to `12.0.0-canary.87` in `package.json` files.
- Modified `implementation` addresses for contracts in `contracts.test.ts.snap` and `contracts-l2.test.ts.snap`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->