### PR TITLE
Fix gas estimation with celo transfer feecurrency

### DIFF
--- a/.changeset/green-terms-carry.md
+++ b/.changeset/green-terms-carry.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+(beta) Fix gas estimation with celo transfer with gas tokens

--- a/packages/cli/src/commands/transfer/celo.ts
+++ b/packages/cli/src/commands/transfer/celo.ts
@@ -59,7 +59,7 @@ export default class TransferCelo extends BaseCommand {
               ? celoERC20Contract.estimateGas.transferWithComment([to, value, res.flags.comment!], {
                   feeCurrency,
                 })
-              : client.estimateGas({ to, value }),
+              : client.estimateGas({ to, value, ...transferParams }),
             getGasPriceOnCelo(client, feeCurrency),
             (feeCurrency
               ? await getERC20Contract({ public: client }, feeCurrency)

--- a/packages/cli/src/transfer-stable-base.ts
+++ b/packages/cli/src/transfer-stable-base.ts
@@ -136,9 +136,6 @@ export abstract class TransferStableBase extends BaseCommand {
         )
       : displayViemTx(
           `${stableToken}->Transfer`,
-          // NOTE: this used to be celoToken.transfer
-          // but this way ledger considers this a native transfer and show the to and value properly
-          // instead of a contract call
           stableTokenContract.write.transfer([to, value], transferParams),
           client
         ))


### PR DESCRIPTION
### Description

feeCurrency was not passed into estimate gas which caused failures

#### Other changes

removed a comment that wasnt really correct 

### Tested

new test


### How to QA

```bash
celocli transfer:celo --from 0xAB63Fe696bcf3600B1524065785f90D5B622De79 --to 0x36B80180D2E3ca4A523A1F05e60775Ee644bDaFF --node alfajores --value 1e17 --useLedger --ledgerAddresses 5 --gasCurrency 0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F
```


### Related issues

- Fixes #675 


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing gas estimation for `celo` transfers when using gas tokens. It enhances the functionality of the transfer command and adds tests to ensure the correct behavior of gas estimation.

### Detailed summary
- Updated `client.estimateGas` to include `transferParams` in `celo.ts`.
- Revised the `stableTokenContract.write.transfer` method in `transfer-stable-base.ts`.
- Added a test to verify that `feeCurrency` is correctly passed to `estimateGas` in `celo.test.ts`.
- Introduced `extractHostFromWeb3` and other utility functions in the test file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->