### PR TITLE
Governance: failure feedback

### DIFF
--- a/.changeset/thin-dryers-compare.md
+++ b/.changeset/thin-dryers-compare.md
@@ -1,0 +1,5 @@
+---
+'@celo/governance': patch
+---
+
+When building proposals if there is a failure show more informational error messages

--- a/docs/sdk/governance/classes/proposal_builder.ProposalBuilder.md
+++ b/docs/sdk/governance/classes/proposal_builder.ProposalBuilder.md
@@ -144,7 +144,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/governance/src/proposal-builder.ts:260](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/governance/src/proposal-builder.ts#L260)
+[packages/sdk/governance/src/proposal-builder.ts:271](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/governance/src/proposal-builder.ts#L271)
 
 ___
 

--- a/packages/sdk/governance/src/proposal-builder.test.ts
+++ b/packages/sdk/governance/src/proposal-builder.test.ts
@@ -169,7 +169,8 @@ testWithAnvilL2('ProposalBuilder', (web3) => {
       }
       await expect(proposalBuilder.fromJsonTx(tx)).rejects.toThrowErrorMatchingInlineSnapshot(`
         "Couldn't build call for transaction:
-         {
+
+        {
           "contract": "SuperContract",
           "function": "superFunction",
           "args": [
@@ -178,9 +179,10 @@ testWithAnvilL2('ProposalBuilder', (web3) => {
           ],
           "value": "0"
         }
-        Due to Failures:
-         1. SuperContract not (yet) registered
-         2. SuperContract is not a core celo contract so address must be specified
+
+        At least one of the following issues must be corrected:
+          1. SuperContract not (yet) registered
+          2. SuperContract is not a core celo contract so address must be specified
         "
       `)
     })

--- a/packages/sdk/governance/src/proposal-builder.test.ts
+++ b/packages/sdk/governance/src/proposal-builder.test.ts
@@ -140,4 +140,49 @@ testWithAnvilL2('ProposalBuilder', (web3) => {
       expect(proposal[0].input).toBeDefined()
     })
   })
+  describe('fromJsonTx', () => {
+    it('checks CoreContract JSON transaction', async () => {
+      const tx = {
+        contract: 'FeeCurrencyDirectory',
+        function: 'setCurrencyConfig',
+        args: [
+          '0x765DE816845861e75A25fCA122bb6898B8B1282a',
+          '0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33',
+          '50000',
+        ],
+        value: '0',
+      }
+      await expect(proposalBuilder.fromJsonTx(tx)).resolves.toMatchInlineSnapshot(`
+        {
+          "input": "0x216ab7df000000000000000000000000765de816845861e75a25fca122bb6898b8b1282a000000000000000000000000efb84935239dacdecf7c5ba76d8de40b077b7b33000000000000000000000000000000000000000000000000000000000000c350",
+          "to": "0x5a7D21C9255DAA32109c8136661D7e853Fc5BF63",
+          "value": "0",
+        }
+      `)
+    })
+    it('gives info when it fails to build transaction', async () => {
+      const tx = {
+        contract: 'SuperContract',
+        function: 'superFunction',
+        args: ['0xa435d2BaBDF80A66eD06A8D981edFE6f5DdAeCfB', '1000'],
+        value: '0',
+      }
+      await expect(proposalBuilder.fromJsonTx(tx)).rejects.toThrowErrorMatchingInlineSnapshot(`
+        "Couldn't build call for transaction:
+         {
+          "contract": "SuperContract",
+          "function": "superFunction",
+          "args": [
+            "0xa435d2BaBDF80A66eD06A8D981edFE6f5DdAeCfB",
+            "1000"
+          ],
+          "value": "0"
+        }
+        Due to Failures:
+         1. SuperContract not (yet) registered
+         2. SuperContract is not a core celo contract so address must be specified
+        "
+      `)
+    })
+  })
 })

--- a/packages/sdk/governance/src/proposal-builder.ts
+++ b/packages/sdk/governance/src/proposal-builder.ts
@@ -246,24 +246,24 @@ export class ProposalBuilder {
 
     const strategies = [this.buildCallToCoreContract, this.buildCallToExternalContract]
 
-    // store failures to display if all fail but show none if any succeeds
-    const failures = []
+    // store issues to display if all fail but show none if any succeeds
+    const issues = []
 
     for (const strategy of strategies) {
       try {
         return await strategy(tx as ProposalTransactionJSON)
       } catch (e) {
-        failures.push(`${isNativeError(e) ? e.message : e}`)
+        issues.push(`${isNativeError(e) ? e.message : e}`)
       }
     }
 
     throw new Error(
-      `Couldn't build call for transaction:\n ${JSON.stringify(
+      `Couldn't build call for transaction:\n\n${JSON.stringify(
         tx,
         undefined,
         2
-      )}\nDue to Failures:\n${failures
-        .map((error, index) => ` ${index + 1}. ${error}`)
+      )}\n\nAt least one of the following issues must be corrected:\n${issues
+        .map((error, index) => `  ${index + 1}. ${error}`)
         .join('\n')}\n`
     )
   }


### PR DESCRIPTION
### Description

After a little talk with Volpe where he asked why a tx was failing i thought we could be showing the errors in a better way.

#### Other changes



### Tested

NEW tests!
```
yarn celocli governance:build-proposal --node celo
Transaction #1:
? Celo Contract: FeeCurrencyDirectory
? FeeCurrencyDirectory Function: transferOwnership
? newOwner: 0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B
Error: Couldn't build call for transaction:
 {"contract":"FeeCurrencyDirectory","function":"transferOwnership","args":["0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"],"value":"0"}
Due to Failures:
 1. FeeCurrencyDirectory not (yet) registered
 2. FeeCurrencyDirectory is not a core celo contract so address must be specified
    at ProposalBuilder.<anonymous> (/Users/aaronderuvo/celo/developer-tooling/packages/sdk/governance/lib/proposal-builder.js:187:19)
    at Generator.throw (<anonymous>)
    at rejected (/Users/aaronderuvo/celo/developer-tooling/packages/sdk/governance/lib/proposal-builder.js:6:65)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
Please retry forming this transaction
Transaction #1:
```

### How to QA
```
yarn celocli governance:build-proposal --node celo
Transaction #1:
? Celo Contract: FeeCurrencyDirectory
? FeeCurrencyDirectory Function: transferOwnership
? newOwner: 0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B
```

note this  QA will only work before we move to L2. but for now it is an easy way to show the error. 


### Related issues

- Fixes #[issue number here]

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the error handling in the `ProposalBuilder` class by providing more informative error messages when building proposals fails. It also includes new tests to verify this functionality.

### Detailed summary
- Added `isNativeError` import from `util/types`.
- Introduced an `issues` array to collect error messages from failed strategies.
- Updated the error message thrown when transaction building fails to include detailed issues.
- Added tests for `fromJsonTx` to check transaction building success and failure scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->