### PR TITLE
fix: allow users to use different apps than celo or ethereum

### DIFF
--- a/.changeset/sharp-fishes-allow.md
+++ b/.changeset/sharp-fishes-allow.md
@@ -1,0 +1,5 @@
+---
+'@celo/wallet-ledger': patch
+---
+
+Allow users to use other apps than ethereum or celo, namely "eth recovery" in order to recovery funds or signTypedData which isnt supported by celo but would require the correct derivationPath

--- a/.changeset/yellow-mails-flash.md
+++ b/.changeset/yellow-mails-flash.md
@@ -1,0 +1,5 @@
+---
+'@celo/viem-account-ledger': patch
+---
+
+Allow users to use other apps than ethereum or celo, namely eth recovery in order to recovery funds or signTypedData which isnt supported by celo but would require the correct derivationPath (which, in turn, isn't supported by ethereum)

--- a/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts
+++ b/packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts
@@ -245,8 +245,8 @@ export class LedgerWallet extends RemoteWallet<LedgerSigner> implements ReadOnly
         `Beware, you opened the Ethereum app instead of the Celo app. Some features may not work correctly, including token transfers.`
       )
     } else {
-      throw new Error(
-        `Beware, you opened the ${appName} app instead of the Celo app. We cannot ensure the safety of using this SDK with ${appName}.`
+      console.error(
+        `\n---\nBeware, you opened the ${appName} app instead of the Celo app. We cannot ensure the safety of using this SDK with ${appName}. USE AT YOUR OWN RISK.\n---\n`
       )
     }
     if (!appConfiguration.arbitraryDataEnabled) {

--- a/packages/viem-account-ledger/src/utils.test.ts
+++ b/packages/viem-account-ledger/src/utils.test.ts
@@ -66,11 +66,6 @@ describe('utils', () => {
   })
 
   describe('assertCompat', () => {
-    it("throws if it doesn't meet the requirements", async () => {
-      await expect(assertCompat(mockLedger({ version: '1.0.0' }))).rejects.toMatchInlineSnapshot(
-        `[Error: Due to technical issues, we require the users to update their ledger celo-app to >= 1.2.0. You can do this on ledger-live by updating the celo-app in the app catalog.]`
-      )
-    })
     it('warns if it doesnt enable `arbitraryDataEnabled`', async () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
       await expect(assertCompat(mockLedger({ arbitraryDataEnabled: 0 }))).resolves.toBeTruthy()
@@ -86,6 +81,19 @@ describe('utils', () => {
       expect(warn.mock.lastCall).toMatchInlineSnapshot(`
         [
           "Beware, you opened the Ethereum app instead of the Celo app. Some features may not work correctly, including token transfers.",
+        ]
+      `)
+    })
+    it('warns if it using with unknown apps', async () => {
+      const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      await expect(assertCompat(mockLedger({ name: 'unknown' }))).resolves.toBeTruthy()
+      expect(error.mock.lastCall).toMatchInlineSnapshot(`
+        [
+          "
+        ---
+        Beware, you opened the unknown app instead of the Celo app. We cannot ensure the safety of using this SDK with unknown. USE AT YOUR OWN RISK.
+        ---
+        ",
         ]
       `)
     })

--- a/packages/viem-account-ledger/src/utils.ts
+++ b/packages/viem-account-ledger/src/utils.ts
@@ -62,8 +62,8 @@ export async function assertCompat(ledger: Eth): Promise<{
       `Beware, you opened the Ethereum app instead of the Celo app. Some features may not work correctly, including token transfers.`
     )
   } else {
-    throw new Error(
-      `Beware, you opened the ${appName} app instead of the Celo app. We cannot ensure the safety of using this SDK with ${appName}.`
+    console.error(
+      `\n---\nBeware, you opened the ${appName} app instead of the Celo app. We cannot ensure the safety of using this SDK with ${appName}. USE AT YOUR OWN RISK.\n---\n`
     )
   }
   if (!appConfiguration.arbitraryDataEnabled) {


### PR DESCRIPTION
Allow users to use other apps than `ethereum` or `celo`, namely `eth recovery` in order to recovery funds or signTypedData which isnt supported by `celo` but would require the correct derivationPath (which, in turn, isn't supported by `ethereum`)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `@celo/wallet-ledger` and `@celo/viem-account-ledger` packages, allowing users to use other apps beyond Ethereum and Celo. It includes updated error handling and new tests for compatibility with unknown apps and other Ledger applications.

### Detailed summary
- Updated documentation to allow usage of apps like "eth recovery".
- Replaced `throw new Error` with `console.error` for warnings about using non-Celo apps in `packages/viem-account-ledger/src/utils.ts` and `packages/sdk/wallets/wallet-ledger/src/ledger-wallet.ts`.
- Added tests for compatibility with unknown apps in `packages/viem-account-ledger/src/utils.test.ts`.
- Implemented tests for initialization warnings with the `ethereum-recovery` and `ethereum` apps in `packages/sdk/wallets/wallet-ledger/src/ledger-wallet.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->