### PR TITLE
feat: add additional checks to the governance:propose descriptionURL flag

### DIFF
--- a/.changeset/grumpy-schools-judge.md
+++ b/.changeset/grumpy-schools-judge.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+Add a check to governance:propose for the flag descriptionURL. The checks verifies that the URL points to the correct governance repository.

--- a/docs/command-line-interface/governance.md
+++ b/docs/command-line-interface/governance.md
@@ -601,7 +601,8 @@ FLAGS
       (required) Amount of Celo to attach to proposal
 
   --descriptionURL=https://www.celo.org
-      (required) A URL where further information about the proposal can be viewed
+      (required) A URL where further information about the proposal can be viewed. This
+      needs to be a valid proposal URL on https://github.com/celo-org/governance
 
   --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
       Address of the multi-sig contract
@@ -650,9 +651,9 @@ DESCRIPTION
   Submit a governance proposal
 
 EXAMPLES
-  propose --jsonTransactions ./transactions.json --deposit 10000e18 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631 --descriptionURL https://gist.github.com/yorhodes/46430eacb8ed2f73f7bf79bef9d58a33
+  propose --jsonTransactions ./transactions.json --deposit 10000e18 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631 --descriptionURL https://github.com/celo-org/governance/blob/main/CGPs/cgp-00000.md
 
-  propose --jsonTransactions ./transactions.json --deposit 10000e18 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631  --useMultiSig --for 0x6c3dDFB1A9e73B5F49eDD46624F4954Bf66CAe93 --descriptionURL https://gist.github.com/yorhodes/46430eacb8ed2f73f7bf79bef9d58a33
+  propose --jsonTransactions ./transactions.json --deposit 10000e18 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631  --useMultiSig --for 0x6c3dDFB1A9e73B5F49eDD46624F4954Bf66CAe93 --descriptionURL https://github.com/celo-org/governance/blob/main/CGPs/gcp-00000.md
 
 FLAG DESCRIPTIONS
   -n, --node=<value>  URL of the node to run commands against or an alias

