### PR TITLE
refactor: trigger upload with workflow_call

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,6 @@ jobs:
     outputs:
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
       published: ${{ steps.changesets.outputs.published }}
-      celocliVersion: ${{ steps.extractCelocliVersion.outputs.celocliVersion }}
 
     steps:
       - name: Checkout Repo
@@ -88,6 +87,8 @@ jobs:
   install-released-packages:
     name: Install Released Packages
     needs: [prepare, release]
+    outputs:
+      assertStableVersionOutcome: ${{ steps.assertStableVersion.outcome }}
     if: needs.release.outputs.published
     runs-on: ubuntu-latest
     container:
@@ -115,6 +116,14 @@ jobs:
           echo "checking celo community fund balance"
           celocli account:balance 0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972 --node celo
           celocli network:whitelist --node alfajores
+      - name: Is stable celocli release
+        id: assertStableVersion
+        if: contains(matrix.package, '@celo/celocli')
+        continue-on-error: true
+        run: |
+          ./scripts/assert_stable_version $CELO_CLI_VERSION
+        env:
+          CELO_CLI_VERSION: ${{ fromJson(needs.release.outputs.publishedPackages).*.version }}
 
   open-docs-pr:
     needs: release
@@ -124,8 +133,8 @@ jobs:
       commit: ${{ github.sha }}
 
   upload-executables:
-    needs: release
-    if: ${{ contains(fromJson(needs.release.outputs.publishedPackages).*.name, '@celo/celocli') }}
+    needs: install-released-packages
+    if: ${{ needs.install-released-packages.outputs.assertStableVersionOutcome != 'failure' }}
     uses: celo-org/developer-tooling/.github/workflows/upload-celocli-executables.yml@master
     with:
       commit: ${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,12 +113,19 @@ jobs:
           celocli --version
           celocli account:new
           echo "checking celo community fund balance"
-          celocli account:balance 0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972  --node celo
+          celocli account:balance 0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972 --node celo
           celocli network:whitelist --node alfajores
 
   open-docs-pr:
     needs: release
     if: ${{ contains(fromJson(needs.release.outputs.publishedPackages).*.name, '@celo/celocli') }}
     uses: celo-org/developer-tooling/.github/workflows/open-docs-pr.yml@master
+    with:
+      commit: ${{ github.sha }}
+
+  upload-executables:
+    needs: release
+    if: ${{ contains(fromJson(needs.release.outputs.publishedPackages).*.name, '@celo/celocli') }}
+    uses: celo-org/developer-tooling/.github/workflows/upload-celocli-executables.yml@master
     with:
       commit: ${{ github.sha }}

--- a/.github/workflows/upload-celocli-executables.yml
+++ b/.github/workflows/upload-celocli-executables.yml
@@ -1,8 +1,19 @@
 name: Upload celocli executables
 
 on:
-  release:
-    types: [released]
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Commit-ish of the developer-tooling repo that the celocli should be compiled and uploaded from'
+        type: string
+        required: true
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Commit-ish of the developer-tooling repo that the celocli should be compiled and uploaded from'
+        type: string
+        required: true
 
 jobs:
   upload:
@@ -13,7 +24,6 @@ jobs:
       id-token: write
       pull-requests: write
       repository-projects: write
-    if: contains(github.ref_name, 'celocli') == true
     steps:
       - name: Get Token from Akeyless
         id: get_token
@@ -26,7 +36,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -62,8 +72,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Parse version from the release name (eg: @celo/celocli@6.1.0)
-          version=$(echo ${{ github.ref_name }} | cut -d' ' -f1 | cut -d'/' -f3)
+          # Parse version from the package.json
+          version=$(cat packages/cli/package.json | jq -r .version)
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
           # Get the short commit from github release
@@ -78,7 +88,7 @@ jobs:
           | jq 'first.filename' -r)
           echo "tarballPath=$tarballPath" >> "$GITHUB_OUTPUT"
 
-          echo $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
 
       - name: Package the released tarball into platform-specific executables
         run: |
@@ -141,7 +151,7 @@ jobs:
           git checkout -b ${{ env.NEW_BRANCH }}
           git status
           cp $cli_workspace/homebrew/Formula/celocli.rb ./Formula/celocli.rb
-          git add ./Formula/c/celocli.rb
+          git add ./Formula/celocli.rb
           git diff --cached
 
           # Commit the new Formula

--- a/.github/workflows/upload-celocli-executables.yml
+++ b/.github/workflows/upload-celocli-executables.yml
@@ -90,6 +90,12 @@ jobs:
 
           cat $GITHUB_OUTPUT
 
+      - name: Assert stable release
+        run: |
+          ./scripts/assert_stable_version $TARBALL_VERSION
+        env:
+          TARBALL_VERSION: ${{ steps.setupVars.outputs.version }}
+
       - name: Package the released tarball into platform-specific executables
         run: |
           # Pack the tarballs from NPM into platform specific executables

--- a/scripts/assert_stable_version
+++ b/scripts/assert_stable_version
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+
+use warnings;
+
+my ($version) = @ARGV;
+
+if (not defined $version) {
+  die "Need version\n";
+}
+
+# https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+my $regex = qr/^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/p;
+
+if ( $version =~ /$regex/g ) {
+  if (defined $+{prerelease}) {
+    die "Not a stable release ($version)\n";
+  }
+  else {
+    print "Stable release ($version)\n";
+    exit(0);
+  }
+}
+else {
+  die "Not a valid SemVer ($version)\n";
+}


### PR DESCRIPTION
As figured out in https://github.com/orgs/community/discussions/25281#discussioncomment-3300251

the current workflow uploading executables cannot work, it just won't be called to prevent worfklow recursion.

Knowing that, I refactored the workflow to use `workflow_call` which is called in the `release.yml`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a Perl script to assert the stability of the `celocli` version based on Semantic Versioning (SemVer) and updates the GitHub Actions workflow to incorporate this check during the release process.

### Detailed summary
- Added a new script `scripts/assert_stable_version` to validate `celocli` versions against SemVer.
- Updated `.github/workflows/release.yaml` to include a step for asserting stable release.
- Modified `upload-celocli-executables.yml` to assert stable version before uploading.
- Enhanced version parsing in `upload-celocli-executables.yml` to use `package.json`.
- Corrected file path in `git add` command for the formula file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->