### PR TITLE
Migrate election:vote to viem

### DIFF
--- a/.changeset/itchy-tips-carry.md
+++ b/.changeset/itchy-tips-carry.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+(chore): Migrate election:vote to viem

--- a/packages/actions/src/multicontract-interactions/stake/index.ts
+++ b/packages/actions/src/multicontract-interactions/stake/index.ts
@@ -1,1 +1,2 @@
 export { ElectedRpcNode, getElectedRpcNodes } from './elected-rpc-nodes'
+export { vote } from './vote'

--- a/packages/actions/src/multicontract-interactions/stake/vote.ts
+++ b/packages/actions/src/multicontract-interactions/stake/vote.ts
@@ -11,7 +11,9 @@ export async function vote(
   const election = await getElectionContract(client)
   const adapter: VoteAdapter = {
     vote: async (validatorGroup, value, lesser, greater) => {
-      return election.write.vote([validatorGroup, value, lesser, greater])
+      const { request } = await election.simulate.vote([validatorGroup, value, lesser, greater])
+      const gasLimit = await election.estimateGas.vote(request.args)
+      return election.write.vote(request.args, { gas: gasLimit })
     },
     getTotalVotesForEligibleValidatorGroups: async () => {
       return election.read.getTotalVotesForEligibleValidatorGroups()

--- a/packages/cli/src/commands/election/show.test.ts
+++ b/packages/cli/src/commands/election/show.test.ts
@@ -3,7 +3,11 @@ import { testWithAnvilL2 } from '@celo/dev-utils/lib/anvil-test'
 import { timeTravel } from '@celo/dev-utils/lib/ganache-test'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
-import { stripAnsiCodesAndTxHashes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import {
+  EXTRA_LONG_TIMEOUT_MS,
+  stripAnsiCodesAndTxHashes,
+  testLocallyWithWeb3Node,
+} from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Switch from '../epochs/switch'
 import Lock from '../lockedcelo/lock'
@@ -44,7 +48,7 @@ testWithAnvilL2('election:show', (web3: Web3) => {
     )
 
     logMock.mockClear()
-  })
+  }, EXTRA_LONG_TIMEOUT_MS)
 
   afterEach(async () => {
     jest.clearAllMocks()

--- a/packages/cli/src/commands/election/vote.test.ts
+++ b/packages/cli/src/commands/election/vote.test.ts
@@ -123,13 +123,28 @@ testWithAnvilL2('election:vote', (web3: Web3) => {
           "All checks passed",
         ],
         [
-          "SendTransaction: vote",
+          "SendTransaction: Electon -> Vote",
         ],
         [
           "txHash: 0xtxhash",
         ],
+        [
+          "ValidatorGroupVoteCast:",
+        ],
+        [
+          "account: 0x5409ED021D9299bf6814279A6A1411A7e866A631
+      group: 0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb
+      value: 12345",
+        ],
       ]
     `)
-    expect(writeMock.mock.calls).toMatchInlineSnapshot(`[]`)
+    expect(writeMock.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "Remember to activate your vote next epoch
+      ",
+        ],
+      ]
+    `)
   })
 })


### PR DESCRIPTION
### Description

move to viem

added in showing that the vote event and reminder to activate votes

#### Other changes

added missed exports to actions

had to add that the election:show test's setup takes a long time since waiting for the vote event has the setup take longer

### Tested

existing test

### How to QA


### Related issues

- Fixes #630

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on migrating the `election:vote` functionality to use the `viem` library, updating related tests and improving code structure for better clarity and functionality.

### Detailed summary
- Exported `vote` from `./vote` in `index.ts`.
- Updated test descriptions in `vote.test.ts`.
- Added new log output for voting confirmation in `vote.test.ts`.
- Changed voting logic in `vote.ts` to use `election.simulate.vote` and `election.estimateGas.vote`.
- Updated import statements in `vote.ts` and changed method names for clarity.
- Modified flags in `ElectionVote` class to use `CustomFlags.bigint`.
- Updated transaction display method to `displayViemTx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->