### PR TITLE
add command to view info about epoch

### DIFF
--- a/.changeset/short-cobras-deny.md
+++ b/.changeset/short-cobras-deny.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+Add epoch:status command to view information on the current epoch

--- a/packages/cli/src/commands/epochs/status.test.ts
+++ b/packages/cli/src/commands/epochs/status.test.ts
@@ -1,0 +1,115 @@
+import { newKitFromWeb3 } from '@celo/contractkit'
+import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
+import { ux } from '@oclif/core'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import Start from './start'
+import Status from './status'
+
+process.env.NO_SYNCCHECK = 'true'
+
+testWithAnvilL2('epochs:status cmd', (web3) => {
+  it('shows the current status of the epoch', async () => {
+    const consoleMock = jest.spyOn(ux.write, 'stdout')
+    const kit = newKitFromWeb3(web3)
+    const epochManagerWrapper = await kit.contracts.getEpochManager()
+
+    expect(await epochManagerWrapper.getCurrentEpochNumber()).toEqual(4)
+    await expect(testLocallyWithWeb3Node(Status, ['--output', 'csv'], web3)).resolves.toBe(true)
+
+    expect(consoleMock.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "Query,Response
+      ",
+        ],
+        [
+          "Current Epoch Number,4n
+      ",
+        ],
+        [
+          "First Block of Epoch,300n
+      ",
+        ],
+        [
+          "Last Block of Epoch,0n
+      ",
+        ],
+        [
+          "Has Epoch Processing Begun?,false
+      ",
+        ],
+        [
+          "Is In Epoch Process?,false
+      ",
+        ],
+        [
+          "Is Processing Individually?,false
+      ",
+        ],
+        [
+          "Is Time for Next Epoch,false
+      ",
+        ],
+        [
+          "Epoch Start Time,2025-02-03T21:50:43.000Z
+      ",
+        ],
+      ]
+    `)
+  })
+  describe('when the epoch has is processing', () => {
+    beforeEach(async () => {
+      const accounts = await web3.eth.getAccounts()
+      await testLocallyWithWeb3Node(Start, ['--from', accounts[0]], web3)
+    })
+    it('shows the current status of the epoch', async () => {
+      const consoleMock = jest.spyOn(ux.write, 'stdout')
+      const kit = newKitFromWeb3(web3)
+      const epochManagerWrapper = await kit.contracts.getEpochManager()
+
+      expect(await epochManagerWrapper.getCurrentEpochNumber()).toEqual(4)
+      await expect(testLocallyWithWeb3Node(Status, ['--output', 'csv'], web3)).resolves.toBe(true)
+
+      expect(consoleMock.mock.calls).toMatchInlineSnapshot(`
+        [
+          [
+            "Query,Response
+        ",
+          ],
+          [
+            "Current Epoch Number,4n
+        ",
+          ],
+          [
+            "First Block of Epoch,300n
+        ",
+          ],
+          [
+            "Last Block of Epoch,0n
+        ",
+          ],
+          [
+            "Has Epoch Processing Begun?,true
+        ",
+          ],
+          [
+            "Is In Epoch Process?,true
+        ",
+          ],
+          [
+            "Is Processing Individually?,false
+        ",
+          ],
+          [
+            "Is Time for Next Epoch,true
+        ",
+          ],
+          [
+            "Epoch Start Time,2025-02-03T21:50:43.000Z
+        ",
+          ],
+        ]
+      `)
+    })
+  })
+})

--- a/packages/cli/src/commands/epochs/status.ts
+++ b/packages/cli/src/commands/epochs/status.ts
@@ -1,0 +1,78 @@
+import { ux } from '@oclif/core'
+import { PublicClient } from 'viem'
+import { BaseCommand } from '../../base'
+import { getEpochManagerContract } from '../../packages-to-be/contracts'
+
+export default class EpochStatus extends BaseCommand {
+  static description = 'View epoch info.'
+
+  static flags = {
+    node: BaseCommand.flags.node,
+    ...(ux.table.flags() as object),
+  }
+
+  static aliases: string[] = ['epochs:current']
+
+  static args = {}
+
+  static examples = []
+
+  async run() {
+    const res = await this.parse(EpochStatus)
+
+    const client = await this.getPublicClient()
+    ux.action.start('Fetching current epoch information')
+
+    const epochManager = await getEpochManagerContract(client as unknown as PublicClient)
+
+    const results = await Promise.allSettled([
+      epochManager.read.getCurrentEpoch(),
+      epochManager.read.getCurrentEpochNumber(),
+      epochManager.read.isEpochProcessingStarted(),
+      epochManager.read.isOnEpochProcess(),
+      epochManager.read.isIndividualProcessing(),
+      epochManager.read.isTimeForNextEpoch(),
+    ])
+    ux.action.stop('Done\n')
+
+    const [
+      currentEpoch,
+      currentEpochNumber,
+      isEpochProcessingStarted,
+      isOnEpochProcess,
+      isIndividualProcessing,
+      isTimeForNextEpoch,
+    ] = results.map((result) => (result.status === 'fulfilled' ? result.value : result.reason))
+
+    const [firstBlock, lastBlock, startTimestamp] = currentEpoch
+
+    ux.table(
+      [
+        { key: 'Current Epoch Number', value: currentEpochNumber },
+        { key: 'First Block of Epoch', value: firstBlock },
+        { key: 'Last Block of Epoch', value: lastBlock },
+        { key: 'Has Epoch Processing Begun?', value: isEpochProcessingStarted },
+        { key: 'Is In Epoch Process?', value: isOnEpochProcess },
+        { key: 'Is Processing Individually?', value: isIndividualProcessing },
+        { key: 'Is Time for Next Epoch', value: isTimeForNextEpoch },
+        {
+          key: 'Epoch Start Time',
+          value:
+            typeof startTimestamp === 'bigint'
+              ? new Date(Number(startTimestamp.toString()) * 1000).toISOString()
+              : startTimestamp,
+        },
+      ],
+      {
+        key: {
+          header: 'Query',
+        },
+        value: {
+          header: 'Response',
+        },
+      },
+      res.flags
+    )
+    return true
+  }
+}

--- a/packages/cli/src/packages-to-be/address-resolver.ts
+++ b/packages/cli/src/packages-to-be/address-resolver.ts
@@ -13,6 +13,7 @@ export type ContractName =
   | 'Governance'
   | 'LockedGold'
   | 'Validators'
+  | 'EpochManager'
   | 'GoldToken'
   | 'StableToken'
   | 'StableTokenEUR'

--- a/packages/cli/src/packages-to-be/contracts.ts
+++ b/packages/cli/src/packages-to-be/contracts.ts
@@ -1,4 +1,10 @@
-import { accountsABI, governanceABI, lockedGoldABI, validatorsABI } from '@celo/abis-12'
+import {
+  accountsABI,
+  epochManagerABI,
+  governanceABI,
+  lockedGoldABI,
+  validatorsABI,
+} from '@celo/abis-12'
 import { getContract, GetContractReturnType, PublicClient } from 'viem'
 import { resolveAddress } from './address-resolver'
 
@@ -34,7 +40,16 @@ export const getValidatorsContract = async (client: PublicClient): Promise<Valid
   })
 }
 
+export const getEpochManagerContract = async (client: PublicClient): Promise<EpochManager> => {
+  return getContract({
+    address: await resolveAddress(client, 'EpochManager'),
+    abi: epochManagerABI,
+    client,
+  })
+}
+
 export type AccountsContract = GetContractReturnType<typeof accountsABI, PublicClient>
 export type GovernanceContract = GetContractReturnType<typeof governanceABI, PublicClient>
 export type LockedGoldContract = GetContractReturnType<typeof lockedGoldABI, PublicClient>
 export type ValidatorsContract = GetContractReturnType<typeof validatorsABI, PublicClient>
+export type EpochManager = GetContractReturnType<typeof epochManagerABI, PublicClient>

--- a/packages/cli/src/packages-to-be/getEpochInfo.ts
+++ b/packages/cli/src/packages-to-be/getEpochInfo.ts
@@ -1,0 +1,16 @@
+import { PublicClient } from 'viem'
+import { getEpochManagerContract } from './contracts'
+
+export async function getEpochInfo(client: PublicClient) {
+  const epochManager = await getEpochManagerContract(client)
+
+  const results = await Promise.allSettled([
+    epochManager.read.getCurrentEpoch(),
+    epochManager.read.getCurrentEpochNumber(),
+    epochManager.read.isEpochProcessingStarted(),
+    epochManager.read.isOnEpochProcess(),
+    epochManager.read.isIndividualProcessing(),
+    epochManager.read.isTimeForNextEpoch(),
+  ])
+  return results.map((result) => (result.status === 'fulfilled' ? result.value : result.reason))
+}


### PR DESCRIPTION
### Description

Gives basic info about what is happening for current epoch. 

can be pass in --output=csv|json for use in scripts. 


#### example output

<img width="462" alt="Screenshot 2025-03-28 at 16 52 55" src="https://github.com/user-attachments/assets/d73c2275-4c1e-45a4-b61e-d16176bf7f74" />

#### Other changes

adds epoch manager contract to the list of contracts

### Tested

two new tests

### How to QA



### Related issues

- Fixes #496

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `epoch:status` command to the CLI, allowing users to view information about the current epoch in the system. It adds functionality to retrieve and display various epoch-related metrics.

### Detailed summary
- Added `epoch:status` command in `packages/cli/src/commands/epochs/status.ts`.
- Implemented `getEpochInfo` function in `packages/cli/src/packages-to-be/getEpochInfo.ts` to fetch epoch details.
- Created `getEpochManagerContract` function in `packages/cli/src/packages-to-be/contracts.ts`.
- Updated `EpochManager` type in `packages/cli/src/packages-to-be/contracts.ts`.
- Introduced error handling and display logic in the command's run method.
- Added tests for the `epoch:status` command in `packages/cli/src/commands/epochs/status.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->