### PR TITLE
Remove web3-utils and @celo/phone-number-utils

### DIFF
--- a/.changeset/strong-houses-scream.md
+++ b/.changeset/strong-houses-scream.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+chore: Remove web3-utils and @celo/phone-number-utils dependencies

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,6 @@
     "@celo/governance": "^5.1.7-beta.0",
     "@celo/identity": "^5.1.2",
     "@celo/metadata-claims": "^1.0.3",
-    "@celo/phone-utils": "^6.0.6",
     "@celo/utils": "^8.0.2",
     "@celo/viem-account-ledger": "^1.2.0-beta.0",
     "@celo/wallet-hsm-azure": "^8.0.0-beta.1",
@@ -79,8 +78,7 @@
     "path": "^0.12.7",
     "prompts": "^2.0.1",
     "viem": "^2.23.5",
-    "web3": "1.10.4",
-    "web3-utils": "^1.10.4"
+    "web3": "1.10.4"
   },
   "devDependencies": {
     "@celo/celo-devchain": "^7.0.0",

--- a/packages/cli/src/utils/command.ts
+++ b/packages/cli/src/utils/command.ts
@@ -2,7 +2,6 @@ import { StrongAddress } from '@celo/base'
 import { URL_REGEX } from '@celo/base/lib/io'
 import { CeloContract, RegisteredContracts } from '@celo/contractkit'
 import { BLS_POP_SIZE, BLS_PUBLIC_KEY_SIZE } from '@celo/cryptographic-utils/lib/bls'
-import { isE164NumberStrict } from '@celo/phone-utils/lib/phoneNumbers'
 import { ensureLeading0x, trimLeading0x } from '@celo/utils/lib/address'
 import { POP_SIZE } from '@celo/utils/lib/signatureUtils'
 import { Args, Errors, Flags } from '@oclif/core'
@@ -75,14 +74,6 @@ export const parsePath: ParseFn<string> = async (input: string) => {
     return input
   } else {
     throw new CLIError(`File at "${input}" does not exist`)
-  }
-}
-
-const parsePhoneNumber: ParseFn<string> = async (input) => {
-  if (isE164NumberStrict(input)) {
-    return input
-  } else {
-    throw new CLIError(`PhoneNumber "${input}" is not a valid E164 number`)
   }
 }
 
@@ -202,11 +193,6 @@ export const CustomFlags = {
     parse: parseArray(parseCoreContract),
     description: 'Array of Registered Core Contracts',
     helpValue: `\'["${CeloContract.Accounts}", "${CeloContract.Governance}", "${CeloContract.Validators}"]\'`,
-  }),
-  phoneNumber: Flags.custom({
-    parse: parsePhoneNumber,
-    description: 'Phone Number in E164 Format',
-    helpValue: '+14152223333',
   }),
   proofOfPossession: Flags.custom({
     parse: parseProofOfPossession,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,7 +1649,6 @@ __metadata:
     "@celo/governance": "npm:^5.1.7-beta.0"
     "@celo/identity": "npm:^5.1.2"
     "@celo/metadata-claims": "npm:^1.0.3"
-    "@celo/phone-utils": "npm:^6.0.6"
     "@celo/typescript": "workspace:^"
     "@celo/utils": "npm:^8.0.2"
     "@celo/viem-account-ledger": "npm:^1.2.0-beta.0"
@@ -1693,7 +1692,6 @@ __metadata:
     typescript: "npm:5.3.3"
     viem: "npm:^2.23.5"
     web3: "npm:1.10.4"
-    web3-utils: "npm:^1.10.4"
   bin:
     celocli: ./bin/run.js
     dev: .bin/dev.js
@@ -2022,7 +2020,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@celo/phone-utils@npm:^6.0.6, @celo/phone-utils@workspace:packages/sdk/phone-utils":
+"@celo/phone-utils@workspace:packages/sdk/phone-utils":
   version: 0.0.0-use.local
   resolution: "@celo/phone-utils@workspace:packages/sdk/phone-utils"
   dependencies:


### PR DESCRIPTION


### Description

removed and no test or build errors

#### Other changes


### Tested

still work fine

### How to QA

open and runa few commands

### Related issues

#225 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the `@celo/phone-utils` and `web3-utils` dependencies from the project, streamlining the codebase and potentially reducing bundle size.

### Detailed summary
- Removed `@celo/phone-utils` dependency from `packages/cli/package.json` and `yarn.lock`.
- Removed `web3-utils` dependency from `packages/cli/package.json` and `yarn.lock`.
- Deleted `parsePhoneNumber` function from `packages/cli/src/utils/command.ts`.
- Removed `phoneNumber` flag from `CustomFlags` in `packages/cli/src/utils/command.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->