### PR TITLE
Migrate RPC and Validator Lists to viem

### DIFF
--- a/.changeset/fuzzy-files-sell.md
+++ b/.changeset/fuzzy-files-sell.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Migrate validator:list to viem

--- a/.changeset/swift-baboons-appear.md
+++ b/.changeset/swift-baboons-appear.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Migrate validator:rpc-urls to viem, speed up due to multicall and higher concurrancy

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -6,7 +6,7 @@ import { AzureHSMWallet } from '@celo/wallet-hsm-azure'
 import { AddressValidation, newLedgerWalletWithSetup } from '@celo/wallet-ledger'
 import { LocalWallet } from '@celo/wallet-local'
 import _TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
-import { Command, Flags } from '@oclif/core'
+import { Command, Flags, ux } from '@oclif/core'
 import { CLIError } from '@oclif/core/lib/errors'
 import { FlagInput } from '@oclif/core/lib/interfaces/parser'
 import chalk from 'chalk'
@@ -196,6 +196,7 @@ export abstract class BaseCommand extends Command {
   public async getPublicClient(): Promise<CeloClient> {
     if (!this.publicClient) {
       const nodeUrl = await this.getNodeUrl()
+      ux.action.start(`Connecting to Node ${nodeUrl}`)
       const transport = await this.getTransport()
 
       // Create an intermediate client to get the chain id
@@ -230,6 +231,7 @@ export abstract class BaseCommand extends Command {
           },
         }) as any as CeloClient
       }
+      ux.action.stop()
     }
 
     return this.publicClient

