### PR TITLE
Migrate account:balance to viem

### DIFF
--- a/packages/cli/src/commands/account/balance.test.ts
+++ b/packages/cli/src/commands/account/balance.test.ts
@@ -4,11 +4,13 @@ import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
 import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import Lock from '../lockedcelo/lock'
+import Unlock from '../lockedcelo/unlock'
 import Balance from './balance'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('account:set-name cmd', (web3: Web3) => {
+testWithAnvilL2('account:balance cmd', (web3: Web3) => {
   const consoleMock = jest.spyOn(console, 'log')
   let accounts: string[] = []
   let kit: ContractKit
@@ -19,55 +21,61 @@ testWithAnvilL2('account:set-name cmd', (web3: Web3) => {
     consoleMock.mockClear()
   })
 
-  it('shows the balance of the account in several currencies', async () => {
+  it('shows the balance of the account for CELO only', async () => {
+    await testLocallyWithWeb3Node(Lock, ['--from', accounts[0], '--value', '1234567890'], web3)
+    await testLocallyWithWeb3Node(Unlock, ['--from', accounts[0], '--value', '890'], web3)
+
+    consoleMock.mockClear()
+
     await testLocallyWithWeb3Node(Balance, [accounts[0]], web3)
 
     expect(stripAnsiCodesFromNestedArray(consoleMock.mock.calls)).toMatchInlineSnapshot(`
       [
         [
-          "All balances expressed in units of 10^-18.",
+          "All balances expressed in units of wei.",
         ],
         [
-          "lockedCELO: 0
-      pending: 0
-      CELO: 1e+24
-      cUSD: 0
-      cEUR: 0
-      cREAL: 0",
+          "CELO: 999999999153393765432110 (~9.9999999915339376543211e+23)
+      cEUR: 0 
+      cREAL: 0 
+      cUSD: 0 
+      lockedCELO: 1234567000 (~1.234567e+9)
+      pending: 890 ",
         ],
       ]
     `)
   })
 
-  it('shows the balance of the account in given currency', async () => {
-    const amount = new BigNumber('1234567890000000000000')
-    await topUpWithToken(kit, StableToken.cUSD, accounts[0], amount)
+  it('shows the balance of the account for different tokens', async () => {
+    const cUSDAmount = new BigNumber('1234567890000000000000')
+    const cEURAmount = new BigNumber('2345678900000000000000')
+    const cREALAmount = new BigNumber('3456789000000000000000')
+
+    await topUpWithToken(kit, StableToken.cUSD, accounts[0], cUSDAmount)
+    await topUpWithToken(kit, StableToken.cEUR, accounts[0], cEURAmount)
+    await topUpWithToken(kit, StableToken.cREAL, accounts[0], cREALAmount)
 
     await testLocallyWithWeb3Node(
       Balance,
-      [
-        accounts[0],
-        '--erc20Address',
-        (await kit.contracts.getStableToken(StableToken.cUSD)).address,
-      ],
+      [accounts[0], '--erc20Address', (await kit.contracts.getGoldToken()).address],
       web3
     )
 
     expect(stripAnsiCodesFromNestedArray(consoleMock.mock.calls)).toMatchInlineSnapshot(`
       [
         [
-          "All balances expressed in units of 10^-18.",
+          "All balances expressed in units of wei.",
         ],
         [
-          "lockedCELO: 0
-      pending: 0
-      CELO: 1e+24
-      cUSD: ${amount.toExponential()}
-      cEUR: 0
-      cREAL: 0",
+          "CELO: 1000000000000000000000000 (~1e+24)
+      cEUR: 2345678900000000000000 (~2.3456789e+21)
+      cREAL: 3456789000000000000000 (~3.456789e+21)
+      cUSD: 1234567890000000000000 (~1.23456789e+21)
+      lockedCELO: 0 
+      pending: 0 ",
         ],
         [
-          "erc20: ${amount.toExponential()}",
+          "erc20: 1000000000000000000000000 (~1e+24)",
         ],
       ]
     `)

--- a/packages/cli/src/commands/account/balance.ts
+++ b/packages/cli/src/commands/account/balance.ts
@@ -1,4 +1,5 @@
-import { Address, erc20Abi, getContract, PublicClient } from 'viem'
+import { StrongAddress } from '@celo/base'
+import { erc20Abi, getContract, PublicClient } from 'viem'
 import { BaseCommand } from '../../base'
 import { getTotalBalance } from '../../packages-to-be/account'
 import { failWith, printValueMapRecursive } from '../../utils/cli'
@@ -32,7 +33,7 @@ export default class Balance extends BaseCommand {
 
     // TODO this typing needs to be handled better...
     printValueMapRecursive(
-      await getTotalBalance(client as any as PublicClient, args.arg1 as Address)
+      await getTotalBalance(client as any as PublicClient, args.arg1 as StrongAddress)
     )
 
     if (flags.erc20Address) {
@@ -44,7 +45,7 @@ export default class Balance extends BaseCommand {
 
       try {
         printValueMapRecursive({
-          erc20: await erc20Contract.read.balanceOf([args.arg1 as Address]),
+          erc20: await erc20Contract.read.balanceOf([args.arg1 as StrongAddress]),
         })
       } catch {
         failWith('Invalid erc20 address')

--- a/packages/cli/src/packages-to-be/account.ts
+++ b/packages/cli/src/packages-to-be/account.ts
@@ -26,44 +26,58 @@ export const getTotalBalance = async (
   cEUR: bigint
   cREAL: bigint
 }> => {
-  const lockedCeloAddress = await resolveAddress(client, 'LockedGold')
+  const [lockedCeloAddress, celoTokenAddress, cUSDAddress, cEURAddress, cREALAddress] =
+    await Promise.all(
+      (['LockedGold', 'GoldToken', 'StableToken', 'StableTokenEUR', 'StableTokenBRL'] as const).map(
+        (contractName) => resolveAddress(client, contractName)
+      )
+    )
 
-  return {
-    lockedCELO: await client.readContract({
+  const [lockedCELO, pending, CELO, cUSD, cEUR, cREAL] = await Promise.all([
+    client.readContract({
       address: lockedCeloAddress,
       abi: lockedGoldABI,
       functionName: 'getAccountTotalLockedGold',
       args: [address],
     }),
-    pending: await client.readContract({
+    client.readContract({
       address: lockedCeloAddress,
       abi: lockedGoldABI,
       functionName: 'getTotalPendingWithdrawals',
       args: [address],
     }),
-    CELO: await client.readContract({
-      address: await resolveAddress(client, 'GoldToken'),
+    client.readContract({
+      address: celoTokenAddress,
       abi: erc20Abi,
       functionName: 'balanceOf',
       args: [address],
     }),
-    cUSD: await client.readContract({
-      address: await resolveAddress(client, 'StableToken'),
+    client.readContract({
+      address: cUSDAddress,
       abi: erc20Abi,
       functionName: 'balanceOf',
       args: [address],
     }),
-    cEUR: await client.readContract({
-      address: await resolveAddress(client, 'StableTokenEUR'),
+    client.readContract({
+      address: cEURAddress,
       abi: erc20Abi,
       functionName: 'balanceOf',
       args: [address],
     }),
-    cREAL: await client.readContract({
-      address: await resolveAddress(client, 'StableTokenBRL'),
+    client.readContract({
+      address: cREALAddress,
       abi: erc20Abi,
       functionName: 'balanceOf',
       args: [address],
     }),
+  ] as const)
+
+  return {
+    lockedCELO,
+    pending,
+    CELO,
+    cUSD,
+    cEUR,
+    cREAL,
   }
 }

--- a/packages/cli/src/packages-to-be/chains.ts
+++ b/packages/cli/src/packages-to-be/chains.ts
@@ -1,0 +1,29 @@
+import { defineChain } from 'viem'
+
+export const celoBaklava = /*#__PURE__*/ defineChain({
+  id: 62_320,
+  name: 'Baklava',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'CELO',
+    symbol: 'B-CELO',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://baklava-forno.celo-testnet.org'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Celo Baklava Explorer',
+      url: 'https://celo-baklava.blockscout.com',
+      apiUrl: 'https://celo-baklava.blockscout.com/api',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+    },
+  },
+  testnet: true,
+})

--- a/packages/cli/src/packages-to-be/client.ts
+++ b/packages/cli/src/packages-to-be/client.ts
@@ -1,4 +1,8 @@
 import { PublicClient, Transport } from 'viem'
 import { celo, celoAlfajores } from 'viem/chains'
+import { celoBaklava } from './chains'
 
-export type CeloClient = PublicClient<Transport, typeof celo | typeof celoAlfajores>
+export type CeloClient = PublicClient<
+  Transport,
+  typeof celo | typeof celoAlfajores | typeof celoBaklava
+>

--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -152,9 +152,10 @@ function toStringValueMapRecursive(valueMap: Record<string, any>, prefix: string
     }
 
     if (typeof v === 'bigint') {
-      const extra = v > 1000n ? `(~${bigintToExponential(v)})` : ''
 
-      return `${v} ${extra}`
+      const asSciNotation = v > 1000n ? `(~${bigintToExponential(v)})` : ''
+
+      return `${v} ${asSciNotation}`
     }
 
     return chalk`${v}`

--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -150,6 +150,13 @@ function toStringValueMapRecursive(valueMap: Record<string, any>, prefix: string
       }
       return '\n' + toStringValueMapRecursive(v, prefix + '  ')
     }
+
+    if (typeof v === 'bigint') {
+      const extra = v > 1000n ? `(~${bigintToExponential(v)})` : ''
+
+      return `${v} ${extra}`
+    }
+
     return chalk`${v}`
   }
   return Object.keys(valueMap)
@@ -186,4 +193,15 @@ export function humanizeRequirements(requirements: LockedGoldRequirements) {
     maxDecimalPoints: 1,
   })
   return { requiredCelo, requiredDays }
+}
+
+// TODO this will have to be refactored not to use BigNumber
+// once we drop its usage
+function bigintToExponential(value: bigint) {
+  // as per the check in `toStringValueMapRecursive`
+  if (value <= 1000n) {
+    return value.toString()
+  }
+
+  return new BigNumber(value.toString()).toExponential()
 }

--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -152,7 +152,6 @@ function toStringValueMapRecursive(valueMap: Record<string, any>, prefix: string
     }
 
     if (typeof v === 'bigint') {
-
       const asSciNotation = v > 1000n ? `(~${bigintToExponential(v)})` : ''
 
       return `${v} ${asSciNotation}`
@@ -199,10 +198,5 @@ export function humanizeRequirements(requirements: LockedGoldRequirements) {
 // TODO this will have to be refactored not to use BigNumber
 // once we drop its usage
 function bigintToExponential(value: bigint) {
-  // as per the check in `toStringValueMapRecursive`
-  if (value <= 1000n) {
-    return value.toString()
-  }
-
   return new BigNumber(value.toString()).toExponential()
 }


### PR DESCRIPTION
### Description

This PR migrates `account:balance` to viem.

#### Other changes

Adds bigint printing support to cli utils.

### Tested

Ran tests and ran the command vs a local anvil node.

### How to QA

`NO_SYNCCHECK=1 yarn workspace @celo/celocli run dev account:balance 0x5409ED021D9299bf6814279A6A1411A7e866A631 --node http://127.0.0.1:8545`

### Related issues

- Fixes #555

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for the `celoBaklava` chain to the Celo client, enhancing balance retrieval functionality, and improving the display of balances in the CLI.

### Detailed summary
- Added `celoBaklava` chain definition in `chains.ts`.
- Updated `CeloClient` type to include `celoBaklava`.
- Modified balance retrieval in `Balance` command to use `getTotalBalance`.
- Improved console output for balance display, converting values to wei.
- Refactored tests to align with new balance retrieval logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->