### PR TITLE
fixes findClaim to fetch latest not first

### DIFF
--- a/.changeset/hungry-bulldogs-smash.md
+++ b/.changeset/hungry-bulldogs-smash.md
@@ -1,0 +1,5 @@
+---
+'@celo/metadata-claims': patch
+---
+
+Fix claims not returning the most recently added claim for a type

--- a/docs/sdk/metadata-claims/classes/metadata.IdentityMetadataWrapper.md
+++ b/docs/sdk/metadata-claims/classes/metadata.IdentityMetadataWrapper.md
@@ -108,7 +108,7 @@
 
 #### Defined in
 
-[packages/sdk/metadata-claims/src/metadata.ts:176](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/metadata-claims/src/metadata.ts#L176)
+[packages/sdk/metadata-claims/src/metadata.ts:181](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/metadata-claims/src/metadata.ts#L181)
 
 ___
 
@@ -134,7 +134,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/metadata-claims/src/metadata.ts:227](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/metadata-claims/src/metadata.ts#L227)
+[packages/sdk/metadata-claims/src/metadata.ts:242](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/metadata-claims/src/metadata.ts#L242)
 
 ___
 
@@ -160,7 +160,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/metadata-claims/src/metadata.ts:223](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/metadata-claims/src/metadata.ts#L223)
+[packages/sdk/metadata-claims/src/metadata.ts:238](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/metadata-claims/src/metadata.ts#L238)
 
 ___
 


### PR DESCRIPTION
### Description

New urls we appended to end of a array but always fetched from start. with no way to delete there was no way to "update" so that the newer url would be used. see #581 

Now we always instead of the first match we return the last match. and when  inserting rather than just returning as is if we find the claim with same url has previously been added we update so it become the most recent. 

#### Other Alternatives

I thought about perhaps adding a findLatest claim method. But it seems to me that pushing claims to the tail but reading from the head is the wrong default. 

### Tested

new tests in metadata mapper!

### How to QA

From root
```bash
yarn
yarn build
cd packages/cli
yarn celocli network:rpc-urls --node celo 
```



### Related issues

- Fixes #581

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the handling of claims in the `IdentityMetadataWrapper` class, ensuring that the most recently added claim of a specific type is returned correctly, even when duplicates exist.

### Detailed summary
- Updated the `addClaim` method to remove existing claims before adding a new one for the same `rpcUrl`.
- Modified the `findClaim` method to return the most recent claim using the `filterClaims` method.
- Added tests to verify the behavior of claims when multiple `rpcUrl` claims are added.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->