### PR TITLE
 should be able to connect via websocket

### DIFF
--- a/packages/cli/src/base.test.ts
+++ b/packages/cli/src/base.test.ts
@@ -82,6 +82,17 @@ describe('flags', () => {
       expect(connectdChain).toBe(42220)
     })
   })
+  describe('--node websockets', () => {
+    it('it connects to 62320', async () => {
+      const command = new BasicCommand(
+        ['--node', 'wss://baklava-forno.celo-testnet.org/ws'],
+        config
+      )
+      const runnerClient = await command.getPublicClient()
+      const connectdChain = runnerClient.chain
+      expect(connectdChain.id).toBe(62320)
+    })
+  })
   describe('--help', () => {
     it('it shows help', async () => {
       const writeSpy = jest.spyOn(ux.write, 'stdout').mockImplementation()

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -19,6 +19,7 @@ import {
   http,
   MethodNotFoundRpcError,
   Transport,
+  webSocket,
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { celo, celoAlfajores } from 'viem/chains'
@@ -185,7 +186,18 @@ export abstract class BaseCommand extends Command {
 
   private async getTransport(): Promise<Transport> {
     const nodeUrl = await this.getNodeUrl()
-    return nodeUrl && nodeUrl.endsWith('.ipc') ? ipc(nodeUrl) : http(nodeUrl)
+    if (nodeUrl?.endsWith('.ipc')) {
+      return ipc(nodeUrl)
+    } else if (nodeUrl?.startsWith('http')) {
+      return http(nodeUrl)
+    } else if (nodeUrl?.startsWith('ws')) {
+      return webSocket(nodeUrl)
+    } else {
+      console.error(`Invalid node URL: ${nodeUrl}`)
+      throw new Error(
+        "Invalid ---node. It should start with 'http', 'ws', end with '.ipc' or be a known alias"
+      )
+    }
   }
 
   private async openLedgerTransport() {


### PR DESCRIPTION
### Description

fixes regression where websockets couldnt be used

#### Other changes

n/a
### Tested

brand new test 

### How to QA

connect to a node with a websocket based url
### Related issues

- fix #626


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces WebSocket support for the command-line interface and enhances error handling for invalid node URLs.

### Detailed summary
- Added a new test suite `--node websockets` to verify connection to a WebSocket node.
- Implemented a test that checks if the connection to `wss://baklava-forno.celo-testnet.org/ws` correctly identifies the chain ID as `62320`.
- Enhanced `getTransport` method in `BaseCommand` to support WebSocket URLs and added error handling for invalid node URLs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->