### PR TITLE
when we create a changeset it will now automatically commit the file

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
     "@changesets/changelog-github",
     { "repo": "celo-org/developer-tooling" }
   ],
-  "commit": false,
+  "commit": true,
   "fixed": [
     [
       "@celo/wallet-*"


### PR DESCRIPTION

### Description

when we create a changeset it will now automatically commit the file with message like 'docs(changeset): <message>'

I think often we do changesets at the end and need a specific commit for them anyway. if we had been creating changesets in same commit as changes this would be less appealing. 



and i checked it only commits the changeset files not any file with changes. 



#### Other changes

no
### Tested



### How to QA

add a changeset and see how it creates a commit. just dont push to this branch please

### Related issues

none

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on changing the configuration setting in the `.changeset/config.json` file to enable commits when creating changesets in the `celo-org/developer-tooling` repository.

### Detailed summary
- Updated the `commit` property in `.changeset/config.json` from `false` to `true`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->