### PR TITLE
refactor: releasecelo/transfer-dollars viem

### DIFF
--- a/packages/actions/src/contracts/erc20.ts
+++ b/packages/actions/src/contracts/erc20.ts
@@ -1,8 +1,8 @@
-import { Client, erc20Abi, getContract, GetContractReturnType, PublicClient } from 'viem'
+import { Address, Client, erc20Abi, getContract, GetContractReturnType, PublicClient } from 'viem'
 
 export async function getERC20Contract<T extends Client = PublicClient>(
   client: T,
-  address: `0x${string}`
+  address: Address
 ): Promise<ERC20<T>> {
   return getContract({
     address,

--- a/packages/actions/src/contracts/release-celo.ts
+++ b/packages/actions/src/contracts/release-celo.ts
@@ -1,9 +1,9 @@
 import { releaseGoldABI } from '@celo/abis'
-import { Client, getContract, GetContractReturnType, PublicClient } from 'viem'
+import { Address, Client, getContract, GetContractReturnType, PublicClient } from 'viem'
 
 export async function getReleaseCeloContract<T extends Client = PublicClient>(
   client: T,
-  address: `0x${string}`
+  address: Address
 ): Promise<ReleaseCeloContract<T>> {
   return getContract({
     address,

--- a/packages/actions/src/contracts/release-celo.ts
+++ b/packages/actions/src/contracts/release-celo.ts
@@ -1,0 +1,17 @@
+import { releaseGoldABI } from '@celo/abis'
+import { Client, getContract, GetContractReturnType, PublicClient } from 'viem'
+
+export async function getReleaseCeloContract<T extends Client = PublicClient>(
+  client: T,
+  address: `0x${string}`
+): Promise<ReleaseCeloContract<T>> {
+  return getContract({
+    address,
+    abi: releaseGoldABI,
+    client,
+  })
+}
+export type ReleaseCeloContract<T extends Client = PublicClient> = GetContractReturnType<
+  typeof releaseGoldABI,
+  T
+>

--- a/packages/cli/src/commands/releasecelo/transfer-dollars.test.ts
+++ b/packages/cli/src/commands/releasecelo/transfer-dollars.test.ts
@@ -3,9 +3,10 @@ import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance
 import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import BigNumber from 'bignumber.js'
+import { formatEther } from 'viem'
 import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import Register from '../account/register'
@@ -79,15 +80,20 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
   })
 
   test('should fail if contract has no celo dollars', async () => {
+    const logSpy = jest.spyOn(console, 'log')
+    const value = BigInt(1)
     await expect(
       testLocallyWithWeb3Node(
         RGTransferDollars,
-        ['--contract', contractAddress, '--to', accounts[0], '--value', '1'],
+        ['--contract', contractAddress, '--to', accounts[0], '--value', value.toString()],
         web3
       )
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Error: execution reverted: revert: transfer value exceeded balance of sender"`
-    )
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
+    expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls).at(-1)).toMatchInlineSnapshot(`
+      [
+        "   ✘  Account has at least ${formatEther(value)} cUSD ",
+      ]
+    `)
   })
   test('should fail if to address is sanctioned', async () => {
     await topUpWithToken(

--- a/packages/cli/src/commands/releasecelo/transfer-dollars.ts
+++ b/packages/cli/src/commands/releasecelo/transfer-dollars.ts
@@ -29,7 +29,8 @@ export default class TransferDollars extends ReleaseGoldBaseCommand {
   async run() {
     const { flags } = await this.parse(TransferDollars)
     const client = await this.getPublicClient()
-    const releaseCeloContract = await getReleaseCeloContract(client, flags.contract)
+    const wallet = await this.getWalletClient()
+    const releaseCeloContract = await getReleaseCeloContract(wallet, flags.contract)
 
     const isRevoked = await releaseCeloContract.read.isRevoked()
 

--- a/packages/cli/src/commands/releasecelo/transfer-dollars.ts
+++ b/packages/cli/src/commands/releasecelo/transfer-dollars.ts
@@ -1,5 +1,6 @@
+import { getReleaseCeloContract } from '@celo/actions/contracts/release-celo'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 
@@ -13,7 +14,7 @@ export default class TransferDollars extends ReleaseGoldBaseCommand {
       required: true,
       description: 'Address of the recipient of Celo Dollars transfer',
     }),
-    value: CustomFlags.wei({
+    value: CustomFlags.bigint({
       required: true,
       description: 'Value (in Wei) of Celo Dollars to transfer',
     }),
@@ -26,16 +27,26 @@ export default class TransferDollars extends ReleaseGoldBaseCommand {
   ]
 
   async run() {
-    const kit = await this.getKit()
     const { flags } = await this.parse(TransferDollars)
-    const isRevoked = await this.releaseGoldWrapper.isRevoked()
-    kit.defaultAccount = isRevoked
-      ? await this.releaseGoldWrapper.getReleaseOwner()
-      : await this.releaseGoldWrapper.getBeneficiary()
+    const client = await this.getPublicClient()
+    const releaseCeloContract = await getReleaseCeloContract(client, flags.contract)
+
+    const isRevoked = await releaseCeloContract.read.isRevoked()
+
+    const account = isRevoked
+      ? await releaseCeloContract.read.releaseOwner()
+      : await releaseCeloContract.read.beneficiary()
+
     await newCheckBuilder(this)
-      .isNotSanctioned(kit.defaultAccount)
+      .isNotSanctioned(account)
       .isNotSanctioned(flags.to)
+      .hasEnoughStable(flags.contract, flags.value, 'cUSD')
       .runChecks()
-    await displaySendTx('transfer', this.releaseGoldWrapper.transfer(flags.to, flags.value))
+
+    await displayViemTx(
+      'transfer',
+      releaseCeloContract.write.transfer([flags.to, flags.value], { account }),
+      client
+    )
   }
 }

--- a/packages/cli/src/packages-to-be/rpc-client.ts
+++ b/packages/cli/src/packages-to-be/rpc-client.ts
@@ -26,7 +26,7 @@ export default async function createRpcWalletClient<T extends Chain | undefined 
   const accounts = await publicClient.request<{
     Parameters: []
     Method: 'eth_requestAccounts'
-    ReturnType: `0x${string}`[]
+    ReturnType: Address[]
   }>({
     method: 'eth_requestAccounts',
     params: [],

--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -17,7 +17,7 @@ import humanizeDuration from 'humanize-duration'
 import { convertEthersToCeloTx } from './mento-broker-adaptor'
 
 import { PublicCeloClient } from '@celo/actions'
-import { Abi, ContractEventName, decodeEventLog, DecodeEventLogReturnType } from 'viem'
+import { Abi, Address, ContractEventName, decodeEventLog, DecodeEventLogReturnType } from 'viem'
 
 const CLIError = Errors.CLIError
 
@@ -63,7 +63,7 @@ export async function displaySafeTx(name: string, safeTxResult: SafeTransactionR
 
 export async function displayViemTx<const abi extends Abi | undefined = undefined>(
   name: string,
-  hash: Promise<`0x${string}`>,
+  hash: Promise<Address>,
   client: PublicCeloClient,
   decodeEventsOpts?: abi extends Abi
     ? {

--- a/packages/dev-utils/src/viem/anvil-test.ts
+++ b/packages/dev-utils/src/viem/anvil-test.ts
@@ -5,6 +5,7 @@ import {
   Address,
   Client,
   createTestClient,
+  Hex,
   http,
   HttpTransport,
   PublicActions,
@@ -145,7 +146,7 @@ async function asCoreContractsOwner(
   )
 }
 
-function setCode(testClient: TestClientExtended, address: Address, code: Address) {
+function setCode(testClient: TestClientExtended, address: Address, code: Hex) {
   return testClient.setCode({ address, bytecode: code })
 }
 

--- a/packages/dev-utils/src/viem/anvil-test.ts
+++ b/packages/dev-utils/src/viem/anvil-test.ts
@@ -2,6 +2,7 @@ import { StrongAddress } from '@celo/base'
 import { Anvil, createAnvil, CreateAnvilOptions } from '@viem/anvil'
 import {
   Account,
+  Address,
   Client,
   createTestClient,
   http,
@@ -93,7 +94,7 @@ function testWithAnvil(
 
 function impersonateAccount(
   testClient: TestClientExtended,
-  address: `0x${string}`,
+  address: Address,
   withBalance?: number | bigint
 ) {
   return Promise.all([
@@ -107,13 +108,13 @@ function impersonateAccount(
   ])
 }
 
-function stopImpersonatingAccount(testClient: TestClientExtended, address: `0x${string}`) {
+function stopImpersonatingAccount(testClient: TestClientExtended, address: Address) {
   return testClient.stopImpersonatingAccount({ address })
 }
 
 async function withImpersonatedAccount(
   testClient: TestClientExtended,
-  account: `0x${string}`,
+  account: Address,
   fn: () => Promise<void>,
   withBalance?: number | bigint
 ) {
@@ -137,7 +138,7 @@ async function asCoreContractsOwner(
   )
 }
 
-function setCode(testClient: TestClientExtended, address: `0x${string}`, code: `0x${string}`) {
+function setCode(testClient: TestClientExtended, address: Address, code: Address) {
   return testClient.setCode({ address, bytecode: code })
 }
 
@@ -145,11 +146,7 @@ function setNextBlockTimestamp(testClient: TestClientExtended, timestamp: number
   return testClient.setNextBlockTimestamp({ timestamp: BigInt(timestamp) })
 }
 
-function setBalance(
-  testClient: TestClientExtended,
-  address: `0x${string}`,
-  balance: number | bigint
-) {
+function setBalance(testClient: TestClientExtended, address: Address, balance: number | bigint) {
   return testClient.setBalance({ address, value: BigInt(balance) })
 }
 

--- a/packages/dev-utils/src/viem/test-utils.ts
+++ b/packages/dev-utils/src/viem/test-utils.ts
@@ -1,4 +1,4 @@
-import { Address } from 'viem'
+import { Hex } from 'viem'
 import { TestClientExtended } from './anvil-test'
 
 type Hooks = {
@@ -33,7 +33,7 @@ export function testWithViem(
   }
 
   describeFn(name, () => {
-    let snapId: Address | null = null
+    let snapId: Hex | null = null
 
     if (options.hooks?.beforeAll) {
       beforeAll(options.hooks.beforeAll)

--- a/packages/dev-utils/src/viem/test-utils.ts
+++ b/packages/dev-utils/src/viem/test-utils.ts
@@ -1,3 +1,4 @@
+import { Address } from 'viem'
 import { TestClientExtended } from './anvil-test'
 
 type Hooks = {
@@ -32,7 +33,7 @@ export function testWithViem(
   }
 
   describeFn(name, () => {
-    let snapId: `0x${string}` | null = null
+    let snapId: Address | null = null
 
     if (options.hooks?.beforeAll) {
       beforeAll(options.hooks.beforeAll)

--- a/packages/sdk/wallets/wallet-base/src/signing-utils.ts
+++ b/packages/sdk/wallets/wallet-base/src/signing-utils.ts
@@ -237,7 +237,7 @@ enum TxTypeToPrefix {
 
 export interface LegacyEncodedTx {
   type: 'celo-legacy'
-  rlpEncode: `0x${string}`
+  rlpEncode: Hex
   transaction: FormattedCeloTx
 }
 


### PR DESCRIPTION
Viem time baby

- Fixes #624

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating type definitions and improving the handling of addresses in the codebase, transitioning from string-based representations to a more structured `Address` type. This enhances type safety and consistency across various modules.

### Detailed summary
- Updated `LegacyEncodedTx` interface to use `Hex` instead of string for `rlpEncode`.
- Changed `eth_requestAccounts` return type from `0x${string}[]` to `Address[]`.
- Modified `getERC20Contract` to accept `Address` instead of `0x${string}`.
- Changed `snapId` type from `0x${string} | null` to `Hex | null`.
- Added `getReleaseCeloContract` function to retrieve release contracts with `Address` type.
- Updated `displayViemTx` function to accept `Promise<Address>` instead of `Promise<0x${string}>`.
- Replaced `0x${string}` with `Address` in various functions in `anvil-test.ts`.
- Changed `setCode` function to use `Hex` for bytecode instead of `0x${string}`.
- Updated `setBalance` and other functions to use `Address` type.
- Switched from `displaySendTx` to `displayViemTx` in `TransferDollars` class methods.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->