### PR TITLE
prepare 6.2.1

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@celo/celocli": "6.2.0",

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,7 +86,7 @@ jobs:
     name: Install Released Packages
     needs: [prepare, release]
     outputs:
-      assertStableVersionOutcome: ${{ steps.assertStableVersion.outcome }}
+      assetStableCLIRelease: ${{ steps.assertStableVersion.outcome }}
     if: needs.release.outputs.published == 'true' && needs.prepare.outputs.result
     runs-on: ubuntu-latest
     container:
@@ -124,14 +124,14 @@ jobs:
 
   open-docs-pr:
     needs: [install-released-packages]
-    if: ${{ needs.install-released-packages.outputs.assertStableVersionOutcome != 'failure' }}
+    if: ${{ needs.install-released-packages.outputs.assetStableCLIRelease != 'failure' }}
     uses: celo-org/developer-tooling/.github/workflows/open-docs-pr.yml@master
     with:
       commit: ${{ github.sha }}
 
   upload-executables:
     needs: [install-released-packages]
-    if: ${{ needs.install-released-packages.outputs.assertStableVersionOutcome != 'failure' }}
+    if: ${{ needs.install-released-packages.outputs.assetStableCLIRelease != 'failure' }}
     uses: celo-org/developer-tooling/.github/workflows/upload-celocli-executables.yml@master
     with:
       ref: ${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - hotfixes
+      - chore/release-3-26
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - hotfixes
+      - chore/release-3-26
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -61,7 +62,7 @@ jobs:
   # release gives an array of published packages as jsob objects, we need an array of strings for installing
   prepare:
     name: Format Output for Install
-    if: needs.publish.outputs.published == 'true'
+    if: needs.release.outputs.published == 'true'
     needs: release
     runs-on: ubuntu-latest
     container:
@@ -87,7 +88,7 @@ jobs:
     needs: [prepare, release]
     outputs:
       assertStableVersionOutcome: ${{ steps.assertStableVersion.outcome }}
-    if: needs.publish.outputs.published == 'true' && needs.prepare.outputs.result
+    if: needs.release.outputs.published == 'true' && needs.prepare.outputs.result
     runs-on: ubuntu-latest
     container:
       image: node:20-bullseye

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
   # release gives an array of published packages as jsob objects, we need an array of strings for installing
   prepare:
     name: Format Output for Install
-    if: needs.release.outputs.published
+    if: needs.publish.outputs.published == 'true'
     needs: release
     runs-on: ubuntu-latest
     container:
@@ -71,10 +71,8 @@ jobs:
       result: '${{ steps.map.outputs.output }}'
     steps:
       - name: Install jq
-        if: needs.release.outputs.published
         uses: dcarbone/install-jq-action@v3.0.1
       - name: Format Published Packages Array
-        if: needs.release.outputs.published
         uses: cloudposse/github-action-jq@main
         id: map
         with:
@@ -90,7 +88,7 @@ jobs:
     needs: [prepare, release]
     outputs:
       assertStableVersionOutcome: ${{ steps.assertStableVersion.outcome }}
-    if: needs.release.outputs.published
+    if: needs.publish.outputs.published == 'true' && needs.prepare.outputs.result
     runs-on: ubuntu-latest
     container:
       image: node:20-bullseye
@@ -126,15 +124,15 @@ jobs:
           ./scripts/assert_stable_version "$version"
 
   open-docs-pr:
-    needs: [install-released-packages, release]
-    if: ${{ needs.release.outputs.published && needs.install-released-packages.outputs.assertStableVersionOutcome != 'failure' }}
+    needs: [install-released-packages]
+    if: ${{ needs.install-released-packages.outputs.assertStableVersionOutcome != 'failure' }}
     uses: celo-org/developer-tooling/.github/workflows/open-docs-pr.yml@master
     with:
       commit: ${{ github.sha }}
 
   upload-executables:
-    needs: [install-released-packages, release]
-    if: ${{ needs.release.outputs.published && needs.install-released-packages.outputs.assertStableVersionOutcome != 'failure' }}
+    needs: [install-released-packages]
+    if: ${{ needs.install-released-packages.outputs.assertStableVersionOutcome != 'failure' }}
     uses: celo-org/developer-tooling/.github/workflows/upload-celocli-executables.yml@master
     with:
       ref: ${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - hotfixes
-      - chore/release-3-26
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,15 +126,15 @@ jobs:
           ./scripts/assert_stable_version "$version"
 
   open-docs-pr:
-    needs: release
-    if: ${{ contains(fromJson(needs.release.outputs.publishedPackages).*.name, '@celo/celocli') }}
+    needs: [install-released-packages, release]
+    if: ${{ needs.release.outputs.published && needs.install-released-packages.outputs.assertStableVersionOutcome != 'failure' }}
     uses: celo-org/developer-tooling/.github/workflows/open-docs-pr.yml@master
     with:
       commit: ${{ github.sha }}
 
   upload-executables:
-    needs: install-released-packages
-    if: ${{ needs.install-released-packages.outputs.assertStableVersionOutcome != 'failure' }}
+    needs: [install-released-packages, release]
+    if: ${{ needs.release.outputs.published && needs.install-released-packages.outputs.assertStableVersionOutcome != 'failure' }}
     uses: celo-org/developer-tooling/.github/workflows/upload-celocli-executables.yml@master
     with:
       ref: ${{ github.sha }}


### PR DESCRIPTION
when releasing fix it so that dry runs dont dont look like failures and also finally dont open docs prs when we are just releasing betas

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the workflow configuration for package releases and adjustments to conditional checks for certain steps. It changes the mode in the `pre.json` file and modifies various conditions in the `.github/workflows/release.yaml` file to ensure correct execution flow.

### Detailed summary
- Changed `mode` from `pre` to `exit` in `.changeset/pre.json`.
- Updated conditional checks in `.github/workflows/release.yaml` to compare outputs against `'true'`.
- Modified job dependencies and conditions for `open-docs-pr` and `upload-executables` to enhance execution logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->