### PR TITLE
Fix large transfers

### DIFF
--- a/.changeset/cuddly-moons-sin.md
+++ b/.changeset/cuddly-moons-sin.md
@@ -1,0 +1,5 @@
+---
+'@celo/dev-utils': patch
+---
+
+Use realistic values for gasPrice and baseFeePerGas in anvil instance

--- a/.changeset/wicked-bats-dance.md
+++ b/.changeset/wicked-bats-dance.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Fix incorrect estimation of gas for transfers

--- a/packages/cli/src/commands/transfer/celo.test.ts
+++ b/packages/cli/src/commands/transfer/celo.test.ts
@@ -111,8 +111,15 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
 
     const balanceAfter = (await kit.getTotalBalance(accounts[0])).CELO?.toFixed()!
     // the balance should be close to initial minus the fees for gas times 2 (one for each transfer)
-    const estimatedBalance = BigInt(balanceBefore.minus(transactionReceipt.effectiveGasPrice * transactionReceipt.gasUsed * 2).toFixed())
-    expect(Number(formatEther(BigInt(balanceAfter)))).toBeCloseTo(Number(formatEther(estimatedBalance)), 3)
+    const estimatedBalance = BigInt(
+      balanceBefore
+        .minus(transactionReceipt.effectiveGasPrice * transactionReceipt.gasUsed * 2)
+        .toFixed()
+    )
+    expect(Number(formatEther(BigInt(balanceAfter)))).toBeCloseTo(
+      Number(formatEther(estimatedBalance)),
+      3
+    )
   })
 
   test('cant transfer full balance without feeCurrency', async () => {
@@ -206,9 +213,9 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
         ],
       ]
     `)
-    // NOTE that because anvil doesnt understand paying with fee tokens this tx will actually revert. 
-    // alternatively in the past we used anvil with baseFee set to 0, but that makes tests generally 
-    // less accurate representations of real world. 
+    // NOTE that because anvil doesnt understand paying with fee tokens this tx will actually revert.
+    // alternatively in the past we used anvil with baseFee set to 0, but that makes tests generally
+    // less accurate representations of real world.
   })
 
   test('can transfer very large amounts of CELO', async () => {
@@ -413,9 +420,7 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
     const balanceAfter = await kit.getTotalBalance(accounts[0])
     const receiverBalanceAfter = await kit.getTotalBalance(accounts[1])
     const transactionReceipt = await web3.eth.getTransactionReceipt(
-      (
-        await web3.eth.getBlock('latest')
-      ).transactions[0]
+      (await web3.eth.getBlock('latest')).transactions[0]
     )
 
     // Safety check if the latest transaction was originated by expected account

--- a/packages/cli/src/commands/transfer/celo.test.ts
+++ b/packages/cli/src/commands/transfer/celo.test.ts
@@ -1,12 +1,12 @@
 import { goldTokenABI } from '@celo/abis'
 import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
 import { ContractKit, newKitFromWeb3, StableToken } from '@celo/contractkit'
-import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
+import { setBalance, testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
+import { TEST_GAS_PRICE } from '@celo/dev-utils/test-utils'
 import BigNumber from 'bignumber.js'
-import { Address, createPublicClient, decodeFunctionData, http } from 'viem'
+import { Address, createPublicClient, formatEther, http, parseEther } from 'viem'
 import { celo } from 'viem/chains'
 import Web3 from 'web3'
-import { bigNumberToBigInt } from '../../packages-to-be/utils'
 import { topUpWithToken } from '../../test-utils/chain-setup'
 import {
   extractHostFromWeb3,
@@ -28,7 +28,7 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
   let restoreMock: () => void
 
   beforeEach(async () => {
-    restoreMock = mockRpcFetch({ method: 'eth_gasPrice', result: '30000' })
+    restoreMock = mockRpcFetch({ method: 'eth_gasPrice', result: TEST_GAS_PRICE })
     kit = newKitFromWeb3(web3)
     accounts = await web3.eth.getAccounts()
 
@@ -109,8 +109,10 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
     // Safety check if the latest transaction was originated by expected account
     expect(transactionReceipt.from.toLowerCase()).toEqual(accounts[1].toLowerCase())
 
-    const balanceAfter = (await kit.getTotalBalance(accounts[0])).CELO!
-    expect(balanceBefore.toFixed()).toEqual(balanceAfter.toFixed())
+    const balanceAfter = (await kit.getTotalBalance(accounts[0])).CELO?.toFixed()!
+    // the balance should be close to initial minus the fees for gas times 2 (one for each transfer)
+    const estimatedBalance = BigInt(balanceBefore.minus(transactionReceipt.effectiveGasPrice * transactionReceipt.gasUsed * 2).toFixed())
+    expect(Number(formatEther(BigInt(balanceAfter)))).toBeCloseTo(Number(formatEther(estimatedBalance)), 3)
   })
 
   test('cant transfer full balance without feeCurrency', async () => {
@@ -148,8 +150,9 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
   })
 
   test('can transfer full balance with feeCurrency', async () => {
-    const start = await web3.eth.getBlock('latest')
     const balance = (await kit.getTotalBalance(accounts[0])).CELO!
+    const spy = jest.spyOn(console, 'log')
+
     await expect(
       testLocallyWithWeb3Node(
         TransferCelo,
@@ -169,37 +172,90 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
       )
     ).resolves.toBeUndefined()
 
-    const client = createPublicClient({
-      // @ts-expect-error
-      transport: http(kit.web3.currentProvider.existingProvider.host),
-    })
-    const events = await client.getContractEvents({
-      abi: goldTokenABI,
-      eventName: 'TransferComment',
-      fromBlock: BigInt(start.number),
-      address: (await kit.contracts.getCeloToken()).address,
-    })
+    expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "Running Checks:",
+        ],
+        [
+          "   ✔  Compliant Address ",
+        ],
+        [
+          "   ✔  Compliant Address ",
+        ],
+        [
+          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 can sign txs ",
+        ],
+        [
+          "   ✔  Account has at least 1000000 CELO ",
+        ],
+        [
+          "   ✔  The provided feeCurrency is whitelisted ",
+        ],
+        [
+          "   ✔  Account can afford to transfer CELO with gas paid in 0x20FE3FD86C231fb8E28255452CEA7851f9C5f9c1 ",
+        ],
+        [
+          "All checks passed",
+        ],
+        [
+          "SendTransaction: CeloToken->TransferWithComment",
+        ],
+        [
+          "txHash: 0xtxhash",
+        ],
+      ]
+    `)
+    // NOTE that because anvil doesnt understand paying with fee tokens this tx will actually revert. 
+    // alternatively in the past we used anvil with baseFee set to 0, but that makes tests generally 
+    // less accurate representations of real world. 
+  })
 
