### PR TITLE
Exiting Beta mode / Fix typo

### DIFF
--- a/.changeset/cuddly-pillows-buy.md
+++ b/.changeset/cuddly-pillows-buy.md
@@ -1,0 +1,25 @@
+---
+'@celo/viem-account-ledger': patch
+'@celo/contractkit': patch
+'@celo/base': patch
+'@celo/celocli': patch
+'@celo/wallet-hsm-azure': patch
+'@celo/wallet-hsm-aws': patch
+'@celo/wallet-ledger': patch
+'@celo/wallet-remote': patch
+'@celo/wallet-local': patch
+'@celo/cryptographic-utils': patch
+'@celo/wallet-base': patch
+'@celo/wallet-hsm': patch
+'@celo/transactions-uri': patch
+'@celo/metadata-claims': patch
+'@celo/network-utils': patch
+'@celo/phone-utils': patch
+'@celo/governance': patch
+'@celo/keystores': patch
+'@celo/explorer': patch
+'@celo/connect': patch
+'@celo/utils': patch
+---
+
+Fix incorrect repo link in package.json

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@celo/celocli": "6.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/cli"
   },
   "homepage": "https://docs.celo.org/cli",

--- a/packages/sdk/base/package.json
+++ b/packages/sdk/base/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://docs.celo.org/developer/tools#celo-sdk-reference-docs",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/base"
   },
   "scripts": {

--- a/packages/sdk/connect/package.json
+++ b/packages/sdk/connect/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://docs.celo.org/developer/tools",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/connect"
   },
   "keywords": [

--- a/packages/sdk/contractkit/package.json
+++ b/packages/sdk/contractkit/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://docs.celo.org/developer-guide/contractkit",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/contractkit"
   },
   "keywords": [

--- a/packages/sdk/cryptographic-utils/package.json
+++ b/packages/sdk/cryptographic-utils/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/celo-org/developer-tooling/tree/master/packages/sdk/cryptographic-utils",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/cryptographic-utils"
   },
   "scripts": {

--- a/packages/sdk/explorer/package.json
+++ b/packages/sdk/explorer/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://docs.celo.org/developer/tools",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/explorer"
   },
   "keywords": [

--- a/packages/sdk/governance/package.json
+++ b/packages/sdk/governance/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://celo-sdk-docs.readthedocs.io/en/latest/governance",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/governance"
   },
   "keywords": [

--- a/packages/sdk/keystores/package.json
+++ b/packages/sdk/keystores/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://docs.celo.org/developer/tools",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/keystores"
   },
   "scripts": {

--- a/packages/sdk/metadata-claims/package.json
+++ b/packages/sdk/metadata-claims/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/metadata-claims"
   },
   "keywords": [

--- a/packages/sdk/network-utils/package.json
+++ b/packages/sdk/network-utils/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://docs.celo.org/developer/tools",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/network-utils"
   },
   "keywords": [

--- a/packages/sdk/phone-utils/package.json
+++ b/packages/sdk/phone-utils/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://docs.celo.org/developer/tools",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/phone-utils"
   },
   "scripts": {

--- a/packages/sdk/transactions-uri/package.json
+++ b/packages/sdk/transactions-uri/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://docs.celo.org/developer/tools",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/transactions-uri"
   },
   "keywords": [

--- a/packages/sdk/utils/package.json
+++ b/packages/sdk/utils/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://docs.celo.org/developer/tools",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/utils"
   },
   "scripts": {

--- a/packages/sdk/wallets/wallet-base/package.json
+++ b/packages/sdk/wallets/wallet-base/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/wallets/"
   },
   "homepage": "https://docs.celo.org",

--- a/packages/sdk/wallets/wallet-hsm-aws/package.json
+++ b/packages/sdk/wallets/wallet-hsm-aws/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/wallets/"
   },
   "homepage": "https://docs.celo.org",

--- a/packages/sdk/wallets/wallet-hsm-azure/package.json
+++ b/packages/sdk/wallets/wallet-hsm-azure/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/wallets/"
   },
   "homepage": "https://docs.celo.org",

--- a/packages/sdk/wallets/wallet-hsm/package.json
+++ b/packages/sdk/wallets/wallet-hsm/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/wallets/"
   },
   "homepage": "https://docs.celo.org",

--- a/packages/sdk/wallets/wallet-ledger/package.json
+++ b/packages/sdk/wallets/wallet-ledger/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/wallets/"
   },
   "homepage": "https://docs.celo.org",

--- a/packages/sdk/wallets/wallet-local/package.json
+++ b/packages/sdk/wallets/wallet-local/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/wallets/"
   },
   "homepage": "https://docs.celo.org",

--- a/packages/sdk/wallets/wallet-remote/package.json
+++ b/packages/sdk/wallets/wallet-remote/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/sdk/wallets/"
   },
   "homepage": "https://docs.celo.org",

--- a/packages/viem-account-ledger/package.json
+++ b/packages/viem-account-ledger/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://docs.celo.org/developer/tools",
   "repository": {
     "type": "git",
-    "url": "git+https:/github.com/celo-org/developer-tooling.git",
+    "url": "git+https://github.com/celo-org/developer-tooling.git",
     "directory": "packages/viem-account-ledger"
   },
   "keywords": [


### PR DESCRIPTION
Next release will be prime time

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting the repository URLs in multiple `package.json` files within the Celo project, ensuring they point to the correct GitHub repository. Additionally, it updates the mode in the `.changeset/pre.json` file and adds patch entries for various packages.

### Detailed summary
- Changed `"mode"` from `"pre"` to `"exit"` in `.changeset/pre.json`.
- Updated repository URLs from `git+https:/` to `git+https://` in multiple `package.json` files:
  - `packages/sdk/base/package.json`
  - `packages/sdk/utils/package.json`
  - `packages/sdk/connect/package.json`
  - `packages/sdk/explorer/package.json`
  - `packages/sdk/keystores/package.json`
  - `packages/sdk/governance/package.json`
  - `packages/sdk/phone-utils/package.json`
  - `packages/sdk/contractkit/package.json`
  - `packages/cli/package.json`
  - `packages/sdk/network-utils/package.json`
  - `packages/sdk/metadata-claims/package.json`
  - `packages/viem-account-ledger/package.json`
  - `packages/sdk/transactions-uri/package.json`
  - `packages/sdk/cryptographic-utils/package.json`
  - `packages/sdk/wallets/wallet-hsm/package.json`
  - `packages/sdk/wallets/wallet-base/package.json`
  - `packages/sdk/wallets/wallet-local/package.json`
  - `packages/sdk/wallets/wallet-ledger/package.json`
  - `packages/sdk/wallets/wallet-remote/package.json`
  - `packages/sdk/wallets/wallet-hsm-aws/package.json`
  - `packages/sdk/wallets/wallet-hsm-azure/package.json`
- Added patch entries for various packages in `.changeset/cuddly-pillows-buy.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->