### PR TITLE
celocli: move to homebrew-brew tap

### DIFF
--- a/.github/workflows/upload-celocli-executables.yml
+++ b/.github/workflows/upload-celocli-executables.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          dynamic-secrets: '{"/dynamic-secrets/keys/github/homebrew-core/contents=write":"HOMEBREW_FORK_TOKEN"}'
+          dynamic-secrets: '{"/dynamic-secrets/keys/github/homebrew-brew/contents=write":"HOMEBREW_BREW_TOKEN"}'
 
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -34,13 +34,13 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Checkout Homebrew Repo
+      - name: Checkout Celo Homebrew Tap
         uses: actions/checkout@v4
         with:
-          repository: 'celo-org/homebrew-core'
-          path: '/home/runner/work/developer-tooling/developer-tooling/homebrew'
-          ref: master
-          token: ${{ env.HOMEBREW_FORK_TOKEN }}
+          repository: 'celo-org/homebrew-brew'
+          path: '/home/runner/work/developer-tooling/developer-tooling/homebrew-brew'
+          ref: main
+          token: ${{ env.HOMEBREW_BREW_TOKEN }}
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
@@ -65,22 +65,20 @@ jobs:
           # Parse version from the release name (eg: @celo/celocli@6.1.0)
           version=$(echo ${{ github.ref_name }} | cut -d' ' -f1 | cut -d'/' -f3)
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo $version
 
           # Get the short commit from github release
           commit=$(gh release view @celo/celocli@$version --json tagName \
             | jq '.tagName' \
             | xargs git rev-list -n 1 --abbrev-commit)
           echo "commit=$commit" >> "$GITHUB_OUTPUT"
-          echo $commit
-
           # Download tarball from published release on NPM and save path
