### PR TITLE
make command not hidden so the command shows up in docs

### DIFF
--- a/docs/command-line-interface/governance.md
+++ b/docs/command-line-interface/governance.md
@@ -3,6 +3,7 @@
 
 Interact with on-chain governance proposals and hotfixes
 
+* [`celocli governance:approve`](#celocli-governanceapprove)
 * [`celocli governance:approvehotfix`](#celocli-governanceapprovehotfix)
 * [`celocli governance:build-proposal`](#celocli-governancebuild-proposal)
 * [`celocli governance:dequeue`](#celocli-governancedequeue)
@@ -25,9 +26,95 @@ Interact with on-chain governance proposals and hotfixes
 * [`celocli governance:whitelisthotfix`](#celocli-governancewhitelisthotfix)
 * [`celocli governance:withdraw`](#celocli-governancewithdraw)
 
+## `celocli governance:approve`
+
+Approve a dequeued governance proposal (or hotfix). Only authorized approvers may use this command
+
+```
+USAGE
+  $ celocli governance:approve --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d [-k
+    <value> | --useLedger | ] [-n <value>] [--gasCurrency
+    0x1234567890123456789012345678901234567890] [--ledgerAddresses <value> ]
+    [--ledgerLiveMode ] [--globalHelp] [--proposalID <value> | --hotfix <value>]
+    [--useMultiSig | --useSafe] [--type approver|securityCouncil ]
+
+FLAGS
+  -k, --privateKey=<value>
+      Use a private key to sign local transactions with
+
+  -n, --node=<value>
+      URL of the node to run commands against or an alias
+
+  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
+      (required) Approver's address
+
+  --gasCurrency=0x1234567890123456789012345678901234567890
+      Use a specific gas currency for transaction fees (defaults to CELO if no gas
+      currency is supplied). It must be a whitelisted token.
+
+  --globalHelp
+      View all available global flags
+
+  --hotfix=<value>
+      Hash of hotfix proposal
+
+  --ledgerAddresses=<value>
+      [default: 1] If --useLedger is set, this will get the first N addresses for local
+      signing
+
+  --ledgerLiveMode
+      When set, the 4th postion of the derivation path will be iterated over instead of
+      the 5th. This is useful to use same address on you Ledger with celocli as you do on
+      Ledger Live
+
+  --proposalID=<value>
+      UUID of proposal to approve
+
+  --type=<option>
+      Determines which type of hotfix approval (approver or security council) to use.
+      <options: approver|securityCouncil>
+
+  --useLedger
+      Set it to use a ledger wallet
+
+  --useMultiSig
+      True means the request will be sent through multisig.
+
+  --useSafe
+      True means the request will be sent through SAFE (http://safe.global)
+
+DESCRIPTION
+  Approve a dequeued governance proposal (or hotfix). Only authorized approvers may use
+  this command
+
+ALIASES
+  $ celocli governance:approvehotfix
+
+EXAMPLES
+  approve --proposalID 99 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631
+
+  approve --proposalID 99 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631 --useMultiSig
+
+  approve --hotfix 0xfcfc98ec3db7c56f0866a7149e811bf7f9e30c9d40008b0def497fcc6fe90649 --from 0xCc50EaC48bA71343dC76852FAE1892c6Bd2971DA --useMultiSig
+
+  approve --hotfix 0xfcfc98ec3db7c56f0866a7149e811bf7f9e30c9d40008b0def497fcc6fe90649 --from 0xCc50EaC48bA71343dC76852FAE1892c6Bd2971DA --useMultiSig --type securityCouncil
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
+```
+
+_See code: [src/commands/governance/approve.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/approve.ts)_
+
 ## `celocli governance:approvehotfix`
 
-Approve a dequeued governance proposal (or hotfix)
+Approve a dequeued governance proposal (or hotfix). Only authorized approvers may use this command
 
 ```
 USAGE
@@ -83,10 +170,10 @@ FLAGS
       True means the request will be sent through SAFE (http://safe.global)
 
 DESCRIPTION
-  Approve a dequeued governance proposal (or hotfix)
+  Approve a dequeued governance proposal (or hotfix). Only authorized approvers may use
+  this command
 
 ALIASES
-  $ celocli governance:approve
   $ celocli governance:approvehotfix
 
 EXAMPLES

--- a/packages/cli/src/commands/governance/approve.ts
+++ b/packages/cli/src/commands/governance/approve.ts
@@ -21,12 +21,10 @@ enum HotfixApprovalType {
 }
 
 export default class Approve extends BaseCommand {
-  static description = 'Approve a dequeued governance proposal (or hotfix)'
+  static description =
+    'Approve a dequeued governance proposal (or hotfix). Only authorized approvers may use this command'
 
-  static aliases = ['governance:approve', 'governance:approvehotfix']
-
-  // Only authorized approvers need to know about this command.
-  static hidden = true
+  static aliases = ['governance:approvehotfix']
 
   static flags = {
     ...BaseCommand.flags,


### PR DESCRIPTION
### Description

command wasn't showing on docs for celocli but wierdly its alias was. now approves can also consult the docs when approving proposals. 

#### Other changes

command is no longer hidden from view

### Tested

just docs

### How to QA



### Related issues

- Fixes https://github.com/celo-org/developer-tooling/issues/501


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the command documentation for `celocli governance:approve` by clarifying its usage and emphasizing that only authorized approvers may use it. It also updates the command's description and usage flags.

### Detailed summary
- Updated `static description` for `Approve` class to include authorization note.
- Removed `hidden` property from `Approve` class.
- Expanded the documentation for `celocli governance:approve` in `governance.md`:
  - Added detailed usage instructions and flags.
  - Included examples of command usage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->