### PR TITLE
Converts governance:vote to viem

### DIFF
--- a/.changeset/gorgeous-queens-laugh.md
+++ b/.changeset/gorgeous-queens-laugh.md
@@ -1,0 +1,6 @@
+---
+'@celo/base': patch
+'@celo/core': patch
+---
+
+use more explicit types for addresses in more places

--- a/.changeset/nine-coins-drive.md
+++ b/.changeset/nine-coins-drive.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+migrate governance:vote commands to viem

--- a/packages/actions/src/contracts/governance.test.ts
+++ b/packages/actions/src/contracts/governance.test.ts
@@ -28,17 +28,14 @@ viem_testWithAnvil(
     afterEach(async () => {
       await client.stopImpersonatingAccount({ address: voter })
     })
-    // Assume a proposal is already created and in the dequeue
-    // For this test, we need a valid proposalId in the dequeue
-    // We'll use a placeholder proposalId for demonstration
-    // In a real test, you would create a proposal and get its ID
+    const txHashRegex = /^0x([A-Fa-f0-9]{64})$/
 
     it(
       'votes Yes on a proposal',
       async () => {
         // This will throw if proposalId is not in the dequeue
         // In a real test, ensure proposalId is valid and in the dequeue
-        await expect(vote(walletClient, proposalId, 'Yes')).resolves.toBeDefined()
+        await expect(vote(walletClient, proposalId, 'Yes')).resolves.toMatch(txHashRegex)
       },
       TIMEOUT
     )
@@ -46,7 +43,7 @@ viem_testWithAnvil(
     it(
       'votes No on a proposal',
       async () => {
-        await expect(vote(walletClient, proposalId, 'No')).resolves.toBeDefined()
+        await expect(vote(walletClient, proposalId, 'No')).resolves.toMatch(txHashRegex)
       },
       TIMEOUT
     )
@@ -54,7 +51,7 @@ viem_testWithAnvil(
     it(
       'votes Abstain on a proposal',
       async () => {
-        await expect(vote(walletClient, proposalId, 'Abstain')).resolves.toBeDefined()
+        await expect(vote(walletClient, proposalId, 'Abstain')).resolves.toMatch(txHashRegex)
       },
       TIMEOUT
     )

--- a/packages/actions/src/contracts/governance.test.ts
+++ b/packages/actions/src/contracts/governance.test.ts
@@ -60,9 +60,13 @@ viem_testWithAnvil(
       'throws if proposalId is not in dequeue',
       async () => {
         const invalidProposalId = 999999n
-        await expect(vote(walletClient, invalidProposalId, 'Yes')).rejects.toThrow()
+        await expect(
+          vote(walletClient, invalidProposalId, 'Yes')
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `[Error: ID 999999 not found in array 36,47,72,32,33,37,38,44,46,45,52,51,58,59,65,64,112,70,73,78,75,74,84,79,81,82,95,87,94,110,90,92,93,97,98,104,100,106,113,108,109,114,126,125,122,124,129,153,146,154,141,152,149,148,155,156,192,184,166,173,186,185,196,230,203,0,207,0,224,206]`
+        )
       },
-      TIMEOUT
+      TIMEOUT * 2
     )
   },
   { forkUrl, forkBlockNumber: forkBlockNumber }

--- a/packages/actions/src/contracts/governance.test.ts
+++ b/packages/actions/src/contracts/governance.test.ts
@@ -1,0 +1,72 @@
+import { viem_testWithAnvil } from '@celo/dev-utils/viem/anvil-test'
+import { createWalletClient, http } from 'viem'
+import { celo } from 'viem/chains'
+import { expect, it } from 'vitest'
+import { WalletCeloClient } from '../client'
+import { vote } from './governance'
+
+const TIMEOUT = 10_000
+
+// We are forking celo mainnet at a known block and impersonating an account known to have been able to vote on that proposal
+const voter = '0x3779CF289d8161Cd6679696D10647FBa2cb0ef50'
+const proposalId = BigInt(230)
+const forkBlockNumber = 35704485 // a few blocks before the account vote irl
+const forkUrl = celo.rpcUrls.default.http[0]
+
+viem_testWithAnvil(
+  'vote',
+  async (client) => {
+    let walletClient: WalletCeloClient
+    beforeEach(async () => {
+      client.impersonateAccount({ address: voter })
+      walletClient = createWalletClient({
+        account: voter,
+        chain: client.chain,
+        transport: http(client.chain.rpcUrls.default.http[0]),
+      })
+    })
+    afterEach(async () => {
+      await client.stopImpersonatingAccount({ address: voter })
+    })
+    // Assume a proposal is already created and in the dequeue
+    // For this test, we need a valid proposalId in the dequeue
+    // We'll use a placeholder proposalId for demonstration
+    // In a real test, you would create a proposal and get its ID
+
+    it(
+      'votes Yes on a proposal',
+      async () => {
+        // This will throw if proposalId is not in the dequeue
+        // In a real test, ensure proposalId is valid and in the dequeue
+        await expect(vote(walletClient, proposalId, 'Yes')).resolves.toBeDefined()
+      },
+      TIMEOUT
+    )
+
+    it(
+      'votes No on a proposal',
+      async () => {
+        await expect(vote(walletClient, proposalId, 'No')).resolves.toBeDefined()
+      },
+      TIMEOUT
+    )
+
+    it(
+      'votes Abstain on a proposal',
+      async () => {
+        await expect(vote(walletClient, proposalId, 'Abstain')).resolves.toBeDefined()
+      },
+      TIMEOUT
+    )
+
+    it(
+      'throws if proposalId is not in dequeue',
+      async () => {
+        const invalidProposalId = 999999n
+        await expect(vote(walletClient, invalidProposalId, 'Yes')).rejects.toThrow()
+      },
+      TIMEOUT
+    )
+  },
+  { forkUrl, forkBlockNumber: forkBlockNumber }
+)

--- a/packages/cli/src/commands/governance/vote.ts
+++ b/packages/cli/src/commands/governance/vote.ts
@@ -1,18 +1,19 @@
-import { VoteValue } from '@celo/contractkit/lib/wrappers/Governance'
+import { governanceABI } from '@celo/abis'
+import { vote } from '@celo/actions/contracts/governance'
 import { Flags } from '@oclif/core'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class Vote extends BaseCommand {
   static description = 'Vote on an approved governance proposal'
 
-  static voteOptions = ['Abstain', 'No', 'Yes']
+  static voteOptions = ['Abstain', 'No', 'Yes'] as const
 
   static flags = {
     ...BaseCommand.flags,
-    proposalID: Flags.string({ required: true, description: 'UUID of proposal to vote on' }),
+    proposalID: CustomFlags.bigint({ required: true, description: 'UUID of proposal to vote on' }),
     value: Flags.option({ options: Vote.voteOptions, required: true, description: 'Vote' })(),
     from: CustomFlags.address({ required: true, description: "Voter's address" }),
   }
@@ -22,14 +23,10 @@ export default class Vote extends BaseCommand {
   ]
 
   async run() {
-    const kit = await this.getKit()
     const res = await this.parse(Vote)
     const signer = res.flags.from
     const id = res.flags.proposalID
-    const voteValue = res.flags.value as keyof typeof VoteValue
-
-    kit.defaultAccount = signer
-    const governance = await kit.contracts.getGovernance()
+    const voteValue = res.flags.value
 
     await newCheckBuilder(this, signer)
       .isVoteSignerOrAccount()
@@ -37,6 +34,14 @@ export default class Vote extends BaseCommand {
       .proposalInStage(id, 'Referendum')
       .runChecks()
 
-    await displaySendTx('voteTx', await governance.vote(id, voteValue), {}, 'ProposalVoted')
+    const walletClient = await this.getWalletClient()
+    const publicClient = await this.getPublicClient()
+
+    // do not wait this. it will be awiated in the displayViemTx
+    const pendingVote = vote(walletClient, id, voteValue)
+    await displayViemTx('Governance -> vote', pendingVote, publicClient, {
+      abi: governanceABI,
+      displayEventName: 'ProposalVoted',
+    })
   }
 }

--- a/packages/cli/src/packages-to-be/governance.ts
+++ b/packages/cli/src/packages-to-be/governance.ts
@@ -1,7 +1,7 @@
 import { governanceABI } from '@celo/abis-12'
 import { resolveAddress } from '@celo/actions'
 import { getProposalStage, ProposalStage } from '@celo/actions/contracts/governance'
-import { Address, bufferToHex } from '@celo/base'
+import { bufferToHex, StrongAddress } from '@celo/base'
 import BigNumber from 'bignumber.js'
 import { PublicClient } from 'viem'
 import { bigintToBigNumber } from './utils'
@@ -12,7 +12,7 @@ type DequeuedStageDurations = Pick<
 >
 
 export interface ProposalMetadata {
-  proposer: Address
+  proposer: StrongAddress
   deposit: BigNumber
   timestamp: BigNumber
   transactionCount: number

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -260,16 +260,16 @@ class CheckBuilder {
       })
     )
 
-  proposalExists = (proposalID: string) =>
+  proposalExists = (proposalID: string | bigint) =>
     this.addCheck(
       `${proposalID} is an existing proposal`,
       this.withGovernance((governance) => governance.read.proposalExists([BigInt(proposalID)]))
     )
 
-  proposalInStage = (proposalID: string, stage: keyof typeof ProposalStage) =>
+  proposalInStage = (proposalID: string | bigint, stage: keyof typeof ProposalStage) =>
     this.proposalInStages(proposalID, [stage])
 
-  proposalInStages = (proposalID: string, stages: (keyof typeof ProposalStage)[]) =>
+  proposalInStages = (proposalID: string | bigint, stages: (keyof typeof ProposalStage)[]) =>
     this.addCheck(
       `${proposalID} is in stage ${stages.join(' or ')}`,
       this.withGovernance(async (_governance) => {

--- a/packages/core/src/governing/index.ts
+++ b/packages/core/src/governing/index.ts
@@ -1,0 +1,1 @@
+export { voteProposal, type VoteProposalAdapter, type VoteProposalTypes } from './vote'

--- a/packages/core/src/governing/vote.test.ts
+++ b/packages/core/src/governing/vote.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { voteProposal, VoteProposalAdapter, VoteProposalTypes } from './vote'
+
+describe('voteProposal', () => {
+  const proposalId = 123n
+  const dequeue = [111n, 123n, 456n]
+
+  let adapter: VoteProposalAdapter
+
+  beforeEach(() => {
+    adapter = {
+      vote: vi.fn().mockResolvedValue('0xabc'),
+      getDequeue: vi.fn().mockResolvedValue(dequeue),
+    }
+  })
+
+  it('calls adapter.vote with correct proposalIndex and voteValue', async () => {
+    await voteProposal(adapter, proposalId, 'Yes')
+    expect(adapter.getDequeue).toHaveBeenCalled()
+    expect(adapter.vote).toHaveBeenCalledWith(proposalId, 1n, 3)
+  })
+
+  it('throws if proposalId is not in dequeue', async () => {
+    await expect(voteProposal(adapter, 999n, 'No')).rejects.toThrow(
+      'ID 999 not found in array 111,123,456'
+    )
+  })
+
+  it('passes correct voteValue for each VoteProposalTypes', async () => {
+    const values: [VoteProposalTypes, number][] = [
+      ['None', 0],
+      ['Abstain', 1],
+      ['No', 2],
+      ['Yes', 3],
+    ]
+    for (const [type, value] of values) {
+      await voteProposal(adapter, proposalId, type)
+      expect(adapter.vote).toHaveBeenLastCalledWith(proposalId, 1n, value)
+    }
+  })
+})

--- a/packages/core/src/governing/vote.ts
+++ b/packages/core/src/governing/vote.ts
@@ -23,7 +23,6 @@ export async function voteProposal(
   return adapater.vote(proposalId, proposalIndex, voteValuesMap[voteValue])
 }
 
-// todo i feel wierd returning a bigint when actually the index will always be a number
 function getDequeueIndex(proposalID: bigint, dequeue: bigint[]): bigint {
   const index = dequeue.findIndex((bn) => bn === proposalID)
 

--- a/packages/core/src/governing/vote.ts
+++ b/packages/core/src/governing/vote.ts
@@ -1,0 +1,34 @@
+import { HexString } from '@celo/base'
+const voteValuesMap = {
+  None: 0,
+  Abstain: 1,
+  No: 2,
+  Yes: 3,
+} as const
+export type VoteProposalTypes = keyof typeof voteValuesMap
+type VoteValues = (typeof voteValuesMap)[keyof typeof voteValuesMap]
+
+export type VoteProposalAdapter = {
+  vote: (proposalID: bigint, proposalIndex: bigint, voteValue: VoteValues) => Promise<HexString>
+  getDequeue: () => Promise<bigint[]>
+}
+
+export async function voteProposal(
+  adapater: VoteProposalAdapter,
+  proposalId: bigint,
+  voteValue: VoteProposalTypes
+) {
+  const dequeue = await adapater.getDequeue()
+  const proposalIndex = getDequeueIndex(proposalId, dequeue)
+  return adapater.vote(proposalId, proposalIndex, voteValuesMap[voteValue])
+}
+
+// todo i feel wierd returning a bigint when actually the index will always be a number
+function getDequeueIndex(proposalID: bigint, dequeue: bigint[]): bigint {
+  const index = dequeue.findIndex((bn) => bn === proposalID)
+
+  if (index === -1) {
+    throw new Error(`ID ${proposalID} not found in array ${dequeue}`)
+  }
+  return BigInt(index)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,2 @@
+export * from './governing'
 export * from './staking'

--- a/packages/core/src/staking/vote.ts
+++ b/packages/core/src/staking/vote.ts
@@ -3,7 +3,6 @@ import { zip } from '@celo/base/lib/collections'
 import { HexString } from '@celo/base/lib/string'
 
 export type VoteAdapter = {
-  // Todo what is the right return type for this? maybe the hash of the transaction?
   vote: (
     validatorGroup: Address,
     value: bigint,

--- a/packages/core/src/staking/vote.ts
+++ b/packages/core/src/staking/vote.ts
@@ -1,11 +1,15 @@
-import { eqAddress, NULL_ADDRESS } from '@celo/base/lib/address'
+import { StrongAddress as Address, eqAddress, NULL_ADDRESS } from '@celo/base/lib/address'
 import { zip } from '@celo/base/lib/collections'
-type Address = `0x${string}`
-type Hex = `0x${string}`
+import { HexString } from '@celo/base/lib/string'
 
 export type VoteAdapter = {
   // Todo what is the right return type for this? maybe the hash of the transaction?
-  vote: (validatorGroup: Address, value: bigint, lesser: Address, greater: Address) => Promise<Hex>
+  vote: (
+    validatorGroup: Address,
+    value: bigint,
+    lesser: Address,
+    greater: Address
+  ) => Promise<HexString>
   getTotalVotesForEligibleValidatorGroups: () => Promise<
     Readonly<[Readonly<Address[]>, Readonly<bigint[]>]>
   >
@@ -20,7 +24,7 @@ export async function vote(
   adapter: VoteAdapter,
   validatorGroup: Address,
   value: bigint
-): Promise<Hex> {
+): Promise<HexString> {
   const [groups, votes] = await adapter.getTotalVotesForEligibleValidatorGroups()
 
   const currentVotes = zip(

--- a/packages/sdk/base/src/address.ts
+++ b/packages/sdk/base/src/address.ts
@@ -29,7 +29,7 @@ export const hexToBuffer = (input: string) => Buffer.from(trimLeading0x(input), 
 
 export const bufferToHex = (buf: Buffer) => ensureLeading0x(buf.toString('hex'))
 
-export const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'
+export const NULL_ADDRESS = '0x0000000000000000000000000000000000000000' as StrongAddress
 
 export const findAddressIndex = (address: Address, addresses: Address[]) =>
   addresses.findIndex((x) => eqAddress(x, address))

--- a/packages/sdk/base/src/string.ts
+++ b/packages/sdk/base/src/string.ts
@@ -15,3 +15,5 @@ export const StringBase = {
   appendPath,
   normalizeAccents,
 }
+
+export type HexString = `0x${string}`

--- a/packages/sdk/contractkit/src/wrappers/Election.ts
+++ b/packages/sdk/contractkit/src/wrappers/Election.ts
@@ -481,10 +481,10 @@ export class ElectionWrapper extends BaseWrapperForGoverning<Election> {
     for (const vote of currentVotes) {
       if (!eqAddress(vote.address, votedGroup)) {
         if (vote.votes.isLessThanOrEqualTo(voteTotal)) {
-          lesserKey = vote.address
+          lesserKey = vote.address as StrongAddress
           break
         }
-        greaterKey = vote.address
+        greaterKey = vote.address as StrongAddress
       }
     }
 

--- a/packages/sdk/contractkit/src/wrappers/SortedOracles.ts
+++ b/packages/sdk/contractkit/src/wrappers/SortedOracles.ts
@@ -294,10 +294,10 @@ export class SortedOraclesWrapper extends BaseWrapper<SortedOracles> {
     for (const rate of currentRates) {
       if (!eqAddress(rate.address, oracleAddress)) {
         if (rate.rate.isLessThanOrEqualTo(value)) {
-          lesserKey = rate.address
+          lesserKey = rate.address as StrongAddress
           break
         }
-        greaterKey = rate.address
+        greaterKey = rate.address as StrongAddress
       }
     }
 


### PR DESCRIPTION
### Description

viem is the future

#### Other changes

* typed `NULL_ADDRESS` as having 0x prefix. 

* added `type HexString` to celo/base

* fewer places use our Address type. 
* can pass a bigInt to a few places that are checking proposalID is valid. just a type change needed since BigInt() takes bigint as an argument already

* testIWithViem now accepts a forkUrl and forkBlockNumber. if passed the anvil chain will be based on that state instead of loading state form the devchain. 

### Tested

just existing tests.

### How to QA

need to have a proposal to vote on. 

### Related issues

- Fixes #622

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing type safety and clarity in the governance and voting functionalities within the Celo ecosystem. It introduces explicit types for addresses, refines the vote proposal process, and improves testing for voting functionalities.

### Detailed summary
- Added `HexString` type for hexadecimal strings.
- Exported `voteProposal`, `VoteProposalAdapter`, and `VoteProposalTypes` from `./vote`.
- Refined address types to `StrongAddress` in various files.
- Updated `vote` function to use explicit types and handle voting logic.
- Added tests for `voteProposal` to ensure correct functionality.
- Enhanced governance command to utilize new voting logic and types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->