### PR TITLE
Update to make it possible to Build Proposals for Core Contracts not registered yet

### DIFF
--- a/packages/sdk/governance/src/proposal-builder.ts
+++ b/packages/sdk/governance/src/proposal-builder.ts
@@ -203,10 +203,13 @@ export class ProposalBuilder {
   buildCallToCoreContract = async (tx: ProposalTransactionJSON): Promise<ProposalTransaction> => {
     // Account for canonical registry addresses from current proposal
     const address =
-      this.getRegistryAddition(tx.contract) ?? (await this.kit.registry.addressFor(tx.contract))
-
-    if (tx.address && address !== tx.address) {
-      throw new Error(`Address mismatch for ${tx.contract}: ${address} !== ${tx.address}`)
+      this.getRegistryAddition(tx.contract) ??
+      tx.address ??
+      (await this.kit.registry.addressFor(tx.contract))
+    console.info('Building call to core contract', tx.contract, 'at address', address)
+    // TEMP
+    if (tx.contract && tx.address && !this.getRegistryAddition(tx.contract)) {
+      this.setRegistryAddition(tx.contract, tx.address)
     }
 
     if (tx.function === SET_AND_INITIALIZE_IMPLEMENTATION_ABI.name && Array.isArray(tx.args[1])) {

--- a/packages/sdk/governance/src/proposals.ts
+++ b/packages/sdk/governance/src/proposals.ts
@@ -144,7 +144,7 @@ export const proposalToJSON = async (
   for (const tx of proposal) {
     const parsedTx = await blockExplorer.tryParseTx(tx as CeloTxPending)
     if (parsedTx == null) {
-      throw new Error(`Unable to parse ${JSON.stringify(tx)} with block explorer`)
+      throw new Error(`Unable to parse ${JSON.stringify(tx, null, 2)} with block explorer`)
     }
     if (isRegistryRepointRaw(abiCoder, tx) && parsedTx.callDetails.isCoreContract) {
       const args = registryRepointRawArgs(abiCoder, tx)


### PR DESCRIPTION
### Description


#### Other changes

make output of json in error cleaner

### Tested

anvil

### How to QA

in cli directory after building

```
anvil --fork-url https://forno.celo.org --auto-impersonate
```

```
NO_SYNCCHECK=1 yarn dev governance:propose --deposit 10000e18 --jsonTransactions prop.json --from 0xc11F5aC70B86517Dcc10f20d8B0D5e77EBb956Ce --descriptionURL https://github.com/celo-org/governance/blob/main/CGPs/cgp-0167.md -n http://127.0.0.1:8545 --afterExecutingID=215 --force
```

### Related issues

- Fixes #[issue number here]