--- a/packages/cli/src/commands/lockedcelo/lock.test.ts
+++ b/packages/cli/src/commands/lockedcelo/lock.test.ts
@@ -91,6 +91,7 @@ testWithAnvilL2('lockedgold:lock cmd', (web3: Web3) => {
         [
           [],
           [],
+          [],
         ]
       `)
 

--- a/packages/cli/src/commands/validator/list.ts
+++ b/packages/cli/src/commands/validator/list.ts
@@ -1,7 +1,9 @@
 import { Validator } from '@celo/contractkit/lib/wrappers/Validators'
 import { ux } from '@oclif/core'
 
+import { PublicClient } from 'viem'
 import { BaseCommand } from '../../base'
+import { getRegisteredValidators } from '../../packages-to-be/validators'
 import { ViewCommmandFlags } from '../../utils/flags'
 
 export const validatorTable: ux.Table.table.Columns<Record<'v', Validator>> = {
@@ -15,7 +17,7 @@ export const validatorTable: ux.Table.table.Columns<Record<'v', Validator>> = {
 
 export default class ValidatorList extends BaseCommand {
   static description =
-    'List registered Validators, their name (if provided), affiliation, uptime score, and public keys used for validating.'
+    'List registered Community Rpc Nodes (Formerly Validators), their name (if provided), affiliation, uptime score, and public keys. For rpc urls use "network:rpc-urls"'
 
   static flags = {
     ...ViewCommmandFlags,
@@ -25,12 +27,12 @@ export default class ValidatorList extends BaseCommand {
   static examples = ['list']
 
   async run() {
-    const kit = await this.getKit()
+    const client = await this.getPublicClient()
     const res = await this.parse(ValidatorList)
 
-    ux.action.start('Fetching Validators')
-    const validators = await kit.contracts.getValidators()
-    const validatorList = await validators.getRegisteredValidators()
+    ux.action.start('Fetching Registered Community Rpc Nodes')
+
+    const validatorList = await getRegisteredValidators(client as PublicClient)
 
     ux.action.stop()
     ux.table(

--- a/packages/cli/src/packages-to-be/account.ts
+++ b/packages/cli/src/packages-to-be/account.ts
@@ -1,7 +1,8 @@
 import { accountsABI, lockedGoldABI } from '@celo/abis-12'
 import { StrongAddress } from '@celo/base'
-import { erc20Abi, PublicClient } from 'viem'
+import { Address, erc20Abi, PublicClient } from 'viem'
 import { resolveAddress } from './address-resolver'
+import { getAccountsContract } from './contracts'
 
 export const signerToAccount = async (
   client: PublicClient,
@@ -80,4 +81,42 @@ export const getTotalBalance = async (
     cEUR,
     cREAL,
   }
+}
+
+export async function getMetadataURLs(client: PublicClient, addresses: Address[]) {
+  const contract = await getAccountsContract(client)
+
+  const urlResults = await Promise.allSettled(
+    addresses.map(async (address) => {
+      const url = await contract.read.getMetadataURL([address])
+      return [address, url]
+    })
+  )
+  const filtered = urlResults
+    .filter((result) => result.status === 'fulfilled')
+    .map((result) => {
+      // we know its fulfilled but the types are not so sure
+      return (result as unknown as PromiseFulfilledResult<string[]>).value as [Address, string]
+    })
+
+  return new Map(filtered)
+}
+
+export async function getNames(client: PublicClient, addresses: Address[]) {
+  const contract = await getAccountsContract(client)
+
+  const nameResults = await Promise.allSettled(
+    addresses.map(async (address) => {
+      const name = await contract.read.getName([address])
+      return [address, name]
+    })
+  )
+  const filtered = nameResults
+    .filter((result) => result.status === 'fulfilled')
+    .map((result) => {
+      // we know its fulfilled but the types are not so sure
+      return (result as unknown as PromiseFulfilledResult<string[]>).value as [Address, string]
+    })
+
+  return new Map(filtered)
 }

--- a/packages/cli/src/packages-to-be/account.ts
+++ b/packages/cli/src/packages-to-be/account.ts
@@ -92,12 +92,7 @@ export async function getMetadataURLs(client: PublicClient, addresses: Address[]
       return [address, url]
     })
   )
-  const filtered = urlResults
-    .filter((result) => result.status === 'fulfilled')
-    .map((result) => {
-      // we know its fulfilled but the types are not so sure
-      return (result as unknown as PromiseFulfilledResult<string[]>).value as [Address, string]
-    })
+  const filtered = selectFulfilled(urlResults)
 
   return new Map(filtered)
 }
@@ -111,12 +106,13 @@ export async function getNames(client: PublicClient, addresses: Address[]) {
       return [address, name]
     })
   )
-  const filtered = nameResults
-    .filter((result) => result.status === 'fulfilled')
-    .map((result) => {
-      // we know its fulfilled but the types are not so sure
-      return (result as unknown as PromiseFulfilledResult<string[]>).value as [Address, string]
-    })
+  const filtered = selectFulfilled(nameResults)
 
   return new Map(filtered)
+}
+
+function selectFulfilled(results: Array<PromiseSettledResult<string[]>>) {
+  return results
+    .filter((result): result is PromiseFulfilledResult<string[]> => result.status === 'fulfilled')
+    .map((result) => result.value as [Address, string])
 }

--- a/packages/cli/src/packages-to-be/validators.ts
+++ b/packages/cli/src/packages-to-be/validators.ts
@@ -99,7 +99,7 @@ export async function getValidatorsGroup(
 
 /* 
   @param address - address of a group
-  @returns 
+  @returns group info including name, commission, affiliates + members and slash data. 
  */
 export const getValidatorGroup = async (
   client: PublicClient,

--- a/packages/cli/src/packages-to-be/validators.ts
+++ b/packages/cli/src/packages-to-be/validators.ts
@@ -4,6 +4,7 @@ import { fromFixed } from '@celo/utils/lib/fixidity'
 import BigNumber from 'bignumber.js'
 import { PublicClient } from 'viem'
 import { resolveAddress } from './address-resolver'
+import { getValidatorsContract } from './contracts'
 import { bigintToBigNumber } from './utils'
 
 export interface Validator {
@@ -84,6 +85,22 @@ export const meetsValidatorGroupBalanceRequirements = async (
   return validatorLockedGoldRequirements[1] <= accountTotalLockedGold
 }
 
+/* 
+  @param validatorAddress - address of validator/community-rpc node affiliated with an Group
+  @returns the group the given address is affiliated with
+ */
+export async function getValidatorsGroup(
+  client: PublicClient,
+  validatorAddress: StrongAddress
+): Promise<StrongAddress> {
+  const contract = await getValidatorsContract(client)
+  return contract.read.getValidatorsGroup([validatorAddress])
+}
+
+/* 
+  @param address - address of a group
+  @returns 
+ */
 export const getValidatorGroup = async (
   client: PublicClient,
   address: Address,

--- a/packages/cli/src/test-utils/multicall.ts
+++ b/packages/cli/src/test-utils/multicall.ts
@@ -3,7 +3,7 @@ import { setCode } from '@celo/dev-utils/lib/anvil-test'
 import Web3 from 'web3'
 
 export async function deployMultiCall(web3: Web3, address: StrongAddress) {
-  setCode(web3, address, bytecode)
+  return setCode(web3, address, bytecode)
 }
 
 // SOURCE https://celo.blockscout.com/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract_bytecode


### PR DESCRIPTION
### Description

* validator:list and validator:rpc-urls both now use viem
* refactored rpc-urls command to take better advantange of automatic multicall with viem

#### Other changes


* I added to get public client that we are connecting to he nodeURl. I think its nice feedback that something is happening and that the url is as expected
* Started to call validators as Community RPC Nodes in places where it doesnt really change the output interface


### Tested

ran commands locally on a few chains and also the tests pass

### How to QA

run the commands 

### Related issues

- Fixes #608

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on migrating various validator-related commands and functionalities to use the `viem` library, optimizing performance, and enhancing the user experience by improving how validators and their metadata are fetched and displayed.

### Detailed summary
- Migrated `validator:list` and `validator:rpc-urls` commands to use `viem`.
- Enhanced fetching of registered validators and their group affiliations.
- Improved concurrency level for fetching data.
- Added new functions for retrieving validator group and metadata URLs.
- Updated user feedback messages using `ux.action`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->