### PR TITLE
fix: 404 links in docs

### DIFF
--- a/docs/command-line-interface/autocomplete.md
+++ b/docs/command-line-interface/autocomplete.md
@@ -34,4 +34,4 @@ EXAMPLES
   $ celocli autocomplete --refresh-cache
 ```
 
-_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v3.2.0/src/commands/autocomplete/index.ts)_
+_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/main/src/commands/autocomplete/index.ts)_

--- a/docs/command-line-interface/commands.md
+++ b/docs/command-line-interface/commands.md
@@ -37,4 +37,4 @@ DESCRIPTION
   list all the commands
 ```
 
-_See code: [@oclif/plugin-commands](https://github.com/oclif/plugin-commands/blob/v3.3.4/src/commands/commands.ts)_
+_See code: [@oclif/plugin-commands](https://github.com/oclif/plugin-commands/blob/main/src/commands/commands.ts)_

--- a/docs/command-line-interface/plugins.md
+++ b/docs/command-line-interface/plugins.md
@@ -35,7 +35,7 @@ EXAMPLES
   $ celocli plugins
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v4.3.10/src/commands/plugins/index.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/main/src/commands/plugins/index.ts)_
 
 ## `celocli plugins:install PLUGIN...`
 
@@ -105,7 +105,7 @@ EXAMPLES
   $ celocli plugins:inspect myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v4.3.10/src/commands/plugins/inspect.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/main/src/commands/plugins/inspect.ts)_
 
 ## `celocli plugins:install PLUGIN...`
 
@@ -150,7 +150,7 @@ EXAMPLES
   $ celocli plugins:install someuser/someplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v4.3.10/src/commands/plugins/install.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/main/src/commands/plugins/install.ts)_
 
 ## `celocli plugins:link PLUGIN`
 
@@ -181,7 +181,7 @@ EXAMPLES
   $ celocli plugins:link myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v4.3.10/src/commands/plugins/link.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/main/src/commands/plugins/link.ts)_
 
 ## `celocli plugins:uninstall PLUGIN...`
 
@@ -223,7 +223,7 @@ FLAGS
   --reinstall  Reinstall all plugins after uninstalling.
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v4.3.10/src/commands/plugins/reset.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/main/src/commands/plugins/reset.ts)_
 
 ## `celocli plugins:uninstall PLUGIN...`
 
@@ -251,7 +251,7 @@ EXAMPLES
   $ celocli plugins:uninstall myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v4.3.10/src/commands/plugins/uninstall.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/main/src/commands/plugins/uninstall.ts)_
 
 ## `celocli plugins:uninstall PLUGIN...`
 
@@ -295,4 +295,4 @@ DESCRIPTION
   Update installed plugins.
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v4.3.10/src/commands/plugins/update.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/main/src/commands/plugins/update.ts)_


### PR DESCRIPTION
### Description
I updates outdated or broken links in the following files:
- `autocomplete.md`
- `commands.md`
- `plugins.md`

The old links pointed to specific versions of the `@oclif` plugin repositories (e.g., `v3.2.0`, `v4.3.10`), which are no longer maintained or accessible. The new links now point to the `main` branch of these repositories, ensuring they remain up-to-date and functional.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the links in the documentation for various `@oclif/plugin-*` commands to point to their main branch versions instead of specific version tags.

### Detailed summary
- Updated link for `@oclif/plugin-commands` in `docs/command-line-interface/commands.md`.
- Updated link for `@oclif/plugin-autocomplete` in `docs/command-line-interface/autocomplete.md`.
- Updated links for `@oclif/plugin-plugins` in `docs/command-line-interface/plugins.md` for the following commands:
  - `inspect`
  - `install`
  - `link`
  - `reset`
  - `uninstall`
  - `update`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->