### PR TITLE
Remove concurrency at job level as it is defined at Workflow level

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,9 +19,6 @@ jobs:
       attestations: write
       id-token: write
       repository-projects: write
-    concurrency:
-      group:   ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-      cancel-in-progress: true
     uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v3.0.0
     with:
       node-version: 20


### PR DESCRIPTION
### Description

Remove concurrency at job level as it is defined at Workflow level (line 9)

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How to QA

Avoid this cancelation: https://github.com/celo-org/developer-tooling/actions/runs/15905530034

### Related issues

N/A


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `.github/workflows/release.yaml` file to modify the workflow configuration for npm publishing.

### Detailed summary
- Removed `concurrency` settings including `group` and `cancel-in-progress`.
- Updated the `uses` directive to reference `celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v3.0.0`.
- Set `node-version` to `20`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->