### PR TITLE
epoch switch precheck

### DIFF
--- a/.changeset/hungry-radios-smoke.md
+++ b/.changeset/hungry-radios-smoke.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Fix bug in epoch switching

--- a/.changeset/neat-chicken-judge.md
+++ b/.changeset/neat-chicken-judge.md
@@ -1,0 +1,5 @@
+---
+'@celo/contractkit': minor
+---
+
+Add startNextEpochProcessTx that will throw early if needed

--- a/docs/command-line-interface/epochs.md
+++ b/docs/command-line-interface/epochs.md
@@ -3,52 +3,11 @@
 
 Finishes next epoch process.
 
-* [`celocli epochs:current`](#celocli-epochscurrent)
 * [`celocli epochs:finish`](#celocli-epochsfinish)
 * [`celocli epochs:process-groups`](#celocli-epochsprocess-groups)
 * [`celocli epochs:send-validator-payment`](#celocli-epochssend-validator-payment)
 * [`celocli epochs:start`](#celocli-epochsstart)
-* [`celocli epochs:status`](#celocli-epochsstatus)
 * [`celocli epochs:switch`](#celocli-epochsswitch)
-
-## `celocli epochs:current`
-
-View epoch info.
-
-```
-USAGE
-  $ celocli epochs:current [-n <value>] [--columns <value> | -x] [--filter <value>]
-    [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort
-    <value>]
-
-FLAGS
-  -n, --node=<value>     URL of the node to run commands against or an alias
-  -x, --extended         show extra columns
-      --columns=<value>  only show provided columns (comma-separated)
-      --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
-      --no-header        hide table header from output
-      --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
-      --sort=<value>     property to sort by (prepend '-' for descending)
-
-DESCRIPTION
-  View epoch info.
-
-ALIASES
-  $ celocli epochs:current
-
-FLAG DESCRIPTIONS
-  -n, --node=<value>  URL of the node to run commands against or an alias
-
-    Can be a full url like https://forno.celo.org or an alias. default:
-    http://localhost:8545
-    Alias options:
-    local, localhost => 'http://localhost:8545'
-    alfajores => Celo Alfajores Testnet,
-    mainnet, celo, forno => Celo Mainnet chain',
-```
 
 ## `celocli epochs:finish`
 
@@ -292,47 +251,6 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/epochs/start.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/epochs/start.ts)_
-
-## `celocli epochs:status`
-
-View epoch info.
-
-```
-USAGE
-  $ celocli epochs:status [-n <value>] [--columns <value> | -x] [--filter <value>]
-    [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort
-    <value>]
-
-FLAGS
-  -n, --node=<value>     URL of the node to run commands against or an alias
-  -x, --extended         show extra columns
-      --columns=<value>  only show provided columns (comma-separated)
-      --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
-      --no-header        hide table header from output
-      --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
-      --sort=<value>     property to sort by (prepend '-' for descending)
-
-DESCRIPTION
-  View epoch info.
-
-ALIASES
-  $ celocli epochs:current
-
-FLAG DESCRIPTIONS
-  -n, --node=<value>  URL of the node to run commands against or an alias
-
-    Can be a full url like https://forno.celo.org or an alias. default:
-    http://localhost:8545
-    Alias options:
-    local, localhost => 'http://localhost:8545'
-    alfajores => Celo Alfajores Testnet,
-    mainnet, celo, forno => Celo Mainnet chain',
-```
-
-_See code: [src/commands/epochs/status.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/epochs/status.ts)_
 
 ## `celocli epochs:switch`
 

--- a/docs/command-line-interface/epochs.md
+++ b/docs/command-line-interface/epochs.md
@@ -3,11 +3,52 @@
 
 Finishes next epoch process.
 
+* [`celocli epochs:current`](#celocli-epochscurrent)
 * [`celocli epochs:finish`](#celocli-epochsfinish)
 * [`celocli epochs:process-groups`](#celocli-epochsprocess-groups)
 * [`celocli epochs:send-validator-payment`](#celocli-epochssend-validator-payment)
 * [`celocli epochs:start`](#celocli-epochsstart)
+* [`celocli epochs:status`](#celocli-epochsstatus)
 * [`celocli epochs:switch`](#celocli-epochsswitch)
+
+## `celocli epochs:current`
+
+View epoch info.
+
+```
+USAGE
+  $ celocli epochs:current [-n <value>] [--columns <value> | -x] [--filter <value>]
+    [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort
+    <value>]
+
+FLAGS
+  -n, --node=<value>     URL of the node to run commands against or an alias
+  -x, --extended         show extra columns
+      --columns=<value>  only show provided columns (comma-separated)
+      --csv              output is csv format [alias: --output=csv]
+      --filter=<value>   filter property by partial string matching, ex: name=foo
+      --no-header        hide table header from output
+      --no-truncate      do not truncate output to fit screen
+      --output=<option>  output in a more machine friendly format
+                         <options: csv|json|yaml>
+      --sort=<value>     property to sort by (prepend '-' for descending)
+
+DESCRIPTION
+  View epoch info.
+
+ALIASES
+  $ celocli epochs:current
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
+```
 
 ## `celocli epochs:finish`
 
@@ -251,6 +292,47 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/epochs/start.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/epochs/start.ts)_
+
+## `celocli epochs:status`
+
+View epoch info.
+
+```
+USAGE
+  $ celocli epochs:status [-n <value>] [--columns <value> | -x] [--filter <value>]
+    [--no-header | [--csv | --no-truncate]] [--output csv|json|yaml |  | ] [--sort
+    <value>]
+
+FLAGS
+  -n, --node=<value>     URL of the node to run commands against or an alias
+  -x, --extended         show extra columns
+      --columns=<value>  only show provided columns (comma-separated)
+      --csv              output is csv format [alias: --output=csv]
+      --filter=<value>   filter property by partial string matching, ex: name=foo
+      --no-header        hide table header from output
+      --no-truncate      do not truncate output to fit screen
+      --output=<option>  output in a more machine friendly format
+                         <options: csv|json|yaml>
+      --sort=<value>     property to sort by (prepend '-' for descending)
+
+DESCRIPTION
+  View epoch info.
+
+ALIASES
+  $ celocli epochs:current
+
+FLAG DESCRIPTIONS
+  -n, --node=<value>  URL of the node to run commands against or an alias
+
+    Can be a full url like https://forno.celo.org or an alias. default:
+    http://localhost:8545
+    Alias options:
+    local, localhost => 'http://localhost:8545'
+    alfajores => Celo Alfajores Testnet,
+    mainnet, celo, forno => Celo Mainnet chain',
+```
+
+_See code: [src/commands/epochs/status.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/epochs/status.ts)_
 
 ## `celocli epochs:switch`
 

--- a/docs/sdk/contractkit/classes/wrappers_EpochManager.EpochManagerWrapper.md
+++ b/docs/sdk/contractkit/classes/wrappers_EpochManager.EpochManagerWrapper.md
@@ -55,6 +55,7 @@ Contract handling epoch management.
 - [getLessersAndGreaters](wrappers_EpochManager.EpochManagerWrapper.md#getlessersandgreaters)
 - [getPastEvents](wrappers_EpochManager.EpochManagerWrapper.md#getpastevents)
 - [processGroupsTx](wrappers_EpochManager.EpochManagerWrapper.md#processgroupstx)
+- [startNextEpochProcessTx](wrappers_EpochManager.EpochManagerWrapper.md#startnextepochprocesstx)
 - [version](wrappers_EpochManager.EpochManagerWrapper.md#version)
 
 ## Constructors
@@ -628,7 +629,7 @@ BaseWrapperForGoverning.address
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:75](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L75)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:104](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L104)
 
 ___
 
@@ -642,7 +643,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:162](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L162)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:191](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L191)
 
 ___
 
@@ -656,7 +657,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:136](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L136)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:165](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L165)
 
 ___
 
@@ -676,7 +677,7 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:87](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L87)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:116](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L116)
 
 ___
 
@@ -717,7 +718,21 @@ ___
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:81](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L81)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:110](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L110)
+
+___
+
+### startNextEpochProcessTx
+
+▸ **startNextEpochProcessTx**(): `Promise`\<`undefined` \| `CeloTransactionObject`\<`void`\>\>
+
+#### Returns
+
+`Promise`\<`undefined` \| `CeloTransactionObject`\<`void`\>\>
+
+#### Defined in
+
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:75](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L75)
 
 ___
 

--- a/docs/sdk/contractkit/modules/wrappers_EpochManager.md
+++ b/docs/sdk/contractkit/modules/wrappers_EpochManager.md
@@ -29,4 +29,4 @@
 
 #### Defined in
 
-[packages/sdk/contractkit/src/wrappers/EpochManager.ts:175](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L175)
+[packages/sdk/contractkit/src/wrappers/EpochManager.ts:204](https://github.com/celo-org/developer-tooling/blob/master/packages/sdk/contractkit/src/wrappers/EpochManager.ts#L204)

--- a/packages/cli/src/commands/epochs/start.ts
+++ b/packages/cli/src/commands/epochs/start.ts
@@ -30,7 +30,10 @@ export default class Start extends BaseCommand {
     if (await epochManager.isOnEpochProcess()) {
       this.error('Epoch process has already started.')
     }
-
-    await displaySendTx('startNextEpoch', epochManager.startNextEpochProcess())
+    const startProcessTx = await epochManager.startNextEpochProcessTx()
+    if (startProcessTx === undefined) {
+      return
+    }
+    await displaySendTx('startNextEpoch', startProcessTx)
   }
 }

--- a/packages/cli/src/commands/epochs/switch.ts
+++ b/packages/cli/src/commands/epochs/switch.ts
@@ -29,7 +29,11 @@ export default class Switch extends BaseCommand {
 
     const isEpochProcessStarted = await epochManager.isOnEpochProcess()
     if (!isEpochProcessStarted) {
-      await displaySendTx('startNextEpoch', epochManager.startNextEpochProcess())
+      const startProcessTx = await epochManager.startNextEpochProcessTx()
+      if (startProcessTx === undefined) {
+        return
+      }
+      await displaySendTx('startNextEpoch', startProcessTx)
     }
     await displaySendTx('finishNextEpoch', await epochManager.finishNextEpochProcessTx())
   }


### PR DESCRIPTION
### Description

double check everything is as it should be before switching epochs

#### Other changes

no

### Tested

not really

### How to QA

please try running the epoch cli commands

### Related issues

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the epoch management functionality in the `@celo/contractkit` library by introducing a new method that ensures proper checks before starting the next epoch process, improving error handling and preventing potential issues.

### Detailed summary
- Added `startNextEpochProcessTx` method in `EpochManagerWrapper` to validate elected accounts and check if the epoch process has already started.
- Updated `start.ts` and `switch.ts` to use `startNextEpochProcessTx` instead of `startNextEpochProcess`.
- Enhanced error handling when starting the epoch process.
- Updated documentation to reflect changes in method definitions and locations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->