### PR TITLE
update workflows to use step security maintained action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
   install-dependencies:
     name: Install dependencies
     outputs:
-      # Propagate more outputs if you need https://github.com/tj-actions/changed-files#outputs
+      # Propagate more outputs if you need https://github.com/step-security/changed-files#outputs
       # Adding a initial comma so ',<path>' matches also for the first file
       all_modified_files: ',${{ steps.changed-files.outputs.all_modified_files }}'
       artifacts_to_cache: ${{ steps.get_artifacts_to_cache.outputs.artifacts_to_cache }}
@@ -87,7 +87,7 @@ jobs:
       # Get workdir local changes and fail if there are any change
       # - name: Verify Changed files
       #   id: verify-changed-files
-      #   uses: tj-actions/verify-changed-files@v17
+      #   uses: step-security/verify-changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1
       #   with:
       #     path: yarn.lock
       #     fail-if-changed: 'true'
@@ -120,7 +120,7 @@ jobs:
             code-${{ github.sha }}
       - name: Detect files changed in PR (or commit), and expose as output
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1
         with:
           # Using comma as separator to be able to easily match full paths (using ,<path>)
           separator: ','


### PR DESCRIPTION
### Description

Switching to use step-security maintained action due to vulnerability with tj-actions/changed-files

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflow configuration by changing the source of certain actions from `tj-actions` to `step-security`, ensuring the workflow uses the latest versions and potentially more secure implementations.

### Detailed summary
- Updated the output URL for `changed-files` from `tj-actions` to `step-security`.
- Changed the action for verifying changed files from `tj-actions/verify-changed-files@v17` to `step-security/verify-changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1`.
- Updated the action for detecting changed files from `tj-actions/changed-files@v44` to `step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->