### PR TITLE
chore: account:new cleanup

### DIFF
--- a/.changeset/fifty-deers-move.md
+++ b/.changeset/fifty-deers-move.md
@@ -1,0 +1,5 @@
+---
+'@celo/base': patch
+---
+
+Minor typing improvement"

--- a/.changeset/shy-kangaroos-grow.md
+++ b/.changeset/shy-kangaroos-grow.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Minor changes in the account:new output

--- a/packages/cli/src/commands/account/new.test.ts
+++ b/packages/cli/src/commands/account/new.test.ts
@@ -41,7 +41,6 @@ testWithAnvilL2('account:new cmd', (web3: Web3) => {
     expect(deRandomize(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
       "mnemonic: *** *** 
       derivationPath: m/44'/52752'/0'/0/0
-      accountAddress: ADDRESS
       privateKey: PUBLIC_KEY
       publicKey: PRIVATE_KEY
       address: ADDRESS"
@@ -54,7 +53,6 @@ testWithAnvilL2('account:new cmd', (web3: Web3) => {
     expect(deRandomize(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
       "mnemonic: *** *** 
       derivationPath: m/44'/60'/0'/0/0
-      accountAddress: ADDRESS
       privateKey: PUBLIC_KEY
       publicKey: PRIVATE_KEY
       address: ADDRESS"
@@ -67,7 +65,6 @@ testWithAnvilL2('account:new cmd', (web3: Web3) => {
     expect(deRandomize(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
       "mnemonic: *** *** 
       derivationPath: m/44'/52752'/0'/0/0
-      accountAddress: ADDRESS
       privateKey: PUBLIC_KEY
       publicKey: PRIVATE_KEY
       address: ADDRESS"
@@ -115,7 +112,6 @@ testWithAnvilL2('account:new cmd', (web3: Web3) => {
       expect(deRandomize(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
         "mnemonic: *** *** 
         derivationPath: m/44'/60'/0'/0/0
-        accountAddress: ADDRESS
         privateKey: PUBLIC_KEY
         publicKey: PRIVATE_KEY
         address: ADDRESS"
@@ -142,7 +138,6 @@ testWithAnvilL2('account:new cmd', (web3: Web3) => {
       expect(stripAnsiCodesAndTxHashes(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
         "mnemonic: hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue
         derivationPath: m/44'/52752'/0'/0/0
-        accountAddress: 0x0a85BeCD036C86faD4Db5519634904be2021fb7d
         privateKey: 6346d0cd7cfdb7904f08df48e442169d3333643de0351682f8b79cf714395471
         publicKey: 02269b3efc9c4c6b81037d06e73e936078e625fb0f12b9ea1e0fd14d2cd45775f2
         address: 0x0a85BeCD036C86faD4Db5519634904be2021fb7d"
@@ -159,7 +154,6 @@ testWithAnvilL2('account:new cmd', (web3: Web3) => {
       expect(stripAnsiCodesAndTxHashes(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
         "mnemonic: hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue
         derivationPath: m/44'/60'/0'/0/0
-        accountAddress: 0x35A4d54B541fc7b2047fb5357cC706191E105cd3
         privateKey: e4816cbb93346760921264ea38a7fc54903f4dd688ae0923fefd89a43c5f58cc
         publicKey: 034b3036d657a6dc2f322db52cca29ae72101a9cf56de4765d17b0507ea1e87b7c
         address: 0x35A4d54B541fc7b2047fb5357cC706191E105cd3"
@@ -175,7 +169,6 @@ testWithAnvilL2('account:new cmd', (web3: Web3) => {
       expect(stripAnsiCodesAndTxHashes(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
         "mnemonic: hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue
         derivationPath: m/44'/60'/0'/2/0
-        accountAddress: 0xb3492799c55141e0B3507302F241f1c34c08E1e2
         privateKey: 3abc861ef3e9e31a6a7dc23e5903e41b3fe4a381d4fbb8f9db14e6730abd1c43
         publicKey: 0280df4d09cf8ebcad418327287be3f4ba0054112544ffa290ab3cc0a87949b32a
         address: 0xb3492799c55141e0B3507302F241f1c34c08E1e2"
@@ -191,7 +184,6 @@ testWithAnvilL2('account:new cmd', (web3: Web3) => {
       expect(stripAnsiCodesAndTxHashes(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
         "mnemonic: hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue
         derivationPath: m/44'/60'/0'/0/3
-        accountAddress: 0x336E523118B6091e033F9715257e2E793002964c
         privateKey: aa324b2efd0ebe6387c3bcf03387c78047d82a1d2e8b4e132e9e1b9fb93529d0
         publicKey: 0394cc7cc524079c545aef2067c9ea7e69decb4815004afecf215ea1e6f370ce6c
         address: 0x336E523118B6091e033F9715257e2E793002964c"

--- a/packages/cli/src/commands/account/new.ts
+++ b/packages/cli/src/commands/account/new.ts
@@ -4,8 +4,6 @@ import {
   normalizeMnemonic,
   validateMnemonic,
 } from '@celo/cryptographic-utils/lib/account'
-import { privateKeyToAddress } from '@celo/utils/lib/address'
-import { toChecksumAddress } from '@ethereumjs/util'
 import { Flags } from '@oclif/core'
 import chalk from 'chalk'
 import * as fs from 'fs-extra'
@@ -157,7 +155,6 @@ export default class NewAccount extends BaseCommand {
       undefined,
       derivationPath
     )
-    const accountAddress = toChecksumAddress(privateKeyToAddress(keys.privateKey))
 
     if (derivationPath === CELO_DERIVATION_PATH_BASE) {
       this.log(
@@ -168,7 +165,7 @@ export default class NewAccount extends BaseCommand {
     }
     const fullDerivationPath = `${derivationPath}/${res.flags.changeIndex}/${res.flags.addressIndex}`
 
-    printValueMap({ mnemonic, derivationPath: fullDerivationPath, accountAddress, ...keys })
+    printValueMap({ mnemonic, derivationPath: fullDerivationPath, ...keys })
 
     this.log(
       chalk.green.bold(

--- a/packages/sdk/base/src/address.ts
+++ b/packages/sdk/base/src/address.ts
@@ -23,7 +23,7 @@ export const ensureLeading0x = (input: string): StrongAddress =>
 export const getAddressChunks = (input: string): string[] =>
   trimLeading0x(input).match(/.{1,4}/g) || []
 
-export const isHexString = (input: string) => HEX_REGEX.test(input)
+export const isHexString = (input: string): input is StrongAddress => HEX_REGEX.test(input)
 
 export const hexToBuffer = (input: string) => Buffer.from(trimLeading0x(input), 'hex')
 

--- a/packages/sdk/wallets/wallet-base/package.json
+++ b/packages/sdk/wallets/wallet-base/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@celo/typescript": "workspace:^",
     "@types/debug": "^4.1.12",
-    "viem": "~1.5.4"
+    "viem": "^2.23.5"
   },
   "dependencies": {
     "@celo/base": "^7.0.2",

--- a/packages/sdk/wallets/wallet-local/package.json
+++ b/packages/sdk/wallets/wallet-local/package.json
@@ -36,7 +36,7 @@
     "@celo/typescript": "workspace:^",
     "@types/debug": "^4.1.12",
     "debug": "^4.3.5",
-    "viem": "~1.5.4",
+    "viem": "^2.23.5",
     "web3": "1.10.4"
   },
   "engines": {


### PR DESCRIPTION
This PR initially aimed to migrate as much as possible to viem, but it turns out this is a bbigger undertaking as it requires refactor @celo/base and @celo/cryptographic-utils . The changes were rolled back and this is a very minimal refresh

- Fixes #623

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on minor improvements and updates to type definitions, package versions, and output formatting in the `@celo` ecosystem, enhancing the overall code quality and user experience.

### Detailed summary
- Updated `viem` package version to `^2.23.5` in `package.json` files.
- Improved type definition for `isHexString` function in `address.ts`.
- Removed `accountAddress` from output in `new.ts` and its tests to streamline the output.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->