-          tarballPath=$(npm pack @celo/celocli@$version \
+          tarballPath=/tmp/$(npm pack @celo/celocli@$version \
           --json \
           --pack-destination /tmp/ \
           | jq 'first.filename' -r)
-          echo "tarballPath=/tmp/$tarballPath" >> "$GITHUB_OUTPUT"
-          echo /tmp/$tarballPath
+          echo "tarballPath=$tarballPath" >> "$GITHUB_OUTPUT"
+
+          echo $GITHUB_OUTPUT
 
       - name: Package the released tarball into platform-specific executables
         run: |
@@ -119,22 +117,21 @@ jobs:
           ./homebrew/scripts/test.sh
 
       - name: Open pull-request on Homebrew repo
-        if: ${{ env.HOMEBREW_FORK_TOKEN }}
+        if: ${{ env.HOMEBREW_BREW_TOKEN }}
         working-directory: packages/cli
         env:
           BOT_NAME: 'celo-org'
           BOT_EMAIL: 'celo-org@github.com'
-          HOMEBREW_FORK: 'celo-org:homebrew-core'
-          HOMEBREW_UPSTREAM: 'Homebrew/homebrew-core'
-          BASE_BRANCH: master
+          HOMEBREW_FORK: 'celo-org:homebrew-brew'
+          BASE_BRANCH: main
           NEW_BRANCH: 'ci/celocli-${{ steps.setupVars.outputs.version }}'
-          GH_TOKEN: ${{ env.HOMEBREW_FORK_TOKEN }}
+          GH_TOKEN: ${{ env.HOMEBREW_BREW_TOKEN }}
           RELEASE_URL: 'https://github.com/celo-org/developer-tooling/releases/download/%40celo%2Fcelocli%40${{ steps.setupVars.outputs.version }}'
         run: |
           set -x
 
           cli_workspace=$(pwd)
-          cd /home/runner/work/developer-tooling/developer-tooling/homebrew
+          cd /home/runner/work/developer-tooling/developer-tooling/homebrew-brew
 
           # Setup the committers identity.
           git config --global user.name ${{ env.BOT_NAME }}
@@ -143,7 +140,7 @@ jobs:
           # Create a new feature branch for the changes.
           git checkout -b ${{ env.NEW_BRANCH }}
           git status
-          cp $cli_workspace/homebrew/Formula/celocli.rb ./Formula/c/
+          cp $cli_workspace/homebrew/Formula/celocli.rb ./Formula/celocli.rb
           git add ./Formula/c/celocli.rb
           git diff --cached
 
@@ -155,11 +152,6 @@ jobs:
           # Write the commit message into a file
           cat >/tmp/pr-body.md <<EOL
           Update celocli formula to [${{ steps.setupVars.outputs.version }}](${{ env.RELEASE_URL }}).
-
-          @celo-org/devtooling:
-          - [Please open a follow-up pr upstream](https://github.com/${{ env.HOMEBREW_UPSTREAM }}/compare/${{ env.BASE_BRANCH }}...${{ env.HOMEBREW_FORK }}:${{ env.NEW_BRANCH }}?title=celocli%20${{ steps.setupVars.outputs.celocliVersion }}).
-
-          _PS: you don't actually need to merge this PR, only upstream matters._
 
           🤖 _This pull-request was opened by a robot beep boop from [@${{ env.BOT_NAME }}](https://github.com/celo-org)_ 🤖
           EOL

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ npm install -g @celo/celocli@beta
 ```
 
 > [!TIP]
-> IF you're on macOS or Linux, you may use [Homebrew](https://brew.sh/) to install this. `brew install celocli`
+> IF you're on macOS or Linux, you may use [Homebrew](https://brew.sh/) to install this. `brew install celo-org/brew/celocli`
 > Other binaries are directly attached to the Github releases (eg: the [6.1.0 release](https://github.com/celo-org/developer-tooling/releases/tag/%40celo%2Fcelocli%406.1.0)).
 > Please open up an issue if you'd like to see this CLI distributed elsewhere.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ npm install -g @celo/celocli@beta
 ```
 
 > [!TIP]
-> IF you're on macOS or Linux, you may use [Homebrew](https://brew.sh/) to install this. `brew install celo-org/brew/celocli`
+> IF you're on macOS or Linux, you may use [Homebrew](https://brew.sh/) to install this. `brew tap celo-org/brew && brew install celocli`
 > Other binaries are directly attached to the Github releases (eg: the [6.1.0 release](https://github.com/celo-org/developer-tooling/releases/tag/%40celo%2Fcelocli%406.1.0)).
 > Please open up an issue if you'd like to see this CLI distributed elsewhere.
 

--- a/packages/cli/homebrew/scripts/test.sh
+++ b/packages/cli/homebrew/scripts/test.sh
@@ -8,4 +8,8 @@ brew update
 brew install "$__dirname/../Formula/celocli.rb"
 brew test celocli
 celocli --version
-celocli help
+celocli --help
+celocli commands
+celocli account:new --language=french
+celocli account:new
+celocli network:whitelist --node mainnet

--- a/packages/cli/homebrew/templates/celocli.rb
+++ b/packages/cli/homebrew/templates/celocli.rb
@@ -4,6 +4,7 @@ class Celocli < Formula
   url "__CLI_MAC_INTEL_DOWNLOAD_URL__"
   sha256 "__CLI_MAC_INTEL_SHA256__"
   version "__CLI_VERSION__"
+  license "Apache-2.0"
   version_scheme 1
 
   on_macos do


### PR DESCRIPTION
Since publishing on homebrew-core is a lot more effort than anticipated (namely having to somehow compile the node-gyp dependants and ledger's usb native packages), I closed the following pr:
- https://github.com/Homebrew/homebrew-core/pull/211460

in favour of the new repo: 
- https://github.com/celo-org/homebrew-brew

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `celocli` formula in Homebrew, enhancing the GitHub Actions workflow for packaging, and improving the documentation for installation instructions.

### Detailed summary
- Added `license "Apache-2.0"` in `celocli.rb`.
- Updated `brew test` commands in `test.sh` to include `--help`, `commands`, and `account:new` commands.
- Changed installation instructions in `README.md` to include `brew tap celo-org/brew`.
- Updated dynamic secrets in `upload-celocli-executables.yml`.
- Renamed Homebrew repository from `homebrew-core` to `homebrew-brew`.
- Adjusted paths and tokens in the GitHub Actions workflow.
- Modified the tarball path handling in the workflow.
- Updated the pull request creation process to reflect the new repository and branch names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->