### PR TITLE
Full Send 

### DIFF
--- a/.changeset/kind-moons-cheer.md
+++ b/.changeset/kind-moons-cheer.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Fix incorrect insufficient balance check for transfers

--- a/packages/cli/src/commands/transfer/celo.test.ts
+++ b/packages/cli/src/commands/transfer/celo.test.ts
@@ -1,9 +1,9 @@
 import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
-import { HttpRpcCaller } from '@celo/connect'
 import { ContractKit, StableToken, newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { mockRpc } from '../../test-utils/mockRpc'
 import TransferCelo from './celo'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -11,28 +11,6 @@ process.env.NO_SYNCCHECK = 'true'
 // Lots of commands, sometimes times out
 jest.setTimeout(15000)
 
-const mockRpc = () =>
-  jest.spyOn(HttpRpcCaller.prototype, 'call').mockImplementation(async (method, _args) => {
-    if (method === 'eth_maxPriorityFeePerGas') {
-      return {
-        result: '20000',
-        id: 1,
-        jsonrpc: '2.0',
-      }
-    }
-    if (method === 'eth_gasPrice') {
-      return {
-        result: '30000',
-        id: 1,
-        jsonrpc: '2.0',
-      }
-    }
-    return {
-      result: 0,
-      id: Math.random(),
-      jsonrpc: '2.0',
-    }
-  })
 testWithAnvilL1('transfer:celo cmd', (web3: Web3) => {
   let accounts: string[] = []
   let kit: ContractKit

--- a/packages/cli/src/commands/transfer/dollars.test.ts
+++ b/packages/cli/src/commands/transfer/dollars.test.ts
@@ -109,22 +109,22 @@ testWithAnvilL1('transfer:dollars cmd', (web3: Web3) => {
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
 
-      expect(logMock.mock.calls).toMatchInlineSnapshot(`
+      expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [
           [
             "Running Checks:",
           ],
           [
-            "[32m   [1m✔[22m  Account has at least 1000 cUSD [39m",
+            "   ✔  Account has at least 1000 cUSD ",
           ],
           [
-            "[32m   [1m✔[22m  Compliant Address [39m",
+            "   ✔  Compliant Address ",
           ],
           [
-            "[32m   [1m✔[22m  Compliant Address [39m",
+            "   ✔  Compliant Address ",
           ],
           [
-            "[31m   [1m✘[22m  Account can afford to transfer cUSD with gas paid in 0x20FE3FD86C231fb8E28255452CEA7851f9C5f9c1 Cannot afford to transfer cUSD with 0x20FE3FD86C231fb8E28255452CEA7851f9C5f9c1 gasCurrency; try reducing value slightly or using a different gasCurrency[39m",
+            "   ✘  Account can afford to transfer cUSD with gas paid in 0x20FE3FD86C231fb8E28255452CEA7851f9C5f9c1 Cannot afford to transfer cUSD with 0x20FE3FD86C231fb8E28255452CEA7851f9C5f9c1 gasCurrency; try reducing value slightly or using a different gasCurrency",
           ],
         ]
       `)

--- a/packages/cli/src/commands/transfer/dollars.test.ts
+++ b/packages/cli/src/commands/transfer/dollars.test.ts
@@ -1,10 +1,15 @@
 import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
-import { ContractKit, StableToken, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromWeb3, StableToken } from '@celo/contractkit'
 import { testWithAnvilL1 } from '@celo/dev-utils/lib/anvil-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import {
+  stripAnsiCodesFromNestedArray,
+  TEST_SANCTIONED_ADDRESS,
+  testLocallyWithWeb3Node,
+} from '../../test-utils/cliUtils'
+import { mockRpc } from '../../test-utils/mockRpc'
 import TransferCUSD from './dollars'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -15,11 +20,11 @@ jest.setTimeout(15000)
 testWithAnvilL1('transfer:dollars cmd', (web3: Web3) => {
   let accounts: string[] = []
   let kit: ContractKit
-
+  let logMock: jest.SpyInstance
   beforeEach(async () => {
     kit = newKitFromWeb3(web3)
     accounts = await web3.eth.getAccounts()
-    jest.spyOn(console, 'log').mockImplementation(() => {})
+    logMock = jest.spyOn(console, 'log').mockImplementation(() => {})
     jest.spyOn(console, 'error').mockImplementation(() => {})
     await topUpWithToken(
       kit,
@@ -62,6 +67,119 @@ testWithAnvilL1('transfer:dollars cmd', (web3: Web3) => {
     )
     const balanceAfter = await kit.getTotalBalance(accounts[0])
     expect(balanceBefore.cUSD).toEqual(balanceAfter.cUSD)
+  })
+  it('will transfer ALL the cusd an address has', async () => {
+    const cusdWrapper = await kit.contracts.getStableToken(StableToken.cUSD)
+    const balance = await cusdWrapper.balanceOf(accounts[0])
+    expect(balance.toFixed()).toEqBigNumber('1000000000000000000000')
+    await testLocallyWithWeb3Node(
+      TransferCUSD,
+      ['--from', accounts[0], '--to', accounts[1], '--value', balance.toFixed()],
+      web3
+    )
+    const balanceAfter = await cusdWrapper.balanceOf(accounts[0])
+    expect(balanceAfter.toFixed()).toEqBigNumber('0')
+  })
+
+  describe('when --gasCurrency matches transfer currency', () => {
+    beforeEach(() => {
+      // need to call this send sending gasCurrency address to the gas price rpc is not supported on anvil.
+      mockRpc()
+    })
+    it('checks that the sender has enough of the token to cover both transfer and pay for gas', async () => {
+      const cusdWrapper = await kit.contracts.getStableToken(StableToken.cUSD)
+      const cusdAddress = cusdWrapper.address
+      const balance = await cusdWrapper.balanceOf(accounts[0])
+      expect(balance.toFixed()).toEqBigNumber('1000000000000000000000')
+      await expect(
+        testLocallyWithWeb3Node(
+          TransferCUSD,
+          [
+            '--from',
+            accounts[0],
+            '--to',
+            accounts[1],
+            '--value',
+            balance.toFixed(),
+            '--gasCurrency',
+            cusdAddress,
+          ],
+
+          web3
+        )
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
+
+      expect(logMock.mock.calls).toMatchInlineSnapshot(`
+        [
+          [
+            "Running Checks:",
+          ],
+          [
+            "[32m   [1m✔[22m  Account has at least 1000 cUSD [39m",
+          ],
+          [
+            "[32m   [1m✔[22m  Compliant Address [39m",
+          ],
+          [
+            "[32m   [1m✔[22m  Compliant Address [39m",
+          ],
+          [
+            "[31m   [1m✘[22m  Account can afford to transfer cUSD with gas paid in 0x20FE3FD86C231fb8E28255452CEA7851f9C5f9c1 Cannot afford to transfer cUSD with 0x20FE3FD86C231fb8E28255452CEA7851f9C5f9c1 gasCurrency; try reducing value slightly or using a different gasCurrency[39m",
+          ],
+        ]
+      `)
+    })
+  })
+
+  describe('when --comment is passed', () => {
+    it('should transfer cUSD with a comment', async () => {
+      const amountToTransfer = '10000000000000000000'
+      const comment = 'Test transfer'
+      await expect(
+        testLocallyWithWeb3Node(
+          TransferCUSD,
+          [
+            '--from',
+            accounts[0],
+            '--to',
+            accounts[1],
+            '--value',
+            amountToTransfer,
+            '--comment',
+            comment,
+          ],
+          web3
+        )
+      ).resolves.toBeUndefined()
+      expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
+        [
+          [
+            "Running Checks:",
+          ],
+          [
+            "   ✔  Account has at least 10 cUSD ",
+          ],
+          [
+            "   ✔  Compliant Address ",
+          ],
+          [
+            "   ✔  Compliant Address ",
+          ],
+          [
+            "   ✔  Account can afford to transfer cUSD with gas paid in CELO ",
+          ],
+          [
+            "All checks passed",
+          ],
+          [
+            "SendTransaction: transferWithComment",
+          ],
+          [
+            "txHash: 0xtxhash",
+          ],
+        ]
+      `)
+    })
   })
 
   test('should fail if to address is sanctioned', async () => {

--- a/packages/cli/src/test-utils/mockRpc.ts
+++ b/packages/cli/src/test-utils/mockRpc.ts
@@ -1,0 +1,24 @@
+import { HttpRpcCaller } from '@celo/connect'
+
+export const mockRpc = () =>
+  jest.spyOn(HttpRpcCaller.prototype, 'call').mockImplementation(async (method, _args) => {
+    if (method === 'eth_maxPriorityFeePerGas') {
+      return {
+        result: '20000',
+        id: 1,
+        jsonrpc: '2.0',
+      }
+    }
+    if (method === 'eth_gasPrice') {
+      return {
+        result: '30000',
+        id: 1,
+        jsonrpc: '2.0',
+      }
+    }
+    return {
+      result: 0,
+      id: Math.random(),
+      jsonrpc: '2.0',
+    }
+  })


### PR DESCRIPTION
### Description

the custom check for if balance is big enough to cover both the sent amount and the full gas costs was not checking that the  fee currency being used actually matched the token being sent. and it would default to assuming gas cost would be paid in the sent currency. 

Now we can send 100% of a token we hold if we pay in celo 

#### Other changes

* added a test for sending with comment, 
* made a few `let`s into `const`s

### Tested

multiple new tests


### How to QA

transfer 

### Related issues

- Fixes #569

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the insufficient balance check for transfers in the `@celo` CLI and improving the testing utilities for transfer commands, ensuring that both transfer amounts and gas fees are accurately validated.

### Detailed summary
- Updated balance check logic in `packages/cli/src/transfer-stable-base.ts` to ensure both transfer and gas fees are covered.
- Refactored `mockRpc` function into `packages/cli/src/test-utils/mockRpc.ts` for cleaner testing.
- Added new tests in `packages/cli/src/commands/transfer/dollars.test.ts` for various transfer scenarios, including gas currency checks.
- Enhanced logging in test cases to provide more insights during execution.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->