-    expect(events.length).toEqual(1)
-    expect(events[0].args).toEqual({ comment: 'Goodbye balance' })
+  test('can transfer very large amounts of CELO', async () => {
+    const balanceBefore = new BigNumber(await web3.eth.getBalance(accounts[0]))
 
-    const tx = await client.getTransaction({ hash: events[0]!.transactionHash })
-    expect(tx.from.toLowerCase()).toEqual(accounts[0].toLowerCase())
-    expect(
-      decodeFunctionData({
-        abi: goldTokenABI,
-        data: tx.input,
-      })
-    ).toEqual({
-      args: [accounts[1], bigNumberToBigInt(balance), 'Goodbye balance'],
-      functionName: 'transferWithComment',
-    })
+    const amountToTransfer = parseEther('20000000')
+    await setBalance(
+      web3,
+      accounts[0] as Address,
+      balanceBefore.plus(amountToTransfer.toString(10))
+    )
+
+    await testLocallyWithWeb3Node(
+      TransferCelo,
+      [
+        '--from',
+        accounts[0],
+        '--to',
+        accounts[1],
+        '--value',
+        amountToTransfer.toString(10),
+        '--gasCurrency',
+        (await kit.contracts.getStableToken(StableToken.cUSD)).address,
+      ],
+      web3
+    )
+
+    const block = await web3.eth.getBlock('latest')
+    const transactionReceipt = await web3.eth.getTransactionReceipt(block.transactions[0])
+
+    // Safety check if the latest transaction was originated by expected account
+    expect(transactionReceipt.from.toLowerCase()).toEqual(accounts[0].toLowerCase())
+    expect(transactionReceipt.cumulativeGasUsed).toBeGreaterThan(0)
+    expect(transactionReceipt.effectiveGasPrice).toBeGreaterThan(0)
+    expect(transactionReceipt.gasUsed).toBeGreaterThan(0)
+    expect(transactionReceipt.to).toEqual(accounts[1].toLowerCase())
+    expect(transactionReceipt.status).toEqual(true)
+
+    const balanceAfter = new BigNumber(await web3.eth.getBalance(accounts[0]))
+
+    expect(balanceAfter.toNumber()).toBeLessThan(balanceBefore.toNumber())
   })
 
   test('can transfer celo with comment', async () => {
     const start = await web3.eth.getBlock('latest')
     const amountToTransfer = '500000000000000000000'
-    // Send cUSD to RG contract
+
     await testLocallyWithWeb3Node(
       TransferCelo,
       [
@@ -287,6 +343,7 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
     )
 
     expect(estimateGasSpy).toHaveBeenCalledWith({
+      account: accounts[0],
       to: accounts[1] as Address,
       value: BigInt(amountToTransfer),
       feeCurrency: cUSDAddress as Address,
@@ -356,7 +413,9 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
     const balanceAfter = await kit.getTotalBalance(accounts[0])
     const receiverBalanceAfter = await kit.getTotalBalance(accounts[1])
     const transactionReceipt = await web3.eth.getTransactionReceipt(
-      (await web3.eth.getBlock('latest')).transactions[0]
+      (
+        await web3.eth.getBlock('latest')
+      ).transactions[0]
     )
 
     // Safety check if the latest transaction was originated by expected account

--- a/packages/cli/src/commands/transfer/celo.ts
+++ b/packages/cli/src/commands/transfer/celo.ts
@@ -58,8 +58,9 @@ export default class TransferCelo extends BaseCommand {
             res.flags.comment
               ? celoERC20Contract.estimateGas.transferWithComment([to, value, res.flags.comment!], {
                   feeCurrency,
+                  account: from,
                 })
-              : client.estimateGas({ to, value, ...transferParams }),
+              : client.estimateGas({ to, value, account: from, ...transferParams }),
             getGasPriceOnCelo(client, feeCurrency),
             (feeCurrency
               ? await getERC20Contract({ public: client }, feeCurrency)

--- a/packages/cli/src/commands/transfer/dollars.test.ts
+++ b/packages/cli/src/commands/transfer/dollars.test.ts
@@ -1,6 +1,7 @@
 import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
 import { ContractKit, newKitFromWeb3, StableToken } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
+import { TEST_GAS_PRICE } from '@celo/dev-utils/test-utils'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
@@ -89,7 +90,7 @@ testWithAnvilL2('transfer:dollars cmd', (web3: Web3) => {
     let restoreMock: () => void
     beforeEach(() => {
       // need to call this send sending gasCurrency address to the gas price rpc is not supported on anvil.
-      restoreMock = mockRpcFetch({ method: 'eth_gasPrice', result: '30000' })
+      restoreMock = mockRpcFetch({ method: 'eth_gasPrice', result: TEST_GAS_PRICE })
     })
     afterEach(() => {
       restoreMock()

--- a/packages/cli/src/commands/transfer/erc20.ts
+++ b/packages/cli/src/commands/transfer/erc20.ts
@@ -76,7 +76,7 @@ export default class TransferErc20 extends BaseCommand {
         `Account can afford to transfer CELO with gas paid in ${feeCurrency || 'CELO'}`,
         async () => {
           const [gas, gasPrice, balanceOfTokenForGas] = await Promise.all([
-            erc20Contract.estimateGas.transfer([to, value], {...transferParams, account: from}),
+            erc20Contract.estimateGas.transfer([to, value], { ...transferParams, account: from }),
             getGasPriceOnCelo(client, feeCurrency),
             (feeCurrency
               ? await getERC20Contract({ public: client }, feeCurrency)

--- a/packages/cli/src/commands/transfer/erc20.ts
+++ b/packages/cli/src/commands/transfer/erc20.ts
@@ -76,7 +76,7 @@ export default class TransferErc20 extends BaseCommand {
         `Account can afford to transfer CELO with gas paid in ${feeCurrency || 'CELO'}`,
         async () => {
           const [gas, gasPrice, balanceOfTokenForGas] = await Promise.all([
-            erc20Contract.estimateGas.transfer([to, value], transferParams),
+            erc20Contract.estimateGas.transfer([to, value], {...transferParams, account: from}),
             getGasPriceOnCelo(client, feeCurrency),
             (feeCurrency
               ? await getERC20Contract({ public: client }, feeCurrency)

--- a/packages/cli/src/transfer-stable-base.ts
+++ b/packages/cli/src/transfer-stable-base.ts
@@ -93,9 +93,12 @@ export abstract class TransferStableBase extends BaseCommand {
             res.flags.comment
               ? stableTokenContract.estimateGas.transferWithComment(
                   [to, value, res.flags.comment],
-                  transferParams
+                  { ...transferParams, account: from }
                 )
-              : stableTokenContract.estimateGas.transfer([to, value], transferParams),
+              : stableTokenContract.estimateGas.transfer([to, value], {
+                  ...transferParams,
+                  account: from,
+                }),
             // fee estimation
             getGasPriceOnCelo(client, feeCurrency),
             //  balanceOfTokenForGas

--- a/packages/dev-utils/src/anvil-test.ts
+++ b/packages/dev-utils/src/anvil-test.ts
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import {
   TEST_BALANCE,
+  TEST_BASE_FEE,
   TEST_GAS_LIMIT,
   TEST_GAS_PRICE,
   TEST_MNEMONIC,
@@ -41,7 +42,7 @@ function createInstance(stateFilePath: string, chainId?: number): Anvil {
     balance: TEST_BALANCE,
     gasPrice: TEST_GAS_PRICE,
     gasLimit: TEST_GAS_LIMIT,
-    blockBaseFeePerGas: 0,
+    blockBaseFeePerGas: TEST_BASE_FEE,
     stopTimeout: 1000,
     chainId,
   }

--- a/packages/dev-utils/src/test-utils.ts
+++ b/packages/dev-utils/src/test-utils.ts
@@ -11,7 +11,8 @@ export const UNLOCKING_PERIOD = 3 * DAY
 export const TEST_MNEMONIC =
   'concert load couple harbor equip island argue ramp clarify fence smart topic'
 export const TEST_BALANCE = 1000000
-export const TEST_GAS_PRICE = 0
+export const TEST_GAS_PRICE = 25001000000 // actual price on celo right now
+export const TEST_BASE_FEE = 25000000000 // actual price on celo right now
 export const TEST_GAS_LIMIT = 20000000
 
 export const NetworkConfig = migrationOverride

--- a/packages/dev-utils/src/viem/anvil-test.ts
+++ b/packages/dev-utils/src/viem/anvil-test.ts
@@ -17,7 +17,13 @@ import {
 } from 'viem'
 import { celo, celoAlfajores } from 'viem/chains'
 import { ANVIL_PORT, DEFAULT_OWNER_ADDRESS } from '../anvil-test'
-import { TEST_BALANCE, TEST_GAS_LIMIT, TEST_GAS_PRICE, TEST_MNEMONIC } from '../test-utils'
+import {
+  TEST_BALANCE,
+  TEST_BASE_FEE,
+  TEST_GAS_LIMIT,
+  TEST_GAS_PRICE,
+  TEST_MNEMONIC,
+} from '../test-utils'
 import { celoBaklava } from './chains'
 import { testWithViem } from './test-utils'
 
@@ -46,7 +52,7 @@ function createInstance(opts?: { chainId?: number; forkUrl?: string; forkBlockNu
     balance: TEST_BALANCE,
     gasPrice: TEST_GAS_PRICE,
     gasLimit: TEST_GAS_LIMIT,
-    blockBaseFeePerGas: 25000000000,
+    blockBaseFeePerGas: TEST_BASE_FEE,
     stopTimeout: 3000,
     chainId: opts?.chainId,
     ...(forkUrl


### PR DESCRIPTION
### Description

large transfers were broken because we failed to pass the from account so estimation happened against NULL address which was fine for small transfers as it ha a balance but was not accurate since it didnt use senders balance

#### Other changes

fixed it so our tests  actually use real values for fees

### Tested

new

erc20
https://alfajores.celoscan.io/tx/0xabaffc10a471aa6e37064a2258a1da8353895bbc56c2f07c9e4b3a76d4c6b85c
native
https://alfajores.celoscan.io/tx/0xd2d302855f1f7d2d26f45fca95cd237bcfef91b62cd4f8935ed760f3488b1c21
### How to QA

run transfer with a large amount ( id did 1000 celo on alfajores) 
### Related issues

- Fixes #[issue number here]
