### PR TITLE
skip renovate check if no change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,7 +429,9 @@ jobs:
 
   validate-renovate-config:
     name: Validate Renovate Config
+    needs: [install-dependencies]
     runs-on: ubuntu-latest
+    if: contains(needs.install-dependencies.outputs.all_modified_files, 'dt-renovate-base.json') || contains(needs.install-dependencies.outputs.all_modified_files, 'renovate.json')
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description

just didnt like that this check keeps running before the checks i want to see. 




<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the GitHub Actions workflow by adding a validation step for the Renovate configuration files, ensuring that the step only runs if certain conditions are met.

### Detailed summary
- Added a `needs` dependency on `install-dependencies` for the `validate-renovate-config` job.
- Introduced a conditional statement to run the validation only if `dt-renovate-base.json` or `renovate.json` is modified.
- Specified the runner environment as `ubuntu-latest` for the job.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->