### PR TITLE
enable ci on fork prs

### DIFF
--- a/.github/actions/upload-codecov/action.yml
+++ b/.github/actions/upload-codecov/action.yml
@@ -10,15 +10,24 @@ runs:
   steps:
     - name: Akeyless Get CODECOV_TOKEN Secrets
       id: get_codecov_token
+      if: github.ref_name == github.event.repository.default_branch
       uses: docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:latest
       with:
         api-url: https://api.gateway.akeyless.celo-networks-dev.org
         access-id: p-kf9vjzruht6l
         static-secrets: '{"/static-secrets/dev-tooling-circle/codecov/developer-tooling":"CODECOV_TOKEN"}'
     - name: Upload coverage to Codecov
+      if: github.ref_name == github.event.repository.default_branch
       uses: codecov/codecov-action@v5
       with:
         verbose: true
         name: ${{ inputs.report-name }}
       env:
         CODECOV_TOKEN: ${{ env.CODECOV_TOKEN }}
+
+    - name: Upload coverage to Codecov
+      if: github.ref_name != github.event.repository.default_branch
+      uses: codecov/codecov-action@v5
+      with:
+        verbose: true
+        name: ${{ inputs.report-name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ env:
   NODE_OPTIONS: '--max-old-space-size=4096'
   TERM: dumb
   # Supported Foundry version defined at celo-org (GitHub organisation) level, for consistency across workflows.
-  SUPPORTED_FOUNDRY_VERSION: ${{ vars.SUPPORTED_FOUNDRY_VERSION }}
+  SUPPORTED_FOUNDRY_VERSION: nightly-fa0e0c2ca3ae75895dd19173a02faf88509c0608
 
 # EXAMPLE on debug ssh step
 #  - name: Setup tmate session


### PR DESCRIPTION
### Description

Update the workflow to use locallly defined environment variables for foundry version, and not require a codecov token for non default branches, since codecov no longer requires these for nonprotected branches, and we need to be able to run workflows from forks.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflow configuration, specifically modifying the `SUPPORTED_FOUNDRY_VERSION` and enhancing the `upload-codecov` action to handle coverage uploads differently based on the branch context.

### Detailed summary
- Updated `SUPPORTED_FOUNDRY_VERSION` to a specific nightly version.
- Added conditional checks to the `upload-codecov` action:
  - For the default branch, it retrieves the `CODECOV_TOKEN` and uploads coverage.
  - For non-default branches, it also uploads coverage but with a separate conditional.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->