--- a/docs/command-line-interface/governance.md
+++ b/docs/command-line-interface/governance.md
@@ -576,8 +576,8 @@ Submit a governance proposal
 ```
 USAGE
   $ celocli governance:propose --jsonTransactions <value> --deposit <value> --from
-    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --descriptionURL https://www.celo.org [-k
-    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --descriptionURL <value> [-k <value> |
+    --useLedger | ] [-n <value>] [--gasCurrency
     0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
     [--ledgerLiveMode ] [--globalHelp] [--for 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
     [--useMultiSig | --useSafe]] [--safeAddress
@@ -600,7 +600,7 @@ FLAGS
   --deposit=<value>
       (required) Amount of Celo to attach to proposal
 
-  --descriptionURL=https://www.celo.org
+  --descriptionURL=<value>
       (required) A URL where further information about the proposal can be viewed. This
       needs to be a valid proposal URL on https://github.com/celo-org/governance
 

--- a/packages/cli/src/commands/governance/propose-l2.test.ts
+++ b/packages/cli/src/commands/governance/propose-l2.test.ts
@@ -12,7 +12,11 @@ import { ux } from '@oclif/core'
 import Safe, { getSafeAddressFromDeploymentTx } from '@safe-global/protocol-kit'
 import * as fs from 'fs'
 import Web3 from 'web3'
-import { EXTRA_LONG_TIMEOUT_MS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import {
+  EXTRA_LONG_TIMEOUT_MS,
+  stripAnsiCodesAndTxHashes,
+  testLocallyWithWeb3Node,
+} from '../../test-utils/cliUtils'
 import { createMultisig, setupSafeContracts } from '../../test-utils/multisigUtils'
 import Approve from '../multisig/approve'
 import Propose from './propose'
@@ -191,7 +195,7 @@ testWithAnvilL2(
             '--from',
             accounts[0],
             '--descriptionURL',
-            'https://example.com',
+            'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
           ],
           web3
         )
@@ -255,7 +259,7 @@ testWithAnvilL2(
             '--for',
             multisigWithOneSigner,
             '--descriptionURL',
-            'https://dummyurl.com',
+            'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
           ],
           web3
         )
@@ -320,7 +324,7 @@ testWithAnvilL2(
             '--for',
             multisigWithTwoSigners,
             '--descriptionURL',
-            'https://dummyurl.com',
+            'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
           ],
           web3
         )
@@ -407,7 +411,7 @@ testWithAnvilL2(
               '--safeAddress',
               safeAddress,
               '--descriptionURL',
-              'https://dummyurl.com',
+              'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
             ],
             web3
           )
@@ -480,7 +484,7 @@ testWithAnvilL2(
               '--safeAddress',
               safeAddress,
               '--descriptionURL',
-              'https://dummyurl.com',
+              'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
             ],
             web3
           )
@@ -501,7 +505,7 @@ testWithAnvilL2(
                 '--safeAddress',
                 safeAddress,
                 '--descriptionURL',
-                'https://dummyurl.com',
+                'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
               ],
               web3
             )
@@ -548,7 +552,7 @@ testWithAnvilL2(
             '--from',
             accounts[0],
             '--descriptionURL',
-            'https://dummyurl.com',
+            'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
             '--force',
             '--noInfo',
           ],
@@ -595,7 +599,7 @@ testWithAnvilL2(
             '--from',
             accounts[0],
             '--descriptionURL',
-            'https://dummyurl.com',
+            'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
             '--force',
             '--noInfo',
           ],
@@ -638,6 +642,35 @@ testWithAnvilL2(
     )
 
     test(
+      'fails when descriptionURl is invalid',
+      async () => {
+        const logMock = jest.spyOn(console, 'log')
+        await expect(
+          testLocallyWithWeb3Node(
+            Propose,
+            [
+              '--from',
+              accounts[0],
+              '--deposit',
+              '0',
+              '--jsonTransactions',
+              './exampleProposal.json',
+              '--descriptionURL',
+              'https://github.com/suspicious-org/governance/blob/main/CGPs/cgp-123.md',
+            ],
+            web3
+          )
+        ).rejects.toThrow("Some checks didn't pass!")
+        expect(logMock.mock.calls.at(-1)!.map(stripAnsiCodesAndTxHashes)).toMatchInlineSnapshot(`
+              [
+                "   ✘  descriptionURL is a valid url on the celo-org/governance repository descriptionURL needs to starts with \`https://github.com/celo-org/governance/blob/main/CGPs/\`",
+              ]
+          `)
+      },
+      EXTRA_LONG_TIMEOUT_MS
+    )
+
+    test(
       'can submit empty proposal',
       async () => {
         await testLocallyWithWeb3Node(
@@ -650,7 +683,7 @@ testWithAnvilL2(
             '--jsonTransactions',
             './exampleProposal.json',
             '--descriptionURL',
-            'https://example.com',
+            'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
           ],
           web3
         )
@@ -673,7 +706,7 @@ testWithAnvilL2(
             '--jsonTransactions',
             './exampleProposal.json',
             '--descriptionURL',
-            'https://example.com',
+            'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
           ],
           web3
         )
@@ -699,7 +732,7 @@ testWithAnvilL2(
             '--jsonTransactions',
             './exampleProposal.json',
             '--descriptionURL',
-            'https://example.com',
+            'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
           ],
           web3
         )

--- a/packages/cli/src/commands/governance/propose-l2.test.ts
+++ b/packages/cli/src/commands/governance/propose-l2.test.ts
@@ -12,11 +12,7 @@ import { ux } from '@oclif/core'
 import Safe, { getSafeAddressFromDeploymentTx } from '@safe-global/protocol-kit'
 import * as fs from 'fs'
 import Web3 from 'web3'
-import {
-  EXTRA_LONG_TIMEOUT_MS,
-  stripAnsiCodesAndTxHashes,
-  testLocallyWithWeb3Node,
-} from '../../test-utils/cliUtils'
+import { EXTRA_LONG_TIMEOUT_MS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import { createMultisig, setupSafeContracts } from '../../test-utils/multisigUtils'
 import Approve from '../multisig/approve'
 import Propose from './propose'
@@ -644,7 +640,6 @@ testWithAnvilL2(
     test(
       'fails when descriptionURl is invalid',
       async () => {
-        const logMock = jest.spyOn(console, 'log')
         await expect(
           testLocallyWithWeb3Node(
             Propose,
@@ -658,14 +653,14 @@ testWithAnvilL2(
               '--descriptionURL',
               'https://github.com/suspicious-org/governance/blob/main/CGPs/cgp-123.md',
             ],
+
             web3
           )
-        ).rejects.toThrow("Some checks didn't pass!")
-        expect(logMock.mock.calls.at(-1)!.map(stripAnsiCodesAndTxHashes)).toMatchInlineSnapshot(`
-              [
-                "   ✘  descriptionURL is a valid url on the celo-org/governance repository descriptionURL needs to starts with \`https://github.com/celo-org/governance/blob/main/CGPs/\`",
-              ]
-          `)
+        ).rejects.toThrowErrorMatchingInlineSnapshot(`
+          "Parsing --descriptionURL 
+          	\`https://github.com/suspicious-org/governance/blob/main/CGPs/cgp-123.md\` is not a valid descriptionURL, it must start with \`https://github.com/celo-org/governance/blob/main/CGPs/\`
+          See more help with --help"
+        `)
       },
       EXTRA_LONG_TIMEOUT_MS
     )

--- a/packages/cli/src/commands/governance/propose.test.ts
+++ b/packages/cli/src/commands/governance/propose.test.ts
@@ -6,11 +6,7 @@ import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import * as fs from 'fs'
 import Web3 from 'web3'
-import {
-  EXTRA_LONG_TIMEOUT_MS,
-  stripAnsiCodesAndTxHashes,
-  testLocallyWithWeb3Node,
-} from '../../test-utils/cliUtils'
+import { EXTRA_LONG_TIMEOUT_MS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import Approve from '../multisig/approve'
 import Propose from './propose'
@@ -457,7 +453,6 @@ testWithAnvilL1('governance:propose cmd', (web3: Web3) => {
   test(
     'fails when descriptionURl is invalid',
     async () => {
-      const logMock = jest.spyOn(console, 'log')
       await expect(
         testLocallyWithWeb3Node(
           Propose,
@@ -471,13 +466,13 @@ testWithAnvilL1('governance:propose cmd', (web3: Web3) => {
             '--descriptionURL',
             'https://github.com/suspicious-org/governance/blob/main/CGPs/cgp-123.md',
           ],
+
           web3
         )
-      ).rejects.toThrow("Some checks didn't pass!")
-      expect(logMock.mock.calls.at(-1)!.map(stripAnsiCodesAndTxHashes)).toMatchInlineSnapshot(`
-          [
-            "   ✘  descriptionURL is a valid url on the celo-org/governance repository descriptionURL needs to starts with \`https://github.com/celo-org/governance/blob/main/CGPs/\`",
-          ]
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`
+        "Parsing --descriptionURL 
+        	\`https://github.com/suspicious-org/governance/blob/main/CGPs/cgp-123.md\` is not a valid descriptionURL, it must start with \`https://github.com/celo-org/governance/blob/main/CGPs/\`
+        See more help with --help"
       `)
     },
     EXTRA_LONG_TIMEOUT_MS

--- a/packages/cli/src/commands/governance/propose.test.ts
+++ b/packages/cli/src/commands/governance/propose.test.ts
@@ -6,7 +6,11 @@ import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import { ux } from '@oclif/core'
 import * as fs from 'fs'
 import Web3 from 'web3'
-import { EXTRA_LONG_TIMEOUT_MS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import {
+  EXTRA_LONG_TIMEOUT_MS,
+  stripAnsiCodesAndTxHashes,
+  testLocallyWithWeb3Node,
+} from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import Approve from '../multisig/approve'
 import Propose from './propose'
@@ -183,7 +187,7 @@ testWithAnvilL1('governance:propose cmd', (web3: Web3) => {
           '--from',
           accounts[0],
           '--descriptionURL',
-          'https://example.com',
+          'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
         ],
         web3
       )
@@ -247,7 +251,7 @@ testWithAnvilL1('governance:propose cmd', (web3: Web3) => {
           '--for',
           multisigWithOneSigner,
           '--descriptionURL',
-          'https://dummyurl.com',
+          'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
         ],
         web3
       )
@@ -312,7 +316,7 @@ testWithAnvilL1('governance:propose cmd', (web3: Web3) => {
           '--for',
           multisigWithTwoSigners,
           '--descriptionURL',
-          'https://dummyurl.com',
+          'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
         ],
         web3
       )
@@ -367,7 +371,7 @@ testWithAnvilL1('governance:propose cmd', (web3: Web3) => {
           '--from',
           accounts[0],
           '--descriptionURL',
-          'https://dummyurl.com',
+          'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
           '--force',
           '--noInfo',
         ],
@@ -415,7 +419,7 @@ testWithAnvilL1('governance:propose cmd', (web3: Web3) => {
           '--from',
           accounts[0],
           '--descriptionURL',
-          'https://dummyurl.com',
+          'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
           '--force',
           '--noInfo',
         ],
@@ -451,6 +455,35 @@ testWithAnvilL1('governance:propose cmd', (web3: Web3) => {
   )
 
   test(
+    'fails when descriptionURl is invalid',
+    async () => {
+      const logMock = jest.spyOn(console, 'log')
+      await expect(
+        testLocallyWithWeb3Node(
+          Propose,
+          [
+            '--from',
+            accounts[0],
+            '--deposit',
+            '0',
+            '--jsonTransactions',
+            './exampleProposal.json',
+            '--descriptionURL',
+            'https://github.com/suspicious-org/governance/blob/main/CGPs/cgp-123.md',
+          ],
+          web3
+        )
+      ).rejects.toThrow("Some checks didn't pass!")
+      expect(logMock.mock.calls.at(-1)!.map(stripAnsiCodesAndTxHashes)).toMatchInlineSnapshot(`
+          [
+            "   ✘  descriptionURL is a valid url on the celo-org/governance repository descriptionURL needs to starts with \`https://github.com/celo-org/governance/blob/main/CGPs/\`",
+          ]
+      `)
+    },
+    EXTRA_LONG_TIMEOUT_MS
+  )
+
+  test(
     'can submit empty proposal',
     async () => {
       await testLocallyWithWeb3Node(
@@ -463,7 +496,7 @@ testWithAnvilL1('governance:propose cmd', (web3: Web3) => {
           '--jsonTransactions',
           './exampleProposal.json',
           '--descriptionURL',
-          'https://example.com',
+          'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
         ],
         web3
       )
@@ -486,7 +519,7 @@ testWithAnvilL1('governance:propose cmd', (web3: Web3) => {
           '--jsonTransactions',
           './exampleProposal.json',
           '--descriptionURL',
-          'https://example.com',
+          'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
         ],
         web3
       )
@@ -512,7 +545,7 @@ testWithAnvilL1('governance:propose cmd', (web3: Web3) => {
           '--jsonTransactions',
           './exampleProposal.json',
           '--descriptionURL',
-          'https://example.com',
+          'https://github.com/celo-org/governance/blob/main/CGPs/cgp-123.md',
         ],
         web3
       )

--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -37,7 +37,8 @@ export default class Propose extends BaseCommand {
     noInfo: Flags.boolean({ description: 'Skip printing the proposal info', default: false }),
     descriptionURL: CustomFlags.url({
       required: true,
-      description: 'A URL where further information about the proposal can be viewed',
+      description:
+        'A URL where further information about the proposal can be viewed. This needs to be a valid proposal URL on https://github.com/celo-org/governance',
     }),
     afterExecutingProposal: Flags.string({
       required: false,
@@ -52,8 +53,8 @@ export default class Propose extends BaseCommand {
   }
 
   static examples = [
-    'propose --jsonTransactions ./transactions.json --deposit 10000e18 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631 --descriptionURL https://gist.github.com/yorhodes/46430eacb8ed2f73f7bf79bef9d58a33',
-    'propose --jsonTransactions ./transactions.json --deposit 10000e18 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631  --useMultiSig --for 0x6c3dDFB1A9e73B5F49eDD46624F4954Bf66CAe93 --descriptionURL https://gist.github.com/yorhodes/46430eacb8ed2f73f7bf79bef9d58a33',
+    'propose --jsonTransactions ./transactions.json --deposit 10000e18 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631 --descriptionURL https://github.com/celo-org/governance/blob/main/CGPs/cgp-00000.md',
+    'propose --jsonTransactions ./transactions.json --deposit 10000e18 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631  --useMultiSig --for 0x6c3dDFB1A9e73B5F49eDD46624F4954Bf66CAe93 --descriptionURL https://github.com/celo-org/governance/blob/main/CGPs/gcp-00000.md',
   ]
 
   async run() {
@@ -115,6 +116,15 @@ export default class Propose extends BaseCommand {
         const safe = await createSafeFromWeb3(await this.getWeb3(), account, proposer)
         return safe.isOwner(account)
       })
+      .addCheck(
+        'descriptionURL is a valid url on the celo-org/governance repository',
+        () => {
+          return res.flags.descriptionURL.startsWith(
+            'https://github.com/celo-org/governance/blob/main/CGPs/'
+          )
+        },
+        'descriptionURL needs to starts with `https://github.com/celo-org/governance/blob/main/CGPs/`'
+      )
       .runChecks()
 
     if (!res.flags.force) {

--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -20,6 +20,8 @@ import {
 export default class Propose extends BaseCommand {
   static description = 'Submit a governance proposal'
 
+  static baseDescriptionURL = 'https://github.com/celo-org/governance/blob/main/CGPs/' as const
+
   static flags = {
     ...BaseCommand.flags,
     ...MultiSigFlags,
@@ -119,11 +121,9 @@ export default class Propose extends BaseCommand {
       .addCheck(
         'descriptionURL is a valid url on the celo-org/governance repository',
         () => {
-          return res.flags.descriptionURL.startsWith(
-            'https://github.com/celo-org/governance/blob/main/CGPs/'
-          )
+          return res.flags.descriptionURL.startsWith(Propose.baseDescriptionURL)
         },
-        'descriptionURL needs to starts with `https://github.com/celo-org/governance/blob/main/CGPs/`'
+        `descriptionURL needs to starts with \`${Propose.baseDescriptionURL}\``
       )
       .runChecks()
 

--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -20,8 +20,6 @@ import {
 export default class Propose extends BaseCommand {
   static description = 'Submit a governance proposal'
 
-  static baseDescriptionURL = 'https://github.com/celo-org/governance/blob/main/CGPs/' as const
-
   static flags = {
     ...BaseCommand.flags,
     ...MultiSigFlags,
@@ -37,10 +35,8 @@ export default class Propose extends BaseCommand {
     from: CustomFlags.address({ required: true, description: "Proposer's address" }),
     force: Flags.boolean({ description: 'Skip execution check', default: false }),
     noInfo: Flags.boolean({ description: 'Skip printing the proposal info', default: false }),
-    descriptionURL: CustomFlags.url({
+    descriptionURL: CustomFlags.proposalDescriptionURL({
       required: true,
-      description:
-        'A URL where further information about the proposal can be viewed. This needs to be a valid proposal URL on https://github.com/celo-org/governance',
     }),
     afterExecutingProposal: Flags.string({
       required: false,
@@ -118,13 +114,6 @@ export default class Propose extends BaseCommand {
         const safe = await createSafeFromWeb3(await this.getWeb3(), account, proposer)
         return safe.isOwner(account)
       })
-      .addCheck(
-        'descriptionURL is a valid url on the celo-org/governance repository',
-        () => {
-          return res.flags.descriptionURL.startsWith(Propose.baseDescriptionURL)
-        },
-        `descriptionURL needs to starts with \`${Propose.baseDescriptionURL}\``
-      )
       .runChecks()
 
     if (!res.flags.force) {

--- a/packages/cli/src/utils/command.ts
+++ b/packages/cli/src/utils/command.ts
@@ -101,6 +101,16 @@ const parseUrl: ParseFn<string> = async (input) => {
   }
 }
 
+const parseProposalDescriptionURL: ParseFn<string> = async (input) => {
+  const baseDescriptionURL = 'https://github.com/celo-org/governance/blob/main/CGPs/'
+  if (input.startsWith(baseDescriptionURL)) {
+    return input
+  }
+  throw new CLIError(
+    `\`${input}\` is not a valid descriptionURL, it must start with \`${baseDescriptionURL}\``
+  )
+}
+
 function parseArray<T>(parseElement: ParseFn<T>): ParseFn<T[]> {
   return async (input) => {
     const array = JSON.parse(input)
@@ -218,6 +228,11 @@ export const CustomFlags = {
     parse: parseWei,
     description: 'Token value without decimals',
     helpValue: '10000000000000000000000',
+  }),
+  proposalDescriptionURL: Flags.custom({
+    parse: parseProposalDescriptionURL,
+    description:
+      'A URL where further information about the proposal can be viewed. This needs to be a valid proposal URL on https://github.com/celo-org/governance',
   }),
 }
 


### PR DESCRIPTION
This PR fixes:
- #509

by adding a check to the `descriptionURL` flag, it now **must** start with `https://github.com/celo-org/governance/blob/main/CGPs` to be proposed

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a validation check for the `descriptionURL` flag in the `governance:propose` command to ensure it points to the correct governance repository. It updates related documentation and tests accordingly.

### Detailed summary
- Added `parseProposalDescriptionURL` function to validate `descriptionURL`.
- Updated `CustomFlags` to include `proposalDescriptionURL`.
- Changed `descriptionURL` in `governance:propose` to use `proposalDescriptionURL`.
- Updated command examples and documentation to reflect new URL format.
- Modified tests to check for valid and invalid `descriptionURL`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->