### PR TITLE
docs(changeset): Bump to decrease  min node recommendation

### DIFF
--- a/.changeset/good-peas-pump.md
+++ b/.changeset/good-peas-pump.md
@@ -1,0 +1,5 @@
+---
+'@celo/core': patch
+---
+
+Bump to decrease min node recommendation


### PR DESCRIPTION
### Description

forgot to add changeset when i changed the min node version from 22 back down to 20 and so now when you install the cli there is a warning so bump it


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `@celo/core` package to a new patch version, which includes a recommendation to decrease the minimum node requirements for better performance.

### Detailed summary
- Updated `@celo/core` to a new patch version.
- Added a note to decrease the minimum node recommendation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->