### PR TITLE
test with node 22

### DIFF
--- a/.changeset/curly-toes-pump.md
+++ b/.changeset/curly-toes-pump.md
@@ -2,4 +2,4 @@
 '@celo/celocli': major
 ---
 
-Now defaults to using "m/44'/60'/0'" as base derivation path for account:new and any command using --useLedger. use celocli config:set --derivationPath celoLegacy for old behavior.
+Now defaults to using "m/44'/60'/0'" as base derivation path for account:new and any command using --useLedger. use celocli `config:set --derivationPath celoLegacy` for old behavior.

--- a/.changeset/fresh-months-share.md
+++ b/.changeset/fresh-months-share.md
@@ -2,4 +2,4 @@
 '@celo/celocli': major
 ---
 
-Remove node:accounts commmand (use account:list)
+Remove node:accounts command (use account:list)

--- a/.changeset/old-cougars-look.md
+++ b/.changeset/old-cougars-look.md
@@ -2,5 +2,5 @@
 '@celo/celocli': patch
 ---
 
-Deprecate useAKV flag with intent to remove. This was for connecting to AzureKeyVault for storing key to sign trnsactions. We hope to streamline and remove this functionality.  
+Deprecate useAKV flag with intent to remove. This was for connecting to AzureKeyVault for storing key to sign transactions. We hope to streamline and remove this functionality.  
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,14 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: 'enable corepack for yarn'
         run: sudo corepack enable yarn
       - uses: actions/checkout@v4
       # must call twice because of chicken and egg problem with yarn and node
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
       - name: Restore node cache
         uses: actions/cache@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       # must call twice because of chicken and egg problem with yarn and node
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
       - name: Install Dependencies
         shell: bash

--- a/.github/workflows/upload-celocli-executables.yml
+++ b/.github/workflows/upload-celocli-executables.yml
@@ -41,7 +41,7 @@ jobs:
       # must call twice because of chicken and egg problem with yarn and node
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
 
       - name: Install Dependencies
@@ -121,7 +121,7 @@ jobs:
       # must call twice because of chicken and egg problem with yarn and node
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
       - name: Install Dependencies
         shell: bash
@@ -194,7 +194,7 @@ jobs:
       # must call twice because of chicken and egg problem with yarn and node
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
       - name: Install Dependencies
         shell: bash

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -49,7 +49,7 @@
     "postbuild": "node ../../scripts/post-build.mjs",
     "clean": "yarn --top-level run tsc -b . --clean && yarn --top-level run rimraf dist",
     "docs": "yarn --top-level run typedoc",
-    "test": "yarn run vitest --run --passWithNoTests",
+    "test": "yarn run vitest --run --retry=1",
     "check-size": "size-limit",
     "test:watch": "yarn run vitest --watch",
     "test:changes": "yarn run vitest --run --changed",

--- a/packages/actions/src/client.ts
+++ b/packages/actions/src/client.ts
@@ -12,7 +12,7 @@ type CeloChain = typeof celo | typeof celoAlfajores | typeof celoBaklava
 
 export type CeloClient = Client<Transport, CeloChain>
 
-export type PublicCeloClient = PublicClient<Transport, CeloChain, undefined>
+export type PublicCeloClient = PublicClient<Transport, CeloChain, Account | undefined>
 
 export type WalletCeloClient = WalletClient<Transport, CeloChain, Account>
 

--- a/packages/actions/src/client.ts
+++ b/packages/actions/src/client.ts
@@ -12,7 +12,7 @@ type CeloChain = typeof celo | typeof celoAlfajores | typeof celoBaklava
 
 export type CeloClient = Client<Transport, CeloChain>
 
-export type PublicCeloClient = PublicClient<Transport, CeloChain, Account | undefined>
+export type PublicCeloClient = PublicClient<Transport, CeloChain, undefined>
 
 export type WalletCeloClient = WalletClient<Transport, CeloChain, Account>
 

--- a/packages/actions/src/client.ts
+++ b/packages/actions/src/client.ts
@@ -1,4 +1,10 @@
-import type { Account, Client, PublicClient, Transport, WalletClient } from 'viem'
+import {
+  type Account,
+  type Client,
+  type PublicClient,
+  type Transport,
+  type WalletClient,
+} from 'viem'
 import type { celo, celoAlfajores } from 'viem/chains'
 import type { celoBaklava } from './chains'
 
@@ -9,3 +15,11 @@ export type CeloClient = Client<Transport, CeloChain>
 export type PublicCeloClient = PublicClient<Transport, CeloChain, undefined>
 
 export type WalletCeloClient = WalletClient<Transport, CeloChain, Account>
+
+export type Clients<
+  P extends PublicCeloClient | PublicClient = PublicCeloClient,
+  W extends WalletCeloClient | WalletClient = WalletCeloClient
+> = {
+  public: P
+  wallet?: W
+}

--- a/packages/actions/src/contracts/accounts.ts
+++ b/packages/actions/src/contracts/accounts.ts
@@ -1,20 +1,18 @@
 import { accountsABI } from '@celo/abis'
-import { Address, Client, getContract, GetContractReturnType, PublicClient } from 'viem'
-
+import { Address, getContract, GetContractReturnType, PublicClient } from 'viem'
+import { Clients } from '../client'
 import { resolveAddress } from './registry'
 
-export type AccountsContract<T extends Client = PublicClient> = GetContractReturnType<
+export type AccountsContract<C extends Clients = Clients> = GetContractReturnType<
   typeof accountsABI,
-  T
+  C
 >
 
-export async function getAccountsContract<T extends Client = PublicClient>(
-  client: T
-): Promise<AccountsContract<T>> {
+export async function getAccountsContract(clients: Clients): Promise<AccountsContract<Clients>> {
   return getContract({
-    address: await resolveAddress(client, 'Accounts'),
+    address: await resolveAddress(clients.public, 'Accounts'),
     abi: accountsABI,
-    client,
+    client: clients,
   })
 }
 

--- a/packages/actions/src/contracts/accounts.ts
+++ b/packages/actions/src/contracts/accounts.ts
@@ -1,6 +1,6 @@
 import { accountsABI } from '@celo/abis'
-import { Address, getContract, GetContractReturnType, PublicClient } from 'viem'
-import { Clients } from '../client'
+import { Address, getContract, GetContractReturnType } from 'viem'
+import { Clients, PublicCeloClient } from '../client'
 import { resolveAddress } from './registry'
 
 export type AccountsContract<C extends Clients = Clients> = GetContractReturnType<
@@ -18,7 +18,10 @@ export async function getAccountsContract(clients: Clients): Promise<AccountsCon
 
 // METHODS
 
-export const signerToAccount = async (client: PublicClient, signer: Address): Promise<Address> => {
+export const signerToAccount = async (
+  client: PublicCeloClient,
+  signer: Address
+): Promise<Address> => {
   return await client.readContract({
     address: await resolveAddress(client, 'Accounts'),
     abi: accountsABI,

--- a/packages/actions/src/contracts/celo-erc20.ts
+++ b/packages/actions/src/contracts/celo-erc20.ts
@@ -1,17 +1,16 @@
 import { goldTokenABI } from '@celo/abis'
-import { Client, getContract, GetContractReturnType, PublicClient } from 'viem'
+import { getContract, GetContractReturnType } from 'viem'
+import { Clients } from '../client'
 import { resolveAddress } from './registry'
 
-export async function getCeloERC20Contract<T extends Client = PublicClient>(
-  client: T
+export type CeloERC20<T extends Clients = Clients> = GetContractReturnType<typeof goldTokenABI, T>
+
+export async function getCeloERC20Contract<T extends Clients = Clients>(
+  clients: T
 ): Promise<CeloERC20<T>> {
   return getContract({
-    address: await resolveAddress(client, 'GoldToken'),
+    address: await resolveAddress(clients.public, 'GoldToken'),
     abi: goldTokenABI,
-    client,
+    client: clients,
   })
 }
-export type CeloERC20<T extends Client = PublicClient> = GetContractReturnType<
-  typeof goldTokenABI,
-  T
->

--- a/packages/actions/src/contracts/election.ts
+++ b/packages/actions/src/contracts/election.ts
@@ -1,18 +1,19 @@
 import { electionABI } from '@celo/abis'
-import { Client, getContract, GetContractReturnType, PublicClient } from 'viem'
+import { getContract, GetContractReturnType } from 'viem'
+import { Clients } from '../client'
 import { resolveAddress } from './registry'
 
-export type ElectionContract<T extends Client = PublicClient> = GetContractReturnType<
+export type ElectionContract<T extends Clients = Clients> = GetContractReturnType<
   typeof electionABI,
   T
 >
 
-export async function getElectionContract<T extends Client = PublicClient>(
-  client: T
+export async function getElectionContract<T extends Clients = Clients>(
+  clients: T
 ): Promise<ElectionContract<T>> {
   return getContract({
-    address: await resolveAddress(client, 'Election'),
+    address: await resolveAddress(clients.public, 'Election'),
     abi: electionABI,
-    client,
+    client: clients,
   })
 }

--- a/packages/actions/src/contracts/epoch-manager.ts
+++ b/packages/actions/src/contracts/epoch-manager.ts
@@ -1,17 +1,19 @@
 import { epochManagerABI } from '@celo/abis'
-import { Client, getContract, GetContractReturnType, PublicClient } from 'viem'
+import { getContract, GetContractReturnType } from 'viem'
+import { Clients } from '../client'
 import { resolveAddress } from './registry'
 
-export async function getEpochManagerContract<T extends Client = PublicClient>(
-  client: T
-): Promise<EpochManager<T>> {
-  return getContract({
-    address: await resolveAddress(client, 'EpochManager'),
-    abi: epochManagerABI,
-    client,
-  })
-}
-export type EpochManager<T extends Client = PublicClient> = GetContractReturnType<
+export type EpochManager<T extends Clients = Clients> = GetContractReturnType<
   typeof epochManagerABI,
   T
 >
+
+export async function getEpochManagerContract<T extends Clients = Clients>(
+  clients: T
+): Promise<EpochManager<T>> {
+  return getContract({
+    address: await resolveAddress(clients.public, 'EpochManager'),
+    abi: epochManagerABI,
+    client: clients,
+  })
+}

--- a/packages/actions/src/contracts/erc20.ts
+++ b/packages/actions/src/contracts/erc20.ts
@@ -1,13 +1,14 @@
-import { Address, Client, erc20Abi, getContract, GetContractReturnType, PublicClient } from 'viem'
+import { erc20Abi, getContract, type Address, type GetContractReturnType } from 'viem'
+import { Clients } from '../client'
 
-export async function getERC20Contract<T extends Client = PublicClient>(
-  client: T,
+export async function getERC20Contract<T extends Clients = Clients>(
+  clients: T,
   address: Address
 ): Promise<ERC20<T>> {
   return getContract({
     address,
     abi: erc20Abi,
-    client,
+    client: clients,
   })
 }
-export type ERC20<T extends Client = PublicClient> = GetContractReturnType<typeof erc20Abi, T>
+export type ERC20<T extends Clients = Clients> = GetContractReturnType<typeof erc20Abi, T>

--- a/packages/actions/src/contracts/feecurrency-directory.ts
+++ b/packages/actions/src/contracts/feecurrency-directory.ts
@@ -1,17 +1,18 @@
 import { feeCurrencyDirectoryABI } from '@celo/abis'
-import { Client, getContract, GetContractReturnType, PublicClient } from 'viem'
+import { getContract, GetContractReturnType } from 'viem'
+import { Clients } from '../client'
 import { resolveAddress } from './registry'
 
-export async function getFeeCurrencyDirectoryContract<T extends Client = PublicClient>(
-  client: T
+export async function getFeeCurrencyDirectoryContract<T extends Clients = Clients>(
+  clients: T
 ): Promise<FeeCurrencyDirectory<T>> {
   return getContract({
-    address: await resolveAddress(client, 'FeeCurrencyDirectory'),
+    address: await resolveAddress(clients.public, 'FeeCurrencyDirectory'),
     abi: feeCurrencyDirectoryABI,
-    client,
+    client: clients,
   })
 }
-export type FeeCurrencyDirectory<T extends Client = PublicClient> = GetContractReturnType<
+export type FeeCurrencyDirectory<T extends Clients = Clients> = GetContractReturnType<
   typeof feeCurrencyDirectoryABI,
   T
 >

--- a/packages/actions/src/contracts/governance.test.ts
+++ b/packages/actions/src/contracts/governance.test.ts
@@ -38,11 +38,15 @@ viem_testWithAnvil(
     const txHashRegex = /^0x([A-Fa-f0-9]{64})$/
 
     it(
-      'votes Yes/No on a proposal',
+      'votes Yes on a proposal',
       async () => {
-        // This will throw if proposalId is not in the dequeue
-        // In a real test, ensure proposalId is valid and in the dequeue
         await expect(vote(clients, proposalId, 'Yes')).resolves.toMatch(txHashRegex)
+      },
+      TIMEOUT
+    )
+    it(
+      'votes No on a proposal',
+      async () => {
         await expect(vote(clients, proposalId, 'No')).resolves.toMatch(txHashRegex)
       },
       TIMEOUT

--- a/packages/actions/src/contracts/governance.test.ts
+++ b/packages/actions/src/contracts/governance.test.ts
@@ -1,5 +1,5 @@
 import { viem_testWithAnvil } from '@celo/dev-utils/viem/anvil-test'
-import { createWalletClient, http } from 'viem'
+import { createPublicClient, createWalletClient, http } from 'viem'
 import { celo } from 'viem/chains'
 import { expect, it } from 'vitest'
 import { PublicCeloClient, WalletCeloClient } from '../client'
@@ -25,7 +25,10 @@ viem_testWithAnvil(
         transport: http(client.chain.rpcUrls.default.http[0]),
       })
       clients = {
-        public: client,
+        public: createPublicClient({
+          chain: client.chain,
+          transport: http(client.chain.rpcUrls.default.http[0]),
+        }),
         wallet: walletClient,
       }
     })
@@ -35,25 +38,18 @@ viem_testWithAnvil(
     const txHashRegex = /^0x([A-Fa-f0-9]{64})$/
 
     it(
-      'votes Yes on a proposal',
+      'votes Yes/No on a proposal',
       async () => {
         // This will throw if proposalId is not in the dequeue
         // In a real test, ensure proposalId is valid and in the dequeue
         await expect(vote(clients, proposalId, 'Yes')).resolves.toMatch(txHashRegex)
-      },
-      TIMEOUT
-    )
-
-    it(
-      'votes No on a proposal',
-      async () => {
         await expect(vote(clients, proposalId, 'No')).resolves.toMatch(txHashRegex)
       },
       TIMEOUT
     )
 
     it(
-      'votes Abstain on a proposal',
+      'votes Abstain a proposal',
       async () => {
         await expect(vote(clients, proposalId, 'Abstain')).resolves.toMatch(txHashRegex)
       },

--- a/packages/actions/src/contracts/governance.ts
+++ b/packages/actions/src/contracts/governance.ts
@@ -1,11 +1,11 @@
 import { governanceABI } from '@celo/abis'
 import { zip } from '@celo/base'
 import { voteProposal, VoteProposalTypes } from '@celo/core'
-import { Client, getContract, GetContractReturnType, PublicClient } from 'viem'
-import { WalletCeloClient } from '../client'
+import { getContract, GetContractReturnType } from 'viem'
+import { Clients, PublicCeloClient } from '../client'
 import { resolveAddress } from './registry'
 
-export type GovernanceContract<T extends Client = PublicClient> = GetContractReturnType<
+export type GovernanceContract<T extends Clients = Clients> = GetContractReturnType<
   typeof governanceABI,
   T
 >
@@ -24,22 +24,22 @@ export interface UpvoteRecord {
   upvotes: bigint
 }
 
-export async function getGovernanceContract<T extends Client = PublicClient>(
-  client: T
+export async function getGovernanceContract<T extends Clients = Clients>(
+  clients: T
 ): Promise<GovernanceContract<T>> {
   return getContract({
-    address: await resolveAddress(client, 'Governance'),
+    address: await resolveAddress(clients.public, 'Governance'),
     abi: governanceABI,
-    client,
+    client: clients,
   })
 }
 
-export async function vote<T extends WalletCeloClient = WalletCeloClient>(
-  client: T,
+export async function vote<C extends Required<Clients> = Required<Clients>>(
+  clients: C,
   proposalId: bigint,
   voteValue: VoteProposalTypes
 ) {
-  const contract = await getGovernanceContract(client)
+  const contract = await getGovernanceContract(clients)
   return voteProposal(
     {
       vote: async (proposalID, proposalIndex, voteValue) => {
@@ -56,7 +56,7 @@ export async function vote<T extends WalletCeloClient = WalletCeloClient>(
   )
 }
 
-export const getQueue = async (client: PublicClient) => {
+export const getQueue = async (client: PublicCeloClient) => {
   const queue = await client.readContract({
     address: await resolveAddress(client, 'Governance'),
     abi: governanceABI,
@@ -74,7 +74,7 @@ export const getQueue = async (client: PublicClient) => {
 }
 
 export const getProposalStage = async (
-  client: PublicClient,
+  client: PublicCeloClient,
   proposalId: bigint
 ): Promise<ProposalStage> => {
   const queue = await getQueue(client)

--- a/packages/actions/src/contracts/governance.ts
+++ b/packages/actions/src/contracts/governance.ts
@@ -43,7 +43,9 @@ export async function vote<C extends Required<Clients> = Required<Clients>>(
   return voteProposal(
     {
       vote: async (proposalID, proposalIndex, voteValue) => {
-        const { request } = await contract.simulate.vote([proposalID, proposalIndex, voteValue])
+        const { request } = await contract.simulate.vote([proposalID, proposalIndex, voteValue], {
+          account: clients.wallet.account.address,
+        })
         return contract.write.vote(request.args)
       },
       getDequeue: async () => {

--- a/packages/actions/src/contracts/locked-celo.ts
+++ b/packages/actions/src/contracts/locked-celo.ts
@@ -1,17 +1,18 @@
 import { lockedGoldABI } from '@celo/abis'
-import { Client, getContract, GetContractReturnType, PublicClient } from 'viem'
+import { getContract, GetContractReturnType } from 'viem'
+import { Clients } from '../client'
 import { resolveAddress } from './registry'
 
-export async function getLockedCeloContract<T extends Client = PublicClient>(
-  client: T
+export async function getLockedCeloContract<T extends Clients = Clients>(
+  clients: T
 ): Promise<LockedCeloContract<T>> {
   return getContract({
-    address: await resolveAddress(client, 'LockedGold'),
+    address: await resolveAddress(clients.public, 'LockedGold'),
     abi: lockedGoldABI,
-    client,
+    client: clients,
   })
 }
-export type LockedCeloContract<T extends Client = PublicClient> = GetContractReturnType<
+export type LockedCeloContract<T extends Clients = Clients> = GetContractReturnType<
   typeof lockedGoldABI,
   T
 >

--- a/packages/actions/src/contracts/release-celo.ts
+++ b/packages/actions/src/contracts/release-celo.ts
@@ -1,17 +1,18 @@
 import { releaseGoldABI } from '@celo/abis'
-import { Address, Client, getContract, GetContractReturnType, PublicClient } from 'viem'
+import { Address, getContract, GetContractReturnType } from 'viem'
+import { Clients } from '../client'
 
-export async function getReleaseCeloContract<T extends Client = PublicClient>(
-  client: T,
+export async function getReleaseCeloContract<T extends Clients = Clients>(
+  clients: T,
   address: Address
 ): Promise<ReleaseCeloContract<T>> {
   return getContract({
     address,
     abi: releaseGoldABI,
-    client,
+    client: clients,
   })
 }
-export type ReleaseCeloContract<T extends Client = PublicClient> = GetContractReturnType<
+export type ReleaseCeloContract<T extends Clients = Clients> = GetContractReturnType<
   typeof releaseGoldABI,
   T
 >

--- a/packages/actions/src/contracts/validators.ts
+++ b/packages/actions/src/contracts/validators.ts
@@ -1,17 +1,18 @@
 import { validatorsABI } from '@celo/abis'
-import { Client, getContract, GetContractReturnType, PublicClient } from 'viem'
+import { getContract, GetContractReturnType } from 'viem'
+import { Clients } from '../client'
 import { resolveAddress } from './registry'
 
-export async function getValidatorsContract<T extends Client = PublicClient>(
-  client: T
+export async function getValidatorsContract<T extends Clients = Clients>(
+  clients: T
 ): Promise<ValidatorsContract<T>> {
   return getContract({
-    address: await resolveAddress(client, 'Validators'),
+    address: await resolveAddress(clients.public, 'Validators'),
     abi: validatorsABI,
-    client,
+    client: clients,
   })
 }
-export type ValidatorsContract<T extends Client = PublicClient> = GetContractReturnType<
+export type ValidatorsContract<T extends Clients = Clients> = GetContractReturnType<
   typeof validatorsABI,
   T
 >

--- a/packages/actions/src/multicontract-interactions/stake/elected-rpc-nodes.ts
+++ b/packages/actions/src/multicontract-interactions/stake/elected-rpc-nodes.ts
@@ -1,5 +1,6 @@
 import { eqAddress, NULL_ADDRESS } from '@celo/base'
-import { Address, PublicClient } from 'viem'
+import { Address } from 'viem'
+import { PublicCeloClient } from '../../client'
 import { AccountsContract, getAccountsContract } from '../../contracts/accounts'
 import { getEpochManagerContract } from '../../contracts/epoch-manager'
 import { getValidatorsContract, ValidatorsContract } from '../../contracts/validators'
@@ -31,13 +32,13 @@ export interface ElectedRpcNode extends UnnamedRpcNode {
  * @returns A promise that resolves to an array of elected validator objects, each decorated with additional metadata.
  */
 export async function getElectedRpcNodes(
-  client: PublicClient,
+  client: PublicCeloClient,
   options: { showChanges?: boolean } = {}
 ) {
   const [validators, epochManager, accountsContract] = await Promise.all([
-    getValidatorsContract(client),
-    getEpochManagerContract(client),
-    getAccountsContract(client),
+    getValidatorsContract({ public: client }),
+    getEpochManagerContract({ public: client }),
+    getAccountsContract({ public: client }),
   ])
 
   const electedSigners = await epochManager.read.getElectedSigners()

--- a/packages/actions/src/multicontract-interactions/stake/vote.ts
+++ b/packages/actions/src/multicontract-interactions/stake/vote.ts
@@ -23,7 +23,9 @@ export async function vote(
   const election = await getElectionContract(clients)
   const adapter: VoteAdapter = {
     vote: async (validatorGroup, value, lesser, greater) => {
-      const { request } = await election.simulate.vote([validatorGroup, value, lesser, greater])
+      const { request } = await election.simulate.vote([validatorGroup, value, lesser, greater], {
+        account: clients.wallet.account.address,
+      })
       const gasLimit = await election.estimateGas.vote(request.args)
       return election.write.vote(request.args, { gas: gasLimit })
     },

--- a/packages/actions/src/multicontract-interactions/stake/vote.ts
+++ b/packages/actions/src/multicontract-interactions/stake/vote.ts
@@ -1,6 +1,6 @@
 import { vote as coreVote, VoteAdapter } from '@celo/core'
 import { Address, Hex } from 'viem'
-import { WalletCeloClient } from '../../client'
+import { Clients } from '../../client'
 import { getElectionContract } from '../../contracts/election'
 
 /**
@@ -16,11 +16,11 @@ import { getElectionContract } from '../../contracts/election'
  * @returns A promise that resolves to a Hex string representing the transaction hash.
  */
 export async function vote(
-  client: WalletCeloClient,
+  clients: Required<Clients>,
   validatorGroup: Address,
   value: bigint
 ): Promise<Hex> {
-  const election = await getElectionContract(client)
+  const election = await getElectionContract(clients)
   const adapter: VoteAdapter = {
     vote: async (validatorGroup, value, lesser, greater) => {
       const { request } = await election.simulate.vote([validatorGroup, value, lesser, greater])

--- a/packages/actions/typedoc.json
+++ b/packages/actions/typedoc.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "exclude": [
-    "**/*+(test).ts"
-  ],
+  "exclude": ["**/*+(test).ts"],
   "excludePrivate": true,
   "excludeProtected": true,
   "hideGenerator": true,
@@ -13,17 +11,15 @@
   "entryPoints": [
     "./src/index.ts",
     "./src/contracts/*.ts",
-    "./src/multicontract-interactions/**/index.ts",
+    "./src/multicontract-interactions/**/index.ts"
   ],
-  "githubPages": false,  
+  "githubPages": false,
   "excludeExternals": true,
-  "excludeNotDocumented":true,
+  "excludeNotDocumented": true,
   "excludeInternal": true,
   "excludeReferences": true,
   "includeVersion": true,
   "disableSources": true,
-  "plugin": [
-    "typedoc-plugin-markdown"
-  ],
+  "plugin": ["typedoc-plugin-markdown"],
   "entryPointStrategy": "resolve"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,8 @@
     "prepack": "yarn run build && oclif readme",
     "homebrew": "node ./homebrew/scripts/prepare.mjs",
     "test": "TZ=UTC NODE_OPTIONS='--experimental-vm-modules' yarn jest --maxWorkers 50% --silent --forceExit",
-    "test-ci": "TZ=UTC NODE_OPTIONS='--experimental-vm-modules' yarn jest --workerIdleMemoryLimit=0.1 --forceExit --ci",
+    "test-ci": "yarn test-ci-base || yarn test-ci-base --onlyFailures",
+    "test-ci-base": "TZ=UTC NODE_OPTIONS='--experimental-vm-modules' yarn jest --workerIdleMemoryLimit=0.1 --forceExit --ci",
     "cs": "yarn --top-level run cs"
   },
   "dependencies": {

--- a/packages/cli/src/commands/config/get.test.ts
+++ b/packages/cli/src/commands/config/get.test.ts
@@ -14,8 +14,8 @@ describe('config:get cmd', () => {
     await testLocally(Get, [])
     expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[0][0].replace(/:\d+/, ':PORT')))
       .toMatchInlineSnapshot(`
-      "node: http://localhost:PORT
-      derivationPath: m/44'/60'/0'
+      "node: http://127.0.0.1:PORT
+      derivationPath: m/44'/52752'/0'
       telemetry: true"
     `)
   })

--- a/packages/cli/src/commands/config/get.test.ts
+++ b/packages/cli/src/commands/config/get.test.ts
@@ -14,7 +14,7 @@ describe('config:get cmd', () => {
     await testLocally(Get, [])
     expect(stripAnsiCodesAndTxHashes(logMock.mock.calls[0][0].replace(/:\d+/, ':PORT')))
       .toMatchInlineSnapshot(`
-      "node: http://127.0.0.1:PORT
+      "node: http://localhost:PORT
       derivationPath: m/44'/52752'/0'
       telemetry: true"
     `)

--- a/packages/cli/src/commands/election/current.ts
+++ b/packages/cli/src/commands/election/current.ts
@@ -1,7 +1,6 @@
 import { Flags, ux } from '@oclif/core'
 
 import { ElectedRpcNode, getElectedRpcNodes } from '@celo/actions/staking'
-import { PublicClient } from 'viem'
 import { BaseCommand } from '../../base'
 
 export const valSetRpcNodeTable: ux.Table.table.Columns<{ address: string }> = {
@@ -35,7 +34,7 @@ export default class ElectionCurrent extends BaseCommand {
   }
 
   async run() {
-    const client = (await this.getPublicClient()) as PublicClient
+    const client = await this.getPublicClient()
     const res = await this.parse(ElectionCurrent)
     ux.action.start('Fetching currently Elected Community Rpc Nodes')
     const validatorList = await getElectedRpcNodes(client, {

--- a/packages/cli/src/commands/election/vote.ts
+++ b/packages/cli/src/commands/election/vote.ts
@@ -36,7 +36,7 @@ export default class ElectionVote extends BaseCommand {
       .hasEnoughNonvotingLockedCelo(value)
       .runChecks()
 
-    const pendingTxHash = vote(walletClient, res.flags.for, value)
+    const pendingTxHash = vote({ public: publicClient, wallet: walletClient }, res.flags.for, value)
     await displayViemTx('Electon -> Vote', pendingTxHash, publicClient, {
       abi: electionABI,
       displayEventName: 'ValidatorGroupVoteCast',

--- a/packages/cli/src/commands/epochs/send-validator-payment.ts
+++ b/packages/cli/src/commands/epochs/send-validator-payment.ts
@@ -31,7 +31,7 @@ export default class SendValidatorPayment extends BaseCommand {
     const wallet = await this.getWalletClient()
     const res = await this.parse(SendValidatorPayment)
 
-    const epochManagerContract = await getEpochManagerContract(wallet)
+    const epochManagerContract = await getEpochManagerContract({ wallet, public: client })
 
     await newCheckBuilder(this).isValidator(res.flags.for).runChecks()
 

--- a/packages/cli/src/commands/epochs/status.ts
+++ b/packages/cli/src/commands/epochs/status.ts
@@ -1,5 +1,5 @@
 import { ux } from '@oclif/core'
-import { BaseError, PublicClient } from 'viem'
+import { BaseError } from 'viem'
 import { BaseCommand } from '../../base'
 import { getEpochInfo } from '../../packages-to-be/getEpochInfo'
 export default class EpochStatus extends BaseCommand {
@@ -28,7 +28,7 @@ export default class EpochStatus extends BaseCommand {
       isOnEpochProcess,
       isIndividualProcessing,
       isTimeForNextEpoch,
-    ] = await getEpochInfo(client as unknown as PublicClient)
+    ] = await getEpochInfo(client)
     ux.action.stop('Done\n')
 
     // if currentEpoch is a tuple, destructure it otherwise it would be an error message

--- a/packages/cli/src/commands/governance/vote.ts
+++ b/packages/cli/src/commands/governance/vote.ts
@@ -38,7 +38,7 @@ export default class Vote extends BaseCommand {
     const publicClient = await this.getPublicClient()
 
     // do not wait this. it will be awiated in the displayViemTx
-    const pendingVote = vote(walletClient, id, voteValue)
+    const pendingVote = vote({ public: publicClient, wallet: walletClient }, id, voteValue)
     await displayViemTx('Governance -> vote', pendingVote, publicClient, {
       abi: governanceABI,
       displayEventName: 'ProposalVoted',

--- a/packages/cli/src/commands/network/info.ts
+++ b/packages/cli/src/commands/network/info.ts
@@ -1,6 +1,5 @@
 import { getEpochManagerContract } from '@celo/actions/contracts/epoch-manager'
 import { Flags } from '@oclif/core'
-import { PublicClient } from 'viem'
 import { BaseCommand } from '../../base'
 import { printValueMapRecursive } from '../../utils/cli'
 import { ViewCommmandFlags } from '../../utils/flags'
@@ -19,14 +18,14 @@ export default class Info extends BaseCommand {
   }
 
   async run() {
-    const client = (await this.getPublicClient()) as PublicClient
+    const client = await this.getPublicClient()
     const res = await this.parse(Info)
     let latestEpochNumber: bigint
     let epochSize: bigint
 
     const blockNumber = await client.getBlockNumber()
 
-    const epochManagerContract = await getEpochManagerContract(client)
+    const epochManagerContract = await getEpochManagerContract({ public: client })
 
     latestEpochNumber = await epochManagerContract.read.getCurrentEpochNumber()
     epochSize = await epochManagerContract.read.epochDuration()

--- a/packages/cli/src/commands/releasecelo/transfer-dollars.ts
+++ b/packages/cli/src/commands/releasecelo/transfer-dollars.ts
@@ -30,7 +30,7 @@ export default class TransferDollars extends ReleaseGoldBaseCommand {
     const { flags } = await this.parse(TransferDollars)
     const client = await this.getPublicClient()
     const wallet = await this.getWalletClient()
-    const releaseCeloContract = await getReleaseCeloContract(wallet, flags.contract)
+    const releaseCeloContract = await getReleaseCeloContract({public: client, wallet}, flags.contract)
 
     const isRevoked = await releaseCeloContract.read.isRevoked()
 

--- a/packages/cli/src/commands/releasecelo/transfer-dollars.ts
+++ b/packages/cli/src/commands/releasecelo/transfer-dollars.ts
@@ -30,7 +30,10 @@ export default class TransferDollars extends ReleaseGoldBaseCommand {
     const { flags } = await this.parse(TransferDollars)
     const client = await this.getPublicClient()
     const wallet = await this.getWalletClient()
-    const releaseCeloContract = await getReleaseCeloContract({public: client, wallet}, flags.contract)
+    const releaseCeloContract = await getReleaseCeloContract(
+      { public: client, wallet },
+      flags.contract
+    )
 
     const isRevoked = await releaseCeloContract.read.isRevoked()
 

--- a/packages/cli/src/commands/transfer/celo.ts
+++ b/packages/cli/src/commands/transfer/celo.ts
@@ -2,7 +2,6 @@ import { getGasPriceOnCelo } from '@celo/actions'
 import { getCeloERC20Contract } from '@celo/actions/contracts/celo-erc20'
 import { getERC20Contract } from '@celo/actions/contracts/erc20'
 import { Flags } from '@oclif/core'
-import { PublicClient, publicActions } from 'viem'
 import { CeloTransactionRequest } from 'viem/celo'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
@@ -39,7 +38,7 @@ export default class TransferCelo extends BaseCommand {
     const value = res.flags.value
     const feeCurrency = res.flags.gasCurrency
 
-    const celoERC20Contract = await getCeloERC20Contract(wallet.extend(publicActions))
+    const celoERC20Contract = await getCeloERC20Contract({ public: client, wallet })
 
     const transferParams = (feeCurrency ? { feeCurrency } : {}) as Pick<
       CeloTransactionRequest,
@@ -63,7 +62,7 @@ export default class TransferCelo extends BaseCommand {
               : client.estimateGas({ to, value }),
             getGasPriceOnCelo(client, feeCurrency),
             (feeCurrency
-              ? await getERC20Contract(client as PublicClient, feeCurrency)
+              ? await getERC20Contract({ public: client }, feeCurrency)
               : celoERC20Contract
             ).read.balanceOf([from]),
           ])

--- a/packages/cli/src/commands/transfer/erc20.ts
+++ b/packages/cli/src/commands/transfer/erc20.ts
@@ -1,7 +1,6 @@
 import { getGasPriceOnCelo } from '@celo/actions'
 import { getCeloERC20Contract } from '@celo/actions/contracts/celo-erc20'
 import { getERC20Contract } from '@celo/actions/contracts/erc20'
-import { PublicClient } from 'viem'
 import { CeloTransactionRequest } from 'viem/celo'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
@@ -49,7 +48,7 @@ export default class TransferErc20 extends BaseCommand {
     const value = res.flags.value
     const feeCurrency = res.flags.gasCurrency
 
-    const erc20Contract = await getERC20Contract(wallet, res.flags.erc20Address)
+    const erc20Contract = await getERC20Contract({ public: client, wallet }, res.flags.erc20Address)
     const transferParams = (feeCurrency ? { feeCurrency } : {}) as Pick<
       CeloTransactionRequest,
       'gas' | 'feeCurrency' | 'maxFeePerGas'
@@ -80,8 +79,8 @@ export default class TransferErc20 extends BaseCommand {
             erc20Contract.estimateGas.transfer([to, value], transferParams),
             getGasPriceOnCelo(client, feeCurrency),
             (feeCurrency
-              ? await getERC20Contract(client as PublicClient, feeCurrency)
-              : await getCeloERC20Contract(client as PublicClient)
+              ? await getERC20Contract({ public: client }, feeCurrency)
+              : await getCeloERC20Contract({ public: client })
             ).read.balanceOf([from]),
           ])
 

--- a/packages/cli/src/commands/validator/list.ts
+++ b/packages/cli/src/commands/validator/list.ts
@@ -1,7 +1,6 @@
 import { Validator } from '@celo/contractkit/lib/wrappers/Validators'
 import { ux } from '@oclif/core'
 
-import { PublicClient } from 'viem'
 import { BaseCommand } from '../../base'
 import { getRegisteredValidators } from '../../packages-to-be/validators'
 import { ViewCommmandFlags } from '../../utils/flags'
@@ -32,7 +31,7 @@ export default class ValidatorList extends BaseCommand {
 
     ux.action.start('Fetching Registered Community Rpc Nodes')
 
-    const validatorList = await getRegisteredValidators(client as PublicClient)
+    const validatorList = await getRegisteredValidators(client)
 
     ux.action.stop()
     ux.table(

--- a/packages/cli/src/commands/validatorgroup/rpc-urls.ts
+++ b/packages/cli/src/commands/validatorgroup/rpc-urls.ts
@@ -4,7 +4,6 @@ import { concurrentMap, StrongAddress } from '@celo/base'
 import { ClaimTypes, IdentityMetadataWrapper } from '@celo/metadata-claims'
 import { AccountMetadataSignerGetters } from '@celo/metadata-claims/lib/types'
 import { Flags, ux } from '@oclif/core'
-import { PublicClient } from 'viem'
 import { BaseCommand } from '../../base'
 import { getMetadataURLs, getNames } from '../../packages-to-be/account'
 import {
@@ -42,7 +41,7 @@ export default class RpcUrls extends BaseCommand {
 
     const res = await this.parse(RpcUrls)
 
-    const client = (await this.getPublicClient()) as PublicClient
+    const client = await this.getPublicClient()
 
     let validatorAddresses: StrongAddress[] = []
 
@@ -50,7 +49,7 @@ export default class RpcUrls extends BaseCommand {
     if (res.flags.all) {
       validatorAddresses = await getRegisteredValidatorsAddresses(client)
     } else {
-      const epochManager = await getEpochManagerContract(client)
+      const epochManager = await getEpochManagerContract({ public: client })
       validatorAddresses = (await epochManager.read.getElectedAccounts()) as StrongAddress[]
     }
 
@@ -74,7 +73,7 @@ export default class RpcUrls extends BaseCommand {
     ux.action.stop()
 
     ux.action.start(`Fetching Group Metadata`)
-    const accountsConract = await getAccountsContract(client)
+    const accountsConract = await getAccountsContract({ public: client })
     // Fetch the name for each group
     const validatorGroupNames = await getNames(client, [
       ...new Set(validatorToGroup.values()),

--- a/packages/cli/src/packages-to-be/account.ts
+++ b/packages/cli/src/packages-to-be/account.ts
@@ -1,5 +1,5 @@
 import { lockedGoldABI } from '@celo/abis'
-import { resolveAddress } from '@celo/actions'
+import { PublicCeloClient, resolveAddress } from '@celo/actions'
 import { getAccountsContract } from '@celo/actions/contracts/accounts'
 import { StrongAddress } from '@celo/base'
 import { Address, erc20Abi, PublicClient } from 'viem'
@@ -71,8 +71,8 @@ export const getTotalBalance = async (
   }
 }
 
-export async function getMetadataURLs(client: PublicClient, addresses: Address[]) {
-  const contract = await getAccountsContract(client)
+export async function getMetadataURLs(client: PublicCeloClient, addresses: Address[]) {
+  const contract = await getAccountsContract({ public: client })
 
   const urlResults = await Promise.allSettled(
     addresses.map(async (address) => {
@@ -85,8 +85,8 @@ export async function getMetadataURLs(client: PublicClient, addresses: Address[]
   return new Map(filtered)
 }
 
-export async function getNames(client: PublicClient, addresses: Address[]) {
-  const contract = await getAccountsContract(client)
+export async function getNames(client: PublicCeloClient, addresses: Address[]) {
+  const contract = await getAccountsContract({ public: client })
 
   const nameResults = await Promise.allSettled(
     addresses.map(async (address) => {

--- a/packages/cli/src/packages-to-be/getEpochInfo.ts
+++ b/packages/cli/src/packages-to-be/getEpochInfo.ts
@@ -1,8 +1,8 @@
+import { PublicCeloClient } from '@celo/actions'
 import { getEpochManagerContract } from '@celo/actions/contracts/epoch-manager'
-import { PublicClient } from 'viem'
 
-export async function getEpochInfo(client: PublicClient) {
-  const epochManager = await getEpochManagerContract(client)
+export async function getEpochInfo(client: PublicCeloClient) {
+  const epochManager = await getEpochManagerContract({ public: client })
 
   const results = await Promise.allSettled([
     epochManager.read.getCurrentEpoch(),

--- a/packages/cli/src/packages-to-be/governance.ts
+++ b/packages/cli/src/packages-to-be/governance.ts
@@ -1,9 +1,8 @@
 import { governanceABI } from '@celo/abis'
-import { resolveAddress } from '@celo/actions'
+import { PublicCeloClient, resolveAddress } from '@celo/actions'
 import { getProposalStage, ProposalStage } from '@celo/actions/contracts/governance'
 import { bufferToHex, StrongAddress } from '@celo/base'
 import BigNumber from 'bignumber.js'
-import { PublicClient } from 'viem'
 import { bigintToBigNumber } from './utils'
 
 type DequeuedStageDurations = Pick<
@@ -20,7 +19,7 @@ export interface ProposalMetadata {
 }
 
 export const getHotfixRecord = async (
-  client: PublicClient,
+  client: PublicCeloClient,
   hash: Buffer
 ): Promise<HotfixRecord> => {
   const address = await resolveAddress(client, 'Governance')
@@ -45,7 +44,7 @@ type StageDurations<V> = {
 }
 
 export const getProposalSchedule = async (
-  client: PublicClient,
+  client: PublicCeloClient,
   proposalId: bigint
 ): Promise<Partial<StageDurations<BigNumber>>> => {
   const meta = await getProposalMetadata(client, proposalId)
@@ -79,7 +78,7 @@ export const getProposalSchedule = async (
 }
 
 export const getProposalMetadata = async (
-  client: PublicClient,
+  client: PublicCeloClient,
   proposalId: bigint
 ): Promise<ProposalMetadata> => {
   const proposal = await client.readContract({
@@ -98,7 +97,7 @@ export const getProposalMetadata = async (
   }
 }
 
-export const stageDurations = async (client: PublicClient): Promise<DequeuedStageDurations> => {
+export const stageDurations = async (client: PublicCeloClient): Promise<DequeuedStageDurations> => {
   const durations = await client.readContract({
     address: await resolveAddress(client, 'Governance'),
     abi: governanceABI,

--- a/packages/cli/src/packages-to-be/validators.ts
+++ b/packages/cli/src/packages-to-be/validators.ts
@@ -1,10 +1,9 @@
 import { accountsABI, lockedGoldABI, validatorsABI } from '@celo/abis'
-import { resolveAddress } from '@celo/actions'
+import { PublicCeloClient, resolveAddress } from '@celo/actions'
 import { getValidatorsContract } from '@celo/actions/contracts/validators'
 import { Address, concurrentMap, ensureLeading0x, eqAddress, StrongAddress } from '@celo/base'
 import { fromFixed } from '@celo/utils/lib/fixidity'
 import BigNumber from 'bignumber.js'
-import { PublicClient } from 'viem'
 import { bigintToBigNumber } from './utils'
 
 export interface Validator {
@@ -34,7 +33,7 @@ export interface MembershipHistoryExtraData {
   tail: number
 }
 
-export const getValidatorLockedGoldRequirements = async (client: PublicClient) => {
+export const getValidatorLockedGoldRequirements = async (client: PublicCeloClient) => {
   const requirements = await client.readContract({
     address: await resolveAddress(client, 'Validators'),
     abi: validatorsABI,
@@ -48,7 +47,7 @@ export const getValidatorLockedGoldRequirements = async (client: PublicClient) =
 }
 
 export const meetsValidatorBalanceRequirements = async (
-  client: PublicClient,
+  client: PublicCeloClient,
   address: StrongAddress
 ) => {
   const accountTotalLockedGold = await client.readContract({
@@ -67,7 +66,7 @@ export const meetsValidatorBalanceRequirements = async (
 }
 
 export const meetsValidatorGroupBalanceRequirements = async (
-  client: PublicClient,
+  client: PublicCeloClient,
   address: StrongAddress
 ) => {
   const accountTotalLockedGold = await client.readContract({
@@ -90,10 +89,10 @@ export const meetsValidatorGroupBalanceRequirements = async (
   @returns the group the given address is affiliated with
  */
 export async function getValidatorsGroup(
-  client: PublicClient,
+  client: PublicCeloClient,
   validatorAddress: StrongAddress
 ): Promise<StrongAddress> {
-  const contract = await getValidatorsContract(client)
+  const contract = await getValidatorsContract({ public: client })
   return contract.read.getValidatorsGroup([validatorAddress])
 }
 
@@ -102,7 +101,7 @@ export async function getValidatorsGroup(
   @returns group info including name, commission, affiliates + members and slash data. 
  */
 export const getValidatorGroup = async (
-  client: PublicClient,
+  client: PublicCeloClient,
   address: Address,
   getAffiliates: boolean = true,
   blockNumber?: number
@@ -145,7 +144,7 @@ export const getValidatorGroup = async (
 }
 
 export const getRegisteredValidators = async (
-  client: PublicClient,
+  client: PublicCeloClient,
   blockNumber?: number
 ): Promise<Validator[]> => {
   const vgAddresses = await getRegisteredValidatorsAddresses(client, blockNumber)
@@ -154,7 +153,7 @@ export const getRegisteredValidators = async (
 }
 
 export const getRegisteredValidatorsAddresses = async (
-  client: PublicClient,
+  client: PublicCeloClient,
   blockNumber?: number
 ): Promise<StrongAddress[]> => {
   return (await client.readContract({
@@ -166,7 +165,7 @@ export const getRegisteredValidatorsAddresses = async (
 }
 
 export const getValidator = async (
-  client: PublicClient,
+  client: PublicCeloClient,
   address: Address,
   blockNumber?: number
 ): Promise<Validator> => {
@@ -197,7 +196,7 @@ export const getValidator = async (
 }
 
 export const getValidatorMembershipHistoryExtraData = async (
-  client: PublicClient,
+  client: PublicCeloClient,
   validator: StrongAddress
 ): Promise<MembershipHistoryExtraData> => {
   const history = await client.readContract({

--- a/packages/cli/src/transfer-stable-base.ts
+++ b/packages/cli/src/transfer-stable-base.ts
@@ -89,13 +89,16 @@ export abstract class TransferStableBase extends BaseCommand {
             feeCurrency && isAddressEqual(feeCurrency, stableTokenContract.address)
 
           const [gas, gasPrice, balanceOfTokenForGas, balanceOfTokenToSend] = await Promise.all([
+            // gas estimation
             res.flags.comment
               ? stableTokenContract.estimateGas.transferWithComment(
                   [to, value, res.flags.comment],
                   transferParams
                 )
               : stableTokenContract.estimateGas.transfer([to, value], transferParams),
+            // fee estimation
             getGasPriceOnCelo(client, feeCurrency),
+            //  balanceOfTokenForGas
             (feeCurrency
               ? feeInSameStableTokenAsTransfer
                 ? stableTokenContract

--- a/packages/cli/src/transfer-stable-base.ts
+++ b/packages/cli/src/transfer-stable-base.ts
@@ -2,7 +2,7 @@ import { getGasPriceOnCelo } from '@celo/actions'
 import { getCeloERC20Contract } from '@celo/actions/contracts/celo-erc20'
 import { getERC20Contract } from '@celo/actions/contracts/erc20'
 import { Flags } from '@oclif/core'
-import { isAddressEqual, publicActions, PublicClient } from 'viem'
+import { isAddressEqual, publicActions } from 'viem'
 import { CeloTransactionRequest } from 'viem/celo'
 import { BaseCommand } from './base'
 import {
@@ -69,7 +69,7 @@ export abstract class TransferStableBase extends BaseCommand {
     } catch {
       failWith(`The ${stableToken} token was not deployed yet`)
     }
-    const celoContract = await getCeloERC20Contract(wallet.extend(publicActions))
+    const celoContract = await getCeloERC20Contract({ public: client, wallet })
 
     const transferParams = (feeCurrency ? { feeCurrency } : {}) as Pick<
       CeloTransactionRequest,
@@ -99,7 +99,7 @@ export abstract class TransferStableBase extends BaseCommand {
             (feeCurrency
               ? feeInSameStableTokenAsTransfer
                 ? stableTokenContract
-                : await getERC20Contract(client as PublicClient, feeCurrency)
+                : await getERC20Contract({ public: client }, feeCurrency)
               : celoContract
             ).read.balanceOf([from]),
             stableTokenContract.read.balanceOf([from]),

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -22,15 +22,7 @@ import { HotfixRecord, ProposalStage } from '@celo/contractkit/lib/wrappers/Gove
 import BigNumber from 'bignumber.js'
 import chalk from 'chalk'
 import { fetch } from 'cross-fetch'
-import {
-  erc20Abi,
-  formatEther,
-  formatUnits,
-  getAddress,
-  isAddressEqual,
-  PublicClient,
-  WalletClient,
-} from 'viem'
+import { erc20Abi, formatEther, formatUnits, getAddress, isAddressEqual, WalletClient } from 'viem'
 import { BaseCommand } from '../base'
 import { getHotfixRecord, getProposalSchedule } from '../packages-to-be/governance'
 import { StableToken, StableTokens } from '../packages-to-be/stable-tokens'
@@ -76,10 +68,10 @@ class CheckBuilder {
     "'The wallet address has been sanctioned by the U.S. Department of the Treasury.''All U.S. persons are prohibited from accessing, receiving, accepting, or facilitating any property 'and interests in property (including use of any technology, software or software patch(es)) of these'designated digital wallet addresses.  These prohibitions include the making of any contribution or''provision of funds, goods, or services by, to, or for the benefit of any blocked person and the ''receipt of any contribution or provision of funds, goods, or services from any such person and ' 'all designated digital asset wallets.'"
   constructor(private command: BaseCommand, private signer?: StrongAddress) {}
 
-  private async getClient(): Promise<PublicClient> {
+  private async getClient() {
     // In this case we're not using any Celo-specific client features, so it can be
     // safely casted to PublicClient
-    return this.command.getPublicClient() as Promise<PublicClient>
+    return this.command.getPublicClient()
   }
 
   private async getWalletClient(): Promise<WalletClient> {
@@ -112,9 +104,7 @@ class CheckBuilder {
     ) => A
   ): () => Promise<Resolve<A>> {
     return async () => {
-      const validatorsContract = (await getValidatorsContract(
-        await this.getClient()
-      )) as ValidatorsContract<PublicClient>
+      const validatorsContract = await getValidatorsContract({ public: await this.getClient() })
 
       if (this.signer) {
         try {
@@ -144,12 +134,8 @@ class CheckBuilder {
     ) => A
   ): () => Promise<Resolve<A>> {
     return async () => {
-      const lockedCeloContract = (await getLockedCeloContract(
-        await this.getClient()
-      )) as LockedCeloContract<PublicClient>
-      const validatorsContract = (await getValidatorsContract(
-        await this.getClient()
-      )) as ValidatorsContract<PublicClient>
+      const lockedCeloContract = await getLockedCeloContract({ public: await this.getClient() })
+      const validatorsContract = await getValidatorsContract({ public: await this.getClient() })
 
       if (this.signer) {
         try {
@@ -165,9 +151,7 @@ class CheckBuilder {
 
   private withAccounts<A>(f: (accounts: AccountsContract) => A): () => Promise<Resolve<A>> {
     return async () => {
-      const accountsContract = (await getAccountsContract(
-        await this.getClient()
-      )) as AccountsContract<PublicClient>
+      const accountsContract = await getAccountsContract({ public: await this.getClient() })
 
       return f(accountsContract) as Resolve<A>
     }
@@ -175,9 +159,7 @@ class CheckBuilder {
 
   private withGovernance<A>(f: (governance: GovernanceContract) => A): () => Promise<Resolve<A>> {
     return async () => {
-      const governanceContract = (await getGovernanceContract(
-        await this.getClient()
-      )) as GovernanceContract<PublicClient>
+      const governanceContract = await getGovernanceContract({ public: await this.getClient() })
 
       return f(governanceContract) as Resolve<A>
     }
@@ -187,9 +169,8 @@ class CheckBuilder {
     f: (feeCurrencyDirectory: FeeCurrencyDirectory) => A
   ): () => Promise<Resolve<A>> {
     return async () => {
-      const feeCurrencyDirectoryContract = (await getFeeCurrencyDirectoryContract(
-        await this.getClient()
-      )) as FeeCurrencyDirectory<PublicClient>
+      const client = await this.getClient()
+      const feeCurrencyDirectoryContract = await getFeeCurrencyDirectoryContract({ public: client })
 
       return f(feeCurrencyDirectoryContract) as Resolve<A>
     }

--- a/packages/core/src/governing/vote.ts
+++ b/packages/core/src/governing/vote.ts
@@ -26,7 +26,8 @@ export type VoteProposalAdapter = {
  * const adapter: VoteProposalAdapter =
  * {
  *  vote: async (proposalID, proposalIndex, voteValue) => {
- *    const { request } = await contract.simulate.vote([proposalID, proposalIndex, voteValue])
+ *    const { request } = await contract.simulate.vote([proposalID, proposalIndex, voteValue], {
+ *      account: client.wallet.account.address})
  *    const gasLimit = await contract.estimateGas.vote(request.args)
  *    return contract.write.vote(request.args, { gas: gasLimit })
  * },

--- a/packages/dev-utils/src/viem/anvil-test.ts
+++ b/packages/dev-utils/src/viem/anvil-test.ts
@@ -46,11 +46,11 @@ function createInstance(opts?: { chainId?: number; forkUrl?: string; forkBlockNu
     balance: TEST_BALANCE,
     gasPrice: TEST_GAS_PRICE,
     gasLimit: TEST_GAS_LIMIT,
-    blockBaseFeePerGas: 0,
-    stopTimeout: 1000,
+    blockBaseFeePerGas: 25000000000,
+    stopTimeout: 3000,
     chainId: opts?.chainId,
     ...(forkUrl
-      ? { forkUrl, forkBlockNumber }
+      ? { forkUrl, forkBlockNumber, forkHeader: { 'User-Agent': 'anvil/devtooling' } }
       : { loadState: require.resolve('@celo/devchain-anvil/devchain.json') }),
   }
 


### PR DESCRIPTION
### Description

set default node version for test runs to 22


#### Other changes

make it so the ci tests can easily be run with other node versions 

### Tested

naturally

### How to QA

n/a
### Related issues

- Fixes #563

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the codebase to improve the handling of client objects, specifically transitioning to a unified `Clients` type. It also updates various configurations and dependencies, enhances test scripts, and modifies command parameters for better clarity and functionality.

### Detailed summary
- Updated `node-version` from `20` to `22` in workflow files.
- Refactored functions to use a unified `Clients` type instead of separate `PublicClient` and `WalletClient`.
- Modified command parameters for `vote`, `getEpochManagerContract`, and others to accept `Clients`.
- Adjusted test scripts to improve reliability and added retries.
- Deprecated `useAKV` flag documentation updated for clarity.
- Updated inline snapshots in tests to reflect new expected values.
- Enhanced error handling in the `vote` function for better feedback.
- Removed redundant imports and streamlined client retrieval in various commands.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->