### PR TITLE
CI size check -- set package manager and script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,7 @@ jobs:
   size_checks: 
     name: Size checks
     runs-on: ['self-hosted', 'org', '8-cpu']
-    timeout-minutes: 30
-    needs: install-dependencies
+    timeout-minutes: 3
     strategy:
       fail-fast: false
       matrix:
@@ -153,14 +152,11 @@ jobs:
         folder: ["actions", "core"]
     steps:
       - uses: actions/checkout@v4
-      - name: Sync workspace
-        uses: ./.github/actions/sync-workspace
-        with:
-          artifacts_to_cache: ${{ needs.install-dependencies.outputs.artifacts_to_cache }}
-      - uses: andresz1/size-limit-action@v1
+     
+       
+      - uses: andresz1/size-limit-action@v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          skip_step: install
           package_manager: yarn
           script: 'yarn check-size' 
           directory: packages/${{ matrix.folder }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,8 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: yarn
-          script: 'yarn check-size' 
+          skip_step: 'build'
+          script: 'yarn check-size --json' 
           directory: packages/${{ matrix.folder }}
          
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,15 +144,19 @@ jobs:
   size_checks: 
     name: Size checks
     runs-on: ['self-hosted', 'org', '8-cpu']
+    needs: install-dependencies
     timeout-minutes: 3
     strategy:
       fail-fast: false
       matrix:
-        # We need to run this job for all the packages that are not @celo/actions and @celo/core
+        # We need to run this job for @celo/actions and @celo/core
         folder: ["actions", "core"]
     steps:
       - uses: actions/checkout@v4
-     
+      - name: Sync workspace
+        uses: ./.github/actions/sync-workspace
+        with:
+          artifacts_to_cache: ${{ needs.install-dependencies.outputs.artifacts_to_cache }}
        
       - uses: andresz1/size-limit-action@v1.8.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,11 @@ jobs:
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          skip_step: install 
+          skip_step: install
+          package_manager: yarn
+          script: 'yarn check-size' 
           directory: packages/${{ matrix.folder }}
+         
 
   general_test:
     name: General jest test

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -84,8 +84,20 @@
     {
       "name": "import * from '@celo/actions' (esm)",
       "path": "dist/mjs/index.js",
-      "limit": "80 kB",
+      "limit": "25 kB",
       "import": "*"
+    },
+    {
+      "name": "import { resolveAddress } from '@celo/actions' (esm)",
+      "path": "dist/mjs/index.js",
+      "limit": "25 kB",
+      "import": "{ resolveAddress }"
+    },
+    {
+      "name": "import { getGasPriceOnCelo } from '@celo/actions' (esm)",
+      "path": "dist/mjs/index.js",
+      "limit": "1 kB",
+      "import": "{ getGasPriceOnCelo }"
     },
     {
       "name": "import * from '@celo/actions/chains' (esm)",
@@ -96,13 +108,13 @@
     {
       "name": "import { getAccountsContract } from '@celo/actions/contracts/accounts' (esm)",
       "path": "dist/mjs/contracts/accounts.js",
-      "limit": "65 kB",
+      "limit": "50 kB",
       "import": "{ getAccountsContract }"
     },
     {
       "name": "import * from '@celo/actions/staking' (esm)",
       "path": "dist/mjs/multicontract-interactions/stake/index.js",
-      "limit": "80 kB",
+      "limit": "60 kB",
       "import": "*"
     }
   ]

--- a/packages/actions/src/contracts/registry.ts
+++ b/packages/actions/src/contracts/registry.ts
@@ -1,7 +1,7 @@
 import { NULL_ADDRESS } from '@celo/base/lib/address'
-import { Address, Client, PublicClient, publicActions } from 'viem'
+import { Address, Client } from 'viem'
+import { readContract } from 'viem/actions'
 import { ContractName } from '../contract-name'
-
 export const REGISTRY_CONTRACT_ADDRESS = '0x000000000000000000000000000000000000ce10'
 
 // we only use this one function from the registry so we don't need the whole ABI
@@ -39,11 +39,7 @@ export const resolveAddress = async (
     return cache[contractName]
   }
 
-  if (!('readContract' in client)) {
-    client = client.extend(publicActions)
-  }
-
-  const address = await (client as PublicClient).readContract({
+  const address = await readContract(client, {
     address: REGISTRY_CONTRACT_ADDRESS,
     abi: ABI,
     functionName: 'getAddressForString',


### PR DESCRIPTION
### Description

new ci action doesnt work yet

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing the `resolveAddress` function in the `registry.ts` file, adjusting CI workflow settings, and updating size limits for various imports in the `package.json`.

### Detailed summary
- Removed `publicActions` from the import in `registry.ts`.
- Used `readContract` directly instead of extending `client`.
- Reduced CI `timeout-minutes` from 30 to 3.
- Updated `size-limit-action` version from `v1` to `v1.8.0`.
- Changed size limits for several imports in `package.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->