### PR TITLE
Fix/compliance esm issue

### DIFF
--- a/.changeset/mean-trainers-punch.md
+++ b/.changeset/mean-trainers-punch.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Fixes issues with using celocli with specific versions of node (20.19 and 22)

--- a/packages/cli/src/commands/releasecelo/transfer-dollars.test.ts
+++ b/packages/cli/src/commands/releasecelo/transfer-dollars.test.ts
@@ -1,11 +1,11 @@
 import { StableToken, StrongAddress } from '@celo/base'
-import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
+import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
 import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import Register from '../account/register'
@@ -109,7 +109,7 @@ testWithAnvilL1('releasegold:transfer-dollars cmd', (web3: Web3) => {
     await expect(
       testLocallyWithWeb3Node(
         RGTransferDollars,
-        ['--contract', contractAddress, '--to', SANCTIONED_ADDRESSES[0], '--value', '10'],
+        ['--contract', contractAddress, '--to', TEST_SANCTIONED_ADDRESS, '--value', '10'],
         web3
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)

--- a/packages/cli/src/commands/transfer/celo.test.ts
+++ b/packages/cli/src/commands/transfer/celo.test.ts
@@ -1,9 +1,9 @@
-import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
+import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
 import { HttpRpcCaller } from '@celo/connect'
 import { ContractKit, StableToken, newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import TransferCelo from './celo'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -112,7 +112,7 @@ testWithAnvilL1('transfer:celo cmd', (web3: Web3) => {
     await expect(
       testLocallyWithWeb3Node(
         TransferCelo,
-        ['--from', accounts[1], '--to', SANCTIONED_ADDRESSES[0], '--value', '1'],
+        ['--from', accounts[1], '--to', TEST_SANCTIONED_ADDRESS, '--value', '1'],
         web3
       )
     ).rejects.toThrow()
@@ -123,7 +123,7 @@ testWithAnvilL1('transfer:celo cmd', (web3: Web3) => {
     await expect(
       testLocallyWithWeb3Node(
         TransferCelo,
-        ['--from', SANCTIONED_ADDRESSES[0], '--to', accounts[0], '--value', '1'],
+        ['--from', TEST_SANCTIONED_ADDRESS, '--to', accounts[0], '--value', '1'],
         web3
       )
     ).rejects.toThrow()

--- a/packages/cli/src/commands/transfer/dollars.test.ts
+++ b/packages/cli/src/commands/transfer/dollars.test.ts
@@ -1,10 +1,10 @@
-import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
+import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
 import { ContractKit, StableToken, newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import TransferCUSD from './dollars'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -69,7 +69,7 @@ testWithAnvilL1('transfer:dollars cmd', (web3: Web3) => {
     await expect(
       testLocallyWithWeb3Node(
         TransferCUSD,
-        ['--from', accounts[1], '--to', SANCTIONED_ADDRESSES[0], '--value', '1'],
+        ['--from', accounts[1], '--to', TEST_SANCTIONED_ADDRESS, '--value', '1'],
         web3
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)

--- a/packages/cli/src/commands/transfer/erc20.test.ts
+++ b/packages/cli/src/commands/transfer/erc20.test.ts
@@ -1,10 +1,10 @@
-import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
+import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
 import { ContractKit, StableToken, newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import TransferERC20 from './erc20'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -101,7 +101,7 @@ testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
           '--from',
           accounts[0],
           '--to',
-          SANCTIONED_ADDRESSES[0],
+          TEST_SANCTIONED_ADDRESS,
           '--value',
           '1',
           '--erc20Address',

--- a/packages/cli/src/commands/transfer/euros.test.ts
+++ b/packages/cli/src/commands/transfer/euros.test.ts
@@ -1,10 +1,10 @@
-import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
+import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
 import { ContractKit, StableToken, newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import TransferEURO from './euros'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -70,7 +70,7 @@ testWithAnvilL1('transfer:euros cmd', (web3: Web3) => {
     await expect(
       testLocallyWithWeb3Node(
         TransferEURO,
-        ['--from', accounts[1], '--to', SANCTIONED_ADDRESSES[0], '--value', '1'],
+        ['--from', accounts[1], '--to', TEST_SANCTIONED_ADDRESS, '--value', '1'],
         web3
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)

--- a/packages/cli/src/commands/transfer/reals.test.ts
+++ b/packages/cli/src/commands/transfer/reals.test.ts
@@ -1,10 +1,10 @@
-import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
+import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
 import { ContractKit, StableToken, newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import TransferReals from './reals'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -74,7 +74,7 @@ testWithAnvilL2('transfer:reals cmd', (web3: Web3) => {
     await expect(
       testLocallyWithWeb3Node(
         TransferReals,
-        ['--from', accounts[1], '--to', SANCTIONED_ADDRESSES[0], '--value', '1'],
+        ['--from', accounts[1], '--to', TEST_SANCTIONED_ADDRESS, '--value', '1'],
         web3
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)

--- a/packages/cli/src/commands/transfer/stable.test.ts
+++ b/packages/cli/src/commands/transfer/stable.test.ts
@@ -1,10 +1,10 @@
-import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
+import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
 import { ContractKit, StableToken, newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import TransferStable from './stable'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -90,7 +90,7 @@ testWithAnvilL2('transfer:stable cmd', (web3: Web3) => {
           '--from',
           accounts[0],
           '--to',
-          SANCTIONED_ADDRESSES[0],
+          TEST_SANCTIONED_ADDRESS,
           '--value',
           '1',
           '--stableToken',

--- a/packages/cli/src/test-utils/cliUtils.ts
+++ b/packages/cli/src/test-utils/cliUtils.ts
@@ -65,3 +65,5 @@ export function stripAnsiCodesFromNestedArray(arrays: Array<string[]>) {
 
 export const LONG_TIMEOUT_MS = 10 * 1000
 export const EXTRA_LONG_TIMEOUT_MS = 60 * 1000
+
+export const TEST_SANCTIONED_ADDRESS = '0x01e2919679362dfbc9ee1644ba9c6da6d6245bb1'

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -1,9 +1,4 @@
 import { eqAddress, NULL_ADDRESS } from '@celo/base/lib/address'
-import {
-  COMPLIANT_ERROR_RESPONSE,
-  OFAC_SANCTIONS_LIST_URL,
-  SANCTIONED_ADDRESSES,
-} from '@celo/compliance'
 import { Address } from '@celo/connect'
 import { StableToken } from '@celo/contractkit'
 import { AccountsWrapper } from '@celo/contractkit/lib/wrappers/Accounts'
@@ -52,7 +47,7 @@ export function newCheckBuilder(cmd: BaseCommand, signer?: Address) {
 
 class CheckBuilder {
   private checks: CommandCheck[] = []
-
+  private COMPLIANT_ERROR_RESPONSE = 'Address is on the OFAC sanctions list'
   constructor(private cmd: BaseCommand, private signer?: Address) {}
 
   async getWeb3() {
@@ -351,7 +346,7 @@ class CheckBuilder {
         const isSanctioned = await this.fetchIsSanctioned(address)
         return !isSanctioned
       },
-      COMPLIANT_ERROR_RESPONSE
+      this.COMPLIANT_ERROR_RESPONSE
     )
   }
 
@@ -605,15 +600,18 @@ class CheckBuilder {
   // SANCTIONED_ADDRESSES is so well typed that if you call includes with a string it gives a type error.
   // same if you make it a set or use indexOf so concat it with an empty string to give type without needing to ts-ignore
   private readonly SANCTIONED_SET = {
-    data: new Set([''].concat(SANCTIONED_ADDRESSES)),
+    data: new Set([''].concat()),
     wasRefreshed: false,
   }
 
   private async fetchIsSanctioned(address: string) {
+    const { COMPLIANT_ERROR_RESPONSE, OFAC_SANCTIONS_LIST_URL, SANCTIONED_ADDRESSES } =
+      await import('@celo/compliance')
+
     // Would like to avoid calling this EVERY run. but at least calling
     // twice in a row (such as when checking from and to addresses) should be cached
     // using boolean because either it's been refreshed or this is the first run of the invocation. its short lived
-    if (!this.SANCTIONED_SET.wasRefreshed) {
+    if (!this.SANCTIONED_SET.wasRefreshed || this.SANCTIONED_SET.data.size === 0) {
       try {
         const result = await fetch(OFAC_SANCTIONS_LIST_URL)
         const data = await result.json()
@@ -622,8 +620,13 @@ class CheckBuilder {
           this.SANCTIONED_SET.wasRefreshed = true
         }
       } catch (e) {
-        console.error('Error fetching OFAC sanctions list', e)
+        ;(this.SANCTIONED_SET.data =
+          this.SANCTIONED_SET.data.size === 0
+            ? new Set([''].concat(SANCTIONED_ADDRESSES))
+            : this.SANCTIONED_SET.data),
+          console.error('Error fetching OFAC sanctions list', e)
       }
+      this.COMPLIANT_ERROR_RESPONSE = COMPLIANT_ERROR_RESPONSE
     }
     return this.SANCTIONED_SET.data.has(address)
   }

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -47,7 +47,8 @@ export function newCheckBuilder(cmd: BaseCommand, signer?: Address) {
 
 class CheckBuilder {
   private checks: CommandCheck[] = []
-  private COMPLIANT_ERROR_RESPONSE = 'Address is on the OFAC sanctions list'
+  private COMPLIANT_ERROR_RESPONSE =
+    "'The wallet address has been sanctioned by the U.S. Department of the Treasury.''All U.S. persons are prohibited from accessing, receiving, accepting, or facilitating any property 'and interests in property (including use of any technology, software or software patch(es)) of these'designated digital wallet addresses.  These prohibitions include the making of any contribution or''provision of funds, goods, or services by, to, or for the benefit of any blocked person and the ''receipt of any contribution or provision of funds, goods, or services from any such person and ' 'all designated digital asset wallets.'"
   constructor(private cmd: BaseCommand, private signer?: Address) {}
 
   async getWeb3() {
@@ -607,7 +608,7 @@ class CheckBuilder {
   private async fetchIsSanctioned(address: string) {
     const { COMPLIANT_ERROR_RESPONSE, OFAC_SANCTIONS_LIST_URL, SANCTIONED_ADDRESSES } =
       await import('@celo/compliance')
-
+    this.COMPLIANT_ERROR_RESPONSE = COMPLIANT_ERROR_RESPONSE
     // Would like to avoid calling this EVERY run. but at least calling
     // twice in a row (such as when checking from and to addresses) should be cached
     // using boolean because either it's been refreshed or this is the first run of the invocation. its short lived
@@ -618,6 +619,8 @@ class CheckBuilder {
         if (Array.isArray(data)) {
           this.SANCTIONED_SET.data = new Set(data)
           this.SANCTIONED_SET.wasRefreshed = true
+        } else {
+          this.SANCTIONED_SET.data = new Set([''].concat(SANCTIONED_ADDRESSES))
         }
       } catch (e) {
         ;(this.SANCTIONED_SET.data =
@@ -626,7 +629,6 @@ class CheckBuilder {
             : this.SANCTIONED_SET.data),
           console.error('Error fetching OFAC sanctions list', e)
       }
-      this.COMPLIANT_ERROR_RESPONSE = COMPLIANT_ERROR_RESPONSE
     }
     return this.SANCTIONED_SET.data.has(address)
   }


### PR DESCRIPTION
### Description

got a report about issues with running command. turns out @celo/compliance is esm and that node 20.19 and higher as far as we can tell do not like that. 

Followed the steps recommended in the error message and refactored to use async import. 

#### Other changes

no

### Tested

ran on node 22 


### How to QA

use nvm to install and run on node 20.11. node 20.19. and any version of node 22

### Related issues

- Fixes #561

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily addresses the integration of a new constant `TEST_SANCTIONED_ADDRESS` in various test files, replacing the previous usage of `SANCTIONED_ADDRESSES`. It also includes a patch for `@celo/celocli` to fix compatibility issues with specific Node.js versions.

### Detailed summary
- Added `TEST_SANCTIONED_ADDRESS` constant in `cliUtils.ts`.
- Updated test files (`erc20.test.ts`, `stable.test.ts`, `euros.test.ts`, `reals.test.ts`, `dollars.test.ts`, `celo.test.ts`, `transfer-dollars.test.ts`) to use `TEST_SANCTIONED_ADDRESS` instead of `SANCTIONED_ADDRESSES`.
- Improved error handling in `checks.ts` by dynamically importing compliance data.
- Removed unused imports of `SANCTIONED_ADDRESSES` from `checks.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->