### PR TITLE
Run tests on node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,14 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: 'enable corepack for yarn'
         run: sudo corepack enable yarn
       - uses: actions/checkout@v4
       # must call twice because of chicken and egg problem with yarn and node
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
       - name: Restore node cache
         uses: actions/cache@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       # must call twice because of chicken and egg problem with yarn and node
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
       - name: Install Dependencies
         shell: bash

--- a/.github/workflows/upload-celocli-executables.yml
+++ b/.github/workflows/upload-celocli-executables.yml
@@ -41,7 +41,7 @@ jobs:
       # must call twice because of chicken and egg problem with yarn and node
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
 
       - name: Install Dependencies
@@ -121,7 +121,7 @@ jobs:
       # must call twice because of chicken and egg problem with yarn and node
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
       - name: Install Dependencies
         shell: bash
@@ -194,7 +194,7 @@ jobs:
       # must call twice because of chicken and egg problem with yarn and node
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
       - name: Install Dependencies
         shell: bash


### PR DESCRIPTION
### Description

We have about a year before node 20 is no longer supported. lets start running our tests on node 22

#### Other changes

no

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `node-version` from `20` to `22` across multiple GitHub Actions workflow files to ensure compatibility with newer Node.js features and improvements.

### Detailed summary
- Updated `node-version` from `20` to `22` in:
  - `.github/workflows/release.yaml`
  - `.github/workflows/ci.yml`
  - `.github/workflows/upload-celocli-executables.yml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->