### PR TITLE
Fix Typo in Telemetry Log and Update Deprecation Notice Message

### DIFF
--- a/.changeset/purple-squids-wait.md
+++ b/.changeset/purple-squids-wait.md
@@ -1,0 +1,5 @@
+---
+"@celo/celocli": patch
+---
+
+Fix Typo in Telemetry Log and Update Deprecation Notice Message

--- a/packages/cli/src/utils/off-chain-data.ts
+++ b/packages/cli/src/utils/off-chain-data.ts
@@ -60,4 +60,4 @@ export abstract class OffchainDataCommand extends BaseCommand {
 }
 
 export const DEPRECATION_NOTICE =
-  'offchain-read and offchain-write commands are deprecated as CIP8 was abandonded. They will be removed next major release.'
+  'offchain-read and offchain-write commands are deprecated as CIP8 was abandoned. They will be removed next major release.'

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -100,7 +100,7 @@ ${telemetryData}
           return
         }
 
-        debug(`Telemetry data sent successfuly`)
+        debug(`Telemetry data sent successfully`)
       })
       .catch((err) => {
         debug(`Failed to send telemetry data: ${err}`)


### PR DESCRIPTION
Description:  
This pull request addresses two minor issues:
1. Corrects a typo in the telemetry debug log message ("successfully" instead of "succesfully") in `packages/cli/src/utils/telemetry.ts`.
2. Updates the deprecation notice in `packages/cli/src/utils/off-chain-data.ts` for clarity, changing "abandoned" to "abandoned".

These changes improve code clarity and log accuracy. No functional changes are introduced.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a typo in the telemetry log message and updating the deprecation notice message in the codebase.

### Detailed summary
- Corrected the typo in the telemetry log message from `successfuly` to `successfully` in the `telemetry.ts` file.
- Updated the deprecation notice message in `off-chain-data.ts` from `abandon` to `abandoned`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->