### PR TITLE
is compliance 27 broken?

### DIFF
--- a/.changeset/bright-lions-flash.md
+++ b/.changeset/bright-lions-flash.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+lock celo compliance version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,4 +137,4 @@ jobs:
     if: ${{ needs.install-released-packages.outputs.assertStableVersionOutcome != 'failure' }}
     uses: celo-org/developer-tooling/.github/workflows/upload-celocli-executables.yml@master
     with:
-      commit: ${{ github.sha }}
+      ref: ${{ github.sha }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@celo/abis": "11.0.0",
     "@celo/base": "^7.0.2",
-    "@celo/compliance": "1.0.25",
+    "@celo/compliance": "1.0.28",
     "@celo/connect": "^6.1.2",
     "@celo/contractkit": "^9.1.0",
     "@celo/cryptographic-utils": "^5.1.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@celo/abis": "11.0.0",
     "@celo/base": "^7.0.2",
-    "@celo/compliance": "~1.0.25",
+    "@celo/compliance": "1.0.25",
     "@celo/connect": "^6.1.2",
     "@celo/contractkit": "^9.1.0",
     "@celo/cryptographic-utils": "^5.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,7 +1640,7 @@ __metadata:
     "@celo/abis": "npm:11.0.0"
     "@celo/base": "npm:^7.0.2"
     "@celo/celo-devchain": "npm:^7.0.0"
-    "@celo/compliance": "npm:~1.0.25"
+    "@celo/compliance": "npm:1.0.25"
     "@celo/connect": "npm:^6.1.2"
     "@celo/contractkit": "npm:^9.1.0"
     "@celo/cryptographic-utils": "npm:^5.1.3"
@@ -1698,7 +1698,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@celo/compliance@npm:~1.0.25":
+"@celo/compliance@npm:1.0.25":
   version: 1.0.25
   resolution: "@celo/compliance@npm:1.0.25"
   checksum: cf3f6fd898460b16aedbf1db4f4d560e96c6944fff6b41520867219cfc97f8824be6ccc1133819c8d58b3c2e8252e52bf5c8f4d3ab12151c95d3b8241c038bdf

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,7 +1640,7 @@ __metadata:
     "@celo/abis": "npm:11.0.0"
     "@celo/base": "npm:^7.0.2"
     "@celo/celo-devchain": "npm:^7.0.0"
-    "@celo/compliance": "npm:1.0.25"
+    "@celo/compliance": "npm:1.0.28"
     "@celo/connect": "npm:^6.1.2"
     "@celo/contractkit": "npm:^9.1.0"
     "@celo/cryptographic-utils": "npm:^5.1.3"
@@ -1698,10 +1698,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@celo/compliance@npm:1.0.25":
-  version: 1.0.25
-  resolution: "@celo/compliance@npm:1.0.25"
-  checksum: cf3f6fd898460b16aedbf1db4f4d560e96c6944fff6b41520867219cfc97f8824be6ccc1133819c8d58b3c2e8252e52bf5c8f4d3ab12151c95d3b8241c038bdf
+"@celo/compliance@npm:1.0.28":
+  version: 1.0.28
+  resolution: "@celo/compliance@npm:1.0.28"
+  checksum: ecb31c0b9a21c0d413ace3ea36bbba97531eb58e9171cf4e6939092c4fc00b45e527c57243efbf5646cf44dae948696e89771ab9c020a1b8b10509ee7bebe873
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the version of the `@celo/compliance` package from `1.0.25` to `1.0.28` across multiple files, including the `package.json` and `yarn.lock`, ensuring consistency in dependency management.

### Detailed summary
- Updated `@celo/compliance` version from `~1.0.25` to `1.0.28` in `packages/cli/package.json`.
- Updated `@celo/compliance` version from `npm:~1.0.25` to `npm:1.0.28` in `yarn.lock`.
- Updated metadata for `@celo/compliance` to reflect new version and checksum.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->