### PR TITLE
ci: checkout the scripts folder

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,6 +114,13 @@ jobs:
           echo "checking celo community fund balance"
           celocli account:balance 0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972 --node celo
           celocli network:whitelist --node alfajores
+
+      - name: Checkout Repo
+        if: contains(matrix.package, '@celo/celocli')
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts
       - name: Is stable celocli release
         id: assertStableVersion
         if: contains(matrix.package, '@celo/celocli')


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the GitHub Actions workflow for the `celocli` project, specifically by adding a step to check out the repository with a sparse checkout for the `scripts` directory when the `@celo/celocli` package is included.

### Detailed summary
- Added a new step named `Checkout Repo` to the workflow.
- The new step is conditionally executed if the matrix includes `@celo/celocli`.
- The checkout uses `actions/checkout@v4` with a sparse checkout configuration for the `scripts` directory.
- Removed the step `Is stable celocli release` from the workflow.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->