### PR TITLE
Migrate network:info to viem

### DIFF
--- a/.changeset/grumpy-flies-run.md
+++ b/.changeset/grumpy-flies-run.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Migrates network:info command to use viem


### PR DESCRIPTION
### Description

viem is the future.

#### Other changes

nope

### Tested

pass


### How to QA


### Related issues




<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on migrating the `network:info` command to utilize the `viem` library for improved functionality and type handling.

### Detailed summary
- Replaced `kit` with `client` of type `PublicClient`.
- Changed epoch number and size types from `number` to `bigint`.
- Updated block number retrieval to use `client`.
- Switched to `getEpochManagerContract` for epoch manager interactions.
- Adjusted methods to work with `bigint`.
- Converted epoch data properties to `Number` where applicable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->