### PR TITLE
Fix admin revoke command for L2

### DIFF
--- a/.changeset/blue-cobras-explode.md
+++ b/.changeset/blue-cobras-explode.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+Fix releasecelo/admin-revoke to work on L2

--- a/.changeset/blue-cobras-explode.md
+++ b/.changeset/blue-cobras-explode.md
@@ -1,5 +1,5 @@
 ---
-'@celo/celocli': minor
+'@celo/celocli': patch
 ---
 
 Fix releasecelo/admin-revoke to work on L2

--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -10,4 +10,6 @@ secret:
     name: account:new test private key
   - match: eb04975ce604ca9ccf7348eb4c6baf299760b4ddcf8ad35b77f23c601c8b7242
     name: wallet-rpc private test key
-version: 2
+  - match: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+    name: admin-rvoke test key  
+version: 3

--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -11,5 +11,5 @@ secret:
   - match: eb04975ce604ca9ccf7348eb4c6baf299760b4ddcf8ad35b77f23c601c8b7242
     name: wallet-rpc private test key
   - match: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-    name: admin-rvoke test key  
+    name: admin-revoke test key 
 version: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - changeset-release/master
       - prerelease/*
       - hotfixes
+      - aaronmgdr/goodbyeL1*
   pull_request:
     types: [opened, reopened, synchronize, edited, ready_for_review]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,34 +311,8 @@ jobs:
       - uses: ./.github/actions/upload-codecov
         name: Upload Code Coverage
         with:
-          report-name: "celocli-anvil"
-
-  cli-tests-ganache:
-    name: CeloCli Tests (Ganache)
-    runs-on: ['self-hosted', 'org', '8-cpu']
-    timeout-minutes: 30
-    permissions: # Must change the job token permissions to use Akeyless JWT auth
-      id-token: write
-      contents: read
-    needs: [install-dependencies]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Sync workspace
-        uses: ./.github/actions/sync-workspace
-        with:
-          artifacts_to_cache: ${{ needs.install-dependencies.outputs.artifacts_to_cache }}
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: ${{ env.SUPPORTED_FOUNDRY_VERSION }}
-      - name: Run tests
-        run: |
-          yarn workspace @celo/celocli test-ci-ganache --coverage
-      - uses: ./.github/actions/upload-codecov
-        name: Upload Code Coverage
-        with:
-          report-name: "celocli-ganache"
-        
+          report-name: "celocli-anvil"      
+            
   docs-tests:
     name: Docs tests
     runs-on: ['self-hosted', 'org', '8-cpu']

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,10 +36,8 @@
     "homebrew": "node ./homebrew/scripts/prepare.mjs",
     "test": "TZ=UTC NODE_OPTIONS='--experimental-vm-modules' yarn jest --runInBand --forceExit",
     "test-anvil": "RUN_GANACHE_TESTS=false RUN_ANVIL_TESTS=true TZ=UTC NODE_OPTIONS='--experimental-vm-modules' yarn jest --forceExit",
-    "test-ganache": "RUN_GANACHE_TESTS=true RUN_ANVIL_TESTS=false TZ=UTC NODE_OPTIONS='--experimental-vm-modules' yarn jest --runInBand --forceExit",
     "test-ci": "TZ=UTC NODE_OPTIONS='--experimental-vm-modules' yarn jest --runInBand --workerIdleMemoryLimit=0.1 --forceExit",
-    "test-ci-anvil": "yarn test-anvil --workerIdleMemoryLimit=0.1",
-    "test-ci-ganache": "yarn test-ganache --workerIdleMemoryLimit=0.1"
+    "test-ci-anvil": "yarn test-anvil --workerIdleMemoryLimit=0.1"
   },
   "dependencies": {
     "@celo/abis": "11.0.0",

--- a/packages/cli/src/commands/releasecelo/admin-revoke.test.ts
+++ b/packages/cli/src/commands/releasecelo/admin-revoke.test.ts
@@ -159,7 +159,6 @@ testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
           const dequeueFrequency = (await governance.dequeueFrequency()).toNumber()
           await timeTravel(dequeueFrequency + 1, web3)
           const multiApprover = await governance.getApproverMultisig()
-          console.warn('Approve...')
           await setBalance(
             web3,
             multiApprover.address,
@@ -171,7 +170,6 @@ testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
               ['--from', multiApprover.address, '--proposalID', '1'],
               web3
             )
-            console.warn('GovernanceVote...')
           })
           await testLocallyWithWeb3Node(
             GovernanceVote,
@@ -193,7 +191,6 @@ testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
           await governance
             .propose([], 'URL')
             .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
-          console.warn('Upvotin...')
           await testLocallyWithWeb3Node(
             GovernanceUpvote,
             ['--from', voteSigner, '--proposalID', '3', '--privateKey', PRIVATE_KEY1],
@@ -204,7 +201,6 @@ testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
         it('will revoke governance votes and upvotes', async () => {
           const isVotingBefore = await governance.isVoting(contractAddress)
           expect(isVotingBefore).toBeTruthy()
-          console.warn('Revoking...')
           await testLocallyWithWeb3Node(
             AdminRevoke,
             ['--contract', contractAddress, '--yesreally'],

--- a/packages/cli/src/commands/releasecelo/admin-revoke.test.ts
+++ b/packages/cli/src/commands/releasecelo/admin-revoke.test.ts
@@ -5,12 +5,17 @@ import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
 import { AccountsWrapper } from '@celo/contractkit/lib/wrappers/Accounts'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
 import { ReleaseGoldWrapper } from '@celo/contractkit/lib/wrappers/ReleaseGold'
-import { setBalance, testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
-import { getContractFromEvent, testWithGanache, timeTravel } from '@celo/dev-utils/lib/ganache-test'
+import {
+  setBalance,
+  testWithAnvilL2,
+  withImpersonatedAccount,
+} from '@celo/dev-utils/lib/anvil-test'
+import { getContractFromEvent, timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
+import { privateKeyToAddress } from 'viem/accounts'
 import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { testLocally, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import Approve from '../governance/approve'
@@ -99,63 +104,43 @@ testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
       const lockedAmount = await lockedGold.getAccountTotalLockedGold(releaseGoldWrapper.address)
       expect(lockedAmount.isZero()).toBeTruthy()
     })
-  })
-})
-
-// Following tests rely on using personal_* RPC methods which are not supported in anvil
-testWithGanache('releasegold:admin-revoke cmd', (web3: Web3) => {
-  let kit: ContractKit
-  let contractAddress: string
-  let accounts: string[]
-
-  beforeEach(async () => {
-    contractAddress = await getContractFromEvent(
-      'ReleaseGoldInstanceCreated(address,address)',
-      web3,
-      { index: 1 } // revocable: true
-    )
-    kit = newKitFromWeb3(web3)
-    accounts = await web3.eth.getAccounts()
-  })
-
-  describe('#when account exists with locked celo', () => {
-    const value = '10'
-
-    beforeEach(async () => {
-      await testLocally(CreateAccount, ['--contract', contractAddress])
-      await testLocally(LockedCelo, [
-        '--contract',
-        contractAddress,
-        '--action',
-        'lock',
-        '--value',
-        value,
-        '--yes',
-      ])
-    })
 
     describe('#when account has authorized a vote signer', () => {
       let voteSigner: string
       let accountsWrapper: AccountsWrapper
+      //
+      const PRIVATE_KEY1 = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
 
       beforeEach(async () => {
-        voteSigner = accounts[2]
+        voteSigner = privateKeyToAddress(PRIVATE_KEY1)
         accountsWrapper = await kit.contracts.getAccounts()
-        const pop = await accountsWrapper.generateProofOfKeyPossession(contractAddress, voteSigner)
-        await testLocally(Authorize, [
-          '--contract',
+        const pop = await accountsWrapper.generateProofOfKeyPossessionLocally(
           contractAddress,
-          '--role',
-          'vote',
-          '--signer',
           voteSigner,
-          '--signature',
-          serializeSignature(pop),
-        ])
+          PRIVATE_KEY1
+        )
+        await testLocallyWithWeb3Node(
+          Authorize,
+          [
+            '--contract',
+            contractAddress,
+            '--role',
+            'vote',
+            '--signer',
+            voteSigner,
+            '--signature',
+            serializeSignature(pop),
+          ],
+          web3
+        )
       })
 
-      test('will rotate vote signer', async () => {
-        await testLocally(AdminRevoke, ['--contract', contractAddress, '--yesreally'])
+      it('will rotate vote signer', async () => {
+        await testLocallyWithWeb3Node(
+          AdminRevoke,
+          ['--contract', contractAddress, '--yesreally'],
+          web3
+        )
         const newVoteSigner = await accountsWrapper.getVoteSigner(contractAddress)
         expect(newVoteSigner).not.toEqual(voteSigner)
       })
@@ -173,52 +158,61 @@ testWithGanache('releasegold:admin-revoke cmd', (web3: Web3) => {
 
           const dequeueFrequency = (await governance.dequeueFrequency()).toNumber()
           await timeTravel(dequeueFrequency + 1, web3)
-
-          await testLocally(Approve, ['--from', accounts[0], '--proposalID', '1', '--useMultiSig'])
-          await testLocally(GovernanceVote, [
-            '--from',
-            voteSigner,
-            '--proposalID',
-            '1',
-            '--value',
-            'Yes',
-          ])
+          const multiApprover = await governance.getApproverMultisig()
+          console.warn('Approve...')
+          await setBalance(
+            web3,
+            multiApprover.address,
+            new BigNumber(web3.utils.toWei('10', 'ether'))
+          )
+          await withImpersonatedAccount(web3, multiApprover.address, async () => {
+            await testLocallyWithWeb3Node(
+              Approve,
+              ['--from', multiApprover.address, '--proposalID', '1'],
+              web3
+            )
+            console.warn('GovernanceVote...')
+          })
+          await testLocallyWithWeb3Node(
+            GovernanceVote,
+            [
+              '--from',
+              voteSigner,
+              '--proposalID',
+              '1',
+              '--value',
+              'Yes',
+              '--privateKey',
+              PRIVATE_KEY1,
+            ],
+            web3
+          )
           await governance
             .propose([], 'URL')
             .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
           await governance
             .propose([], 'URL')
             .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
-          await testLocally(GovernanceUpvote, ['--from', voteSigner, '--proposalID', '3'])
-
-          // const validators = await kit.contracts.getValidators()
-          // const groups = await validators.getRegisteredValidatorGroupsAddresses()
-          // await testLocally(ElectionVote, [
-          //   '--from',
-          //   voteSigner,
-          //   '--for',
-          //   groups[0],
-          //   '--value',
-          //   value
-          // ])
+          console.warn('Upvotin...')
+          await testLocallyWithWeb3Node(
+            GovernanceUpvote,
+            ['--from', voteSigner, '--proposalID', '3', '--privateKey', PRIVATE_KEY1],
+            web3
+          )
         })
 
-        test('will revoke governance votes and upvotes', async () => {
+        it('will revoke governance votes and upvotes', async () => {
           const isVotingBefore = await governance.isVoting(contractAddress)
           expect(isVotingBefore).toBeTruthy()
-          await testLocally(AdminRevoke, ['--contract', contractAddress, '--yesreally'])
+          console.warn('Revoking...')
+          await testLocallyWithWeb3Node(
+            AdminRevoke,
+            ['--contract', contractAddress, '--yesreally'],
+            web3
+          )
           const isVotingAfter = await governance.isVoting(contractAddress)
           expect(isVotingAfter).toBeFalsy()
         })
-
-        // test.only('will revoke election votes', async () => {
-        //   const election = await kit.contracts.getElection()
-        //   const votesBefore = await election.getTotalVotesByAccount(contractAddress)
-        //   expect(votesBefore.isZero).toBeFalsy()
-        //   await testLocally(AdminRevoke, ['--contract', contractAddress, '--yesreally'])
-        //   const votesAfter = await election.getTotalVotesByAccount(contractAddress)
-        //   expect(votesAfter.isZero()).toBeTruthy()
-        // })
       })
     })
   })

--- a/packages/cli/src/utils/release-gold-base.ts
+++ b/packages/cli/src/utils/release-gold-base.ts
@@ -1,4 +1,5 @@
 import { newReleaseGold } from '@celo/abis/web3/ReleaseGold'
+import { StrongAddress } from '@celo/base'
 import { ReleaseGoldWrapper } from '@celo/contractkit/lib/wrappers/ReleaseGold'
 import { BaseCommand } from '../base'
 import { CustomFlags } from './command'
@@ -20,7 +21,7 @@ export abstract class ReleaseGoldBaseCommand extends BaseCommand {
       const res = await this.parse()
       this._contractAddress = String(res.flags.contract)
     }
-    return this._contractAddress
+    return this._contractAddress as StrongAddress
   }
 
   get releaseGoldWrapper() {


### PR DESCRIPTION
### Description

admin revoke was using the personal name space as a way to set the authorized voted signer to a meaningless address, since personal is now deprecated instead set it back to the default account. 

#### Other changes

since this was the last cli test using ganache remove the ganache cli test from ci

### Tested


### How to QA

_List of steps required to QA the change if applicable_

### Related issues

- Fixes #257 #539

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `releasecelo/admin-revoke` command to ensure it works correctly on L2, along with updates to test configurations and dependencies.

### Detailed summary
- Updated `releasecelo/admin-revoke` to work with L2.
- Changed `contractAddress` return type to `StrongAddress`.
- Modified test configurations in `package.json` and `.github/workflows/ci.yml`.
- Updated `gitguardian.yml` to reflect a new test key.
- Enhanced tests in `admin-revoke.test.ts` for better coverage and functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->