### PR TITLE
Start Beta Mode again

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,31 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@celo/celocli": "6.1.0",
+    "@celo/dev-utils": "0.0.8",
+    "@celo/base": "7.0.1",
+    "@celo/connect": "6.1.1",
+    "@celo/contractkit": "9.0.1",
+    "@celo/cryptographic-utils": "5.1.2",
+    "@celo/explorer": "5.0.14",
+    "@celo/governance": "5.1.5",
+    "@celo/keystores": "5.0.13",
+    "@celo/metadata-claims": "1.0.1",
+    "@celo/network-utils": "5.0.7",
+    "@celo/phone-utils": "6.0.5",
+    "@celo/transactions-uri": "5.0.13",
+    "@celo/utils": "8.0.1",
+    "@celo/wallet-base": "7.0.0",
+    "@celo/wallet-hsm": "7.0.0",
+    "@celo/wallet-hsm-aws": "7.0.0",
+    "@celo/wallet-hsm-azure": "7.0.0",
+    "@celo/wallet-hsm-gcp": "7.0.0",
+    "@celo/wallet-ledger": "7.0.0",
+    "@celo/wallet-local": "7.0.0",
+    "@celo/wallet-remote": "7.0.0",
+    "@celo/typescript": "0.0.1",
+    "@celo/viem-account-ledger": "1.1.0"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
nil

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new pre-release configuration for a project, specifying version numbers for various `@celo` packages and setting the mode to `pre` with a `beta` tag.

### Detailed summary
- Added a new `.changeset/pre.json` file.
- Set `mode` to `pre` and `tag` to `beta`.
- Defined initial versions for multiple `@celo` packages, including:
  - `@celo/celocli`: "6.1.0"
  - `@celo/dev-utils`: "0.0.8"
  - `@celo/base`: "7.0.1"
  - `@celo/connect`: "6.1.1"
  - `@celo/contractkit`: "9.0.1"
  - ... (and others)
- Included an empty `changesets` array.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->