### PR TITLE
Default Derivation

### DIFF
--- a/.changeset/curly-toes-pump.md
+++ b/.changeset/curly-toes-pump.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': major
+---
+
+Now defaults to using "m/44'/60'/0'" as base derivation path for account:new and any command using --useLedger. use celocli config:set --derivationPath celoLegacy for old behavior.

--- a/.changeset/wild-hornets-approve.md
+++ b/.changeset/wild-hornets-approve.md
@@ -1,0 +1,5 @@
+---
+'@celo/cryptographic-utils': major
+---
+
+Default to using eth derivation path "m/44'/60'/0'" in generateKeysFromSeed, generateKeys, generateDeterministicInviteCode. Pass your own in if needed.

--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -12,4 +12,6 @@ secret:
     name: wallet-rpc private test key
   - match: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
     name: admin-revoke test key 
+  - match: e4816cbb93346760921264ea38a7fc54903f4dd688ae0923fefd89a43c5f58cc
+    name: account:new test private key
 version: 3

--- a/packages/cli/src/base.test.ts
+++ b/packages/cli/src/base.test.ts
@@ -178,6 +178,7 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
       expect(logSpy.mock.calls[0]).toMatchInlineSnapshot(`
         [
           "Retrieving derivation Paths",
+          "m/44'/60'/0'",
           [
             0,
             1,
@@ -227,6 +228,7 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
         expect(logSpy.mock.calls[0]).toMatchInlineSnapshot(`
           [
             "Retrieving derivation Paths",
+            "m/44'/60'/0'",
             [
               0,
               1,
@@ -275,6 +277,7 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
           expect(logSpy.mock.calls[0]).toMatchInlineSnapshot(`
             [
               "Retrieving derivation Paths",
+              "m/44'/60'/0'",
               [
                 1,
                 8,
@@ -322,6 +325,7 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
         expect(logSpy.mock.calls[0]).toMatchInlineSnapshot(`
           [
             "Retrieving derivation Paths",
+            "m/44'/60'/0'",
             [
               1,
               8,

--- a/packages/cli/src/commands/account/new.test.ts
+++ b/packages/cli/src/commands/account/new.test.ts
@@ -26,12 +26,6 @@ testWithAnvilL2('account:new cmd', (web3: Web3) => {
       [
         [
           "
-      Using celoLegacy path (m/44'/52752'/0') for derivation. This will default to eth derivation path (m/44'/60'/0') next major version.
-       use "config:set --derivationPath <path>" to set your preffered default
-      ",
-        ],
-        [
-          "
       This is not being stored anywhere. Save the mnemonic somewhere to use this account at a later point.
       ",
         ],
@@ -40,7 +34,7 @@ testWithAnvilL2('account:new cmd', (web3: Web3) => {
 
     expect(deRandomize(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
       "mnemonic: *** *** 
-      derivationPath: m/44'/52752'/0'/0/0
+      derivationPath: m/44'/60'/0'/0/0
       privateKey: PUBLIC_KEY
       publicKey: PRIVATE_KEY
       address: ADDRESS"
@@ -132,8 +126,24 @@ testWithAnvilL2('account:new cmd', (web3: Web3) => {
       fs.rmSync(MNEMONIC_PATH)
     })
 
-    it('generates using celo derivation path', async () => {
+    it('generates using eth derivation path', async () => {
       await testLocallyWithWeb3Node(NewAccount, [`--mnemonicPath`, MNEMONIC_PATH], web3)
+
+      expect(stripAnsiCodesAndTxHashes(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
+        "mnemonic: hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue
+        derivationPath: m/44'/60'/0'/0/0
+        privateKey: e4816cbb93346760921264ea38a7fc54903f4dd688ae0923fefd89a43c5f58cc
+        publicKey: 034b3036d657a6dc2f322db52cca29ae72101a9cf56de4765d17b0507ea1e87b7c
+        address: 0x35A4d54B541fc7b2047fb5357cC706191E105cd3"
+      `)
+    })
+
+    it('and "--derivationPath celoLegacy" generates using celo-legacy derivation path', async () => {
+      await testLocallyWithWeb3Node(
+        NewAccount,
+        ['--derivationPath', 'celoLegacy', `--mnemonicPath`, MNEMONIC_PATH],
+        web3
+      )
 
       expect(stripAnsiCodesAndTxHashes(consoleMock.mock.lastCall?.[0])).toMatchInlineSnapshot(`
         "mnemonic: hamster label near volume denial spawn stable orbit trade only crawl learn forest fire test feel bubble found angle also olympic obscure fork venue

--- a/packages/cli/src/commands/account/new.ts
+++ b/packages/cli/src/commands/account/new.ts
@@ -159,7 +159,7 @@ export default class NewAccount extends BaseCommand {
     ) {
       this.log(
         chalk.magenta(
-          `\nUsing eth path (${ETHEREUM_DERIVATION_PATH}) for derivation. This used to default to ${CELO_BASE_DERIVATION_PATH} but changed in version 10.0.0. use "config:set --derivationPath <path>" to set your preffered default\n`
+          `\nUsing eth path (${ETHEREUM_DERIVATION_PATH}) for derivation. This used to default to ${CELO_BASE_DERIVATION_PATH} but changed in version 10.0.0. use "config:set --derivationPath <path>" to set your preferred default\n`
         )
       )
     }

--- a/packages/cli/src/commands/config/get.test.ts
+++ b/packages/cli/src/commands/config/get.test.ts
@@ -14,7 +14,7 @@ describe('config:get cmd', () => {
     await testLocally(Get, [])
     expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[0][0].replace(/:\d+/, ':PORT')))
       .toMatchInlineSnapshot(`
-      "node: http://127.0.0.1:PORT
+      "node:http://localhost:PORT
       derivationPath: m/44'/60'/0'
       telemetry: true"
     `)

--- a/packages/cli/src/commands/config/get.test.ts
+++ b/packages/cli/src/commands/config/get.test.ts
@@ -14,8 +14,8 @@ describe('config:get cmd', () => {
     await testLocally(Get, [])
     expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[0][0].replace(/:\d+/, ':PORT')))
       .toMatchInlineSnapshot(`
-      "node: http://localhost:PORT
-      derivationPath: m/44'/52752'/0'
+      "node: http://127.0.0.1:PORT
+      derivationPath: m/44'/60'/0'
       telemetry: true"
     `)
   })

--- a/packages/cli/src/commands/config/get.test.ts
+++ b/packages/cli/src/commands/config/get.test.ts
@@ -14,7 +14,7 @@ describe('config:get cmd', () => {
     await testLocally(Get, [])
     expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[0][0].replace(/:\d+/, ':PORT')))
       .toMatchInlineSnapshot(`
-      "node:http://localhost:PORT
+      "node: http://localhost:PORT
       derivationPath: m/44'/60'/0'
       telemetry: true"
     `)

--- a/packages/cli/src/utils/config.test.ts
+++ b/packages/cli/src/utils/config.test.ts
@@ -28,7 +28,7 @@ describe('writeConfig', () => {
     expect(spy.mock.calls[0][0]).toEqual(file)
     expect(spy.mock.calls[0][1]).toMatchInlineSnapshot(`
       {
-        "derivationPath": "m/44'/52752'/0'",
+        "derivationPath": "m/44'/60'/0'",
         "node": "http://localhost:8545",
         "telemetry": true,
       }
@@ -74,7 +74,7 @@ describe('readConfig', () => {
     fs.writeJsonSync(file, { foo: 'bar' })
     expect(readConfig(dir)).toMatchInlineSnapshot(`
       {
-        "derivationPath": "m/44'/52752'/0'",
+        "derivationPath": "m/44'/60'/0'",
         "foo": "bar",
         "node": "http://localhost:8545",
         "telemetry": true,
@@ -86,7 +86,7 @@ describe('readConfig', () => {
     fs.writeJsonSync(file, { nodeUrl: 'bar' })
     expect(readConfig(dir)).toMatchInlineSnapshot(`
       {
-        "derivationPath": "m/44'/52752'/0'",
+        "derivationPath": "m/44'/60'/0'",
         "node": "bar",
         "telemetry": true,
       }
@@ -97,7 +97,7 @@ describe('readConfig', () => {
     fs.writeJsonSync(file, { gasCurrency: 'CELO' })
     expect(readConfig(dir)).toMatchInlineSnapshot(`
       {
-        "derivationPath": "m/44'/52752'/0'",
+        "derivationPath": "m/44'/60'/0'",
         "node": "http://localhost:8545",
         "telemetry": true,
       }

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -1,10 +1,10 @@
-import { CELO_DERIVATION_PATH_BASE } from '@celo/base'
+import { DerivationPath, ETHEREUM_DERIVATION_PATH } from '@celo/base'
 import * as fs from 'fs-extra'
 import * as path from 'path'
 
 export interface CeloConfig {
   node: string
-  derivationPath: string
+  derivationPath: DerivationPath
   telemetry: boolean
 }
 
@@ -16,7 +16,7 @@ const LEGACY_MAPPING: Record<string, keyof CeloConfig | undefined> = {
 
 export const defaultConfig: CeloConfig = {
   node: 'http://localhost:8545',
-  derivationPath: CELO_DERIVATION_PATH_BASE,
+  derivationPath: ETHEREUM_DERIVATION_PATH,
   telemetry: true,
 }
 
@@ -24,6 +24,10 @@ const configFile = 'config.json'
 
 export function configPath(configDir: string) {
   return path.join(configDir, configFile)
+}
+
+export async function configExists(configDir: string): Promise<boolean> {
+  return fs.pathExists(configPath(configDir))
 }
 
 export function readConfig(configDir: string): CeloConfig {

--- a/packages/sdk/cryptographic-utils/src/account.test.ts
+++ b/packages/sdk/cryptographic-utils/src/account.test.ts
@@ -1,4 +1,5 @@
-import { MnemonicLanguages } from '@celo/base/lib/account'
+import { CELO_DERIVATION_PATH_BASE, MnemonicLanguages } from '@celo/base/lib/account'
+
 import * as bip39 from '@scure/bip39'
 import {
   generateKeys,
@@ -139,9 +140,30 @@ describe('AccountUtils', () => {
       expect(mnemonics.length).toEqual(expectedPrivateKeys.length)
       for (let i = 0; i < mnemonics.length; ++i) {
         expect(validateMnemonic(mnemonics[i])).toBe(true)
-        const derivation0 = await generateKeys(mnemonics[i])
-        const derivation1 = await generateKeys(mnemonics[i], undefined, 0, 1)
-        const password = await generateKeys(mnemonics[i], 'password')
+        const derivation0 = await generateKeys(
+          mnemonics[i],
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          CELO_DERIVATION_PATH_BASE
+        )
+        const derivation1 = await generateKeys(
+          mnemonics[i],
+          undefined,
+          0,
+          1,
+          undefined,
+          CELO_DERIVATION_PATH_BASE
+        )
+        const password = await generateKeys(
+          mnemonics[i],
+          'password',
+          0,
+          0,
+          undefined,
+          CELO_DERIVATION_PATH_BASE
+        )
         expect({ derivation0, derivation1, password }).toEqual(expectedPrivateKeys[i])
       }
     })

--- a/packages/sdk/cryptographic-utils/src/account.ts
+++ b/packages/sdk/cryptographic-utils/src/account.ts
@@ -1,6 +1,6 @@
 import {
   Bip39,
-  CELO_DERIVATION_PATH_BASE,
+  ETHEREUM_DERIVATION_PATH,
   MnemonicLanguages,
   MnemonicStrength,
   RandomNumberGenerator,
@@ -392,7 +392,7 @@ function wordSuggestions(typo: string, language: MnemonicLanguages): Suggestions
  * @param changeIndex postion 4 from https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
  * @param addressIndex postion 5 from https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
  * bip39ToUse - bip39 library
- * @param derivationPath - This will default to ETH_DERIVATION_PATH in 7.0 forum.celo.org/t/deprecating-the-celo-derivation-path/9229
+ * @param derivationPath - Defaults to ETH_DERIVATION_PATH in 7.0 forum.celo.org/t/deprecating-the-celo-derivation-path/9229
  */
 export async function generateKeys(
   mnemonic: string,
@@ -400,7 +400,7 @@ export async function generateKeys(
   changeIndex: number = 0,
   addressIndex: number = 0,
   bip39ToUse: Bip39 = bip39Wrapper,
-  derivationPath: string = CELO_DERIVATION_PATH_BASE
+  derivationPath: string = ETHEREUM_DERIVATION_PATH
 ): Promise<{ privateKey: string; publicKey: string; address: string }> {
   const seed: Buffer = await generateSeed(mnemonic, password, bip39ToUse)
   return generateKeysFromSeed(seed, changeIndex, addressIndex, derivationPath)
@@ -412,7 +412,7 @@ export function generateDeterministicInviteCode(
   recipientPepper: string,
   addressIndex: number = 0,
   changeIndex: number = 0,
-  derivationPath: string = CELO_DERIVATION_PATH_BASE
+  derivationPath: string = ETHEREUM_DERIVATION_PATH
 ): { privateKey: string; publicKey: string } {
   const seed = Buffer.from(keccak_256(utf8ToBytes(recipientPhoneHash + recipientPepper)))
   return generateKeysFromSeed(seed, changeIndex, addressIndex, derivationPath)
@@ -439,13 +439,13 @@ export async function generateSeed(
  * @param seed - Buffer created from mnemonic
  * @param changeIndex postion 4 from https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
  * @param addressIndex postion 5 from https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
- * @param derivationPath - This will default to ETH_DERIVATION_PATH in 7.0 forum.celo.org/t/deprecating-the-celo-derivation-path/9229
+ * @param derivationPath - This defaults to ETH_DERIVATION_PATH forum.celo.org/t/deprecating-the-celo-derivation-path/9229
  */
 export function generateKeysFromSeed(
   seed: Buffer,
   changeIndex: number = 0,
   addressIndex: number = 0,
-  derivationPath: string = CELO_DERIVATION_PATH_BASE
+  derivationPath: string = ETHEREUM_DERIVATION_PATH
 ): { privateKey: string; publicKey: string; address: string } {
   const node = HDKey.fromMasterSeed(seed)
   const newNode = node.derive(

--- a/packages/sdk/cryptographic-utils/src/dataEncryptionKey.ts
+++ b/packages/sdk/cryptographic-utils/src/dataEncryptionKey.ts
@@ -1,7 +1,7 @@
 import { ensureLeading0x } from '@celo/utils/lib/address'
 import { bytesToHex } from '@noble/curves/abstract/utils'
 import { secp256k1 } from '@noble/curves/secp256k1'
-import { Bip39, generateKeys } from './account'
+import { Bip39, CELO_DERIVATION_PATH_BASE, generateKeys } from './account'
 
 /**
  * Turns a private key to a compressed public key (hex string with hex leader).
@@ -40,7 +40,8 @@ export function deriveDek(mnemonic: string, bip39ToUse?: Bip39) {
     undefined,
     1, // The DEK is derived from change index 1, not 0 like the wallet's transaction keys
     0,
-    bip39ToUse
+    bip39ToUse,
+    CELO_DERIVATION_PATH_BASE
   )
 }
 


### PR DESCRIPTION
### Description

this one has been in the works for a while. With lots of warnings we now default to the same derivation path as metamask. 

Anyone who has used celocli for a while wont be affected if they have ever used the config:set command (even if only for setting the default node) as that would have defaulted the config to use the celo path. 

But new users will get eth derivation paths. 

anyone can set their own default with config:set --derivationPath eth | celoLegacy

#### Other changes



### Tested

not yet

### How to QA

run account:new. 
run some commands with a ledger
run config:set 

### Related issues

- Fixes #352

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the default derivation path for the Celo wallet from `m/44'/52752'/0'` to `m/44'/60'/0'`, along with related changes across various files to accommodate this new default.

### Detailed summary
- Changed default derivation path in multiple files to `m/44'/60'/0'`.
- Updated tests to reflect the new derivation path.
- Adjusted descriptions and documentation to indicate the new default behavior.
- Added functionality to check if the user is using the default derivation path.
- Modified `generateKeys` and related functions to accept the new derivation path.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->