### PR TITLE
Fix release celo  dollars transfer

### DIFF
--- a/.changeset/fine-bushes-bow.md
+++ b/.changeset/fine-bushes-bow.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': patch
+---
+
+Fix releasecelo:transfer-dollars to load the correct account to send from

--- a/packages/cli/src/base.test.ts
+++ b/packages/cli/src/base.test.ts
@@ -484,7 +484,7 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
     it('should fail when --from address does not match private key', async () => {
       const privateKey = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
       const wrongFromAddress = '0x0000000000000000000000000000000000000001'
-      
+
       class TestPrivateKeyCommand extends BaseCommand {
         static flags = {
           ...BaseCommand.flags,
@@ -509,7 +509,7 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
     it('should succeed when --from address matches private key', async () => {
       const privateKey = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
       const correctFromAddress = '0xc2D7CF95645D33006175B78989035C7c9061d3F9'
-      
+
       class TestPrivateKeyCommand extends BaseCommand {
         static flags = {
           ...BaseCommand.flags,
@@ -532,7 +532,7 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
 
     it('should succeed when no --from address is provided with private key', async () => {
       const privateKey = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
-      
+
       class TestPrivateKeyCommand extends BaseCommand {
         static flags = {
           ...BaseCommand.flags,
@@ -545,11 +545,7 @@ testWithAnvilL2('BaseCommand', (web3: Web3) => {
       }
 
       await expect(
-        testLocallyWithWeb3Node(
-          TestPrivateKeyCommand,
-          ['--privateKey', privateKey],
-          web3
-        )
+        testLocallyWithWeb3Node(TestPrivateKeyCommand, ['--privateKey', privateKey], web3)
       ).resolves.not.toThrow()
     })
   })

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -311,9 +311,7 @@ export abstract class BaseCommand extends Command {
       } else if (res.flags.useAKV) {
         failWith('--useAKV flag is no longer supported')
       } else if (res.flags.privateKey) {
-        const accountFromPrivateKey = privateKeyToAccount(
-          ensureLeading0x(res.flags.privateKey)
-        )
+        const accountFromPrivateKey = privateKeyToAccount(ensureLeading0x(res.flags.privateKey))
         if (accountAddress && accountAddress !== accountFromPrivateKey.address) {
           failWith(
             `The --from address ${accountAddress} does not match the address derived from the provided private key ${accountFromPrivateKey.address}.`

--- a/packages/cli/src/commands/releasecelo/transfer-dollars.test.ts
+++ b/packages/cli/src/commands/releasecelo/transfer-dollars.test.ts
@@ -2,6 +2,8 @@ import { StableToken, StrongAddress } from '@celo/base'
 import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
 import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
+import { mineBlocks } from '@celo/dev-utils/ganache-test'
+import { ACCOUNT_PRIVATE_KEYS } from '@celo/dev-utils/test-accounts'
 import { TEST_BASE_FEE, TEST_GAS_PRICE } from '@celo/dev-utils/test-utils'
 import BigNumber from 'bignumber.js'
 import { formatEther, toHex } from 'viem'
@@ -63,28 +65,71 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
       accounts[0],
       new BigNumber(web3.utils.toWei('1000', 'ether'))
     )
-    const balanceBefore = await kit.getTotalBalance(accounts[0])
+    jest.clearAllMocks()
+    const logSpy = jest.spyOn(console, 'log')
     const cUSDToTransfer = '500000000000000000000'
     // Send cUSD to RG contract
-    await testLocallyWithWeb3Node(
-      TransferDollars,
-      ['--from', accounts[0], '--to', contractAddress, '--value', cUSDToTransfer],
-      web3
-    )
+    await expect(
+      testLocallyWithWeb3Node(
+        TransferDollars,
+        ['--from', accounts[0], '--to', contractAddress, '--value', cUSDToTransfer],
+        web3
+      )
+    ).resolves.toBeUndefined()
+    expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
+      [
+        [
+          "Running Checks:",
+        ],
+        [
+          "   ✔  Account has at least 500 cUSD ",
+        ],
+        [
+          "   ✔  Compliant Address ",
+        ],
+        [
+          "   ✔  Compliant Address ",
+        ],
+        [
+          "   ✔  0x5409ED021D9299bf6814279A6A1411A7e866A631 can sign txs ",
+        ],
+        [
+          "   ✔  Account can afford to transfer cUSD with gas paid in CELO ",
+        ],
+        [
+          "All checks passed",
+        ],
+        [
+          "SendTransaction: cUSD->Transfer",
+        ],
+        [
+          "txHash: 0xtxhash",
+        ],
+      ]
+    `)
+    jest.clearAllMocks()
+    await mineBlocks(2, web3)
     // RG cUSD balance should match the amount sent
     const contractBalance = await kit.getTotalBalance(contractAddress)
     expect(contractBalance.cUSD!.toFixed()).toEqual(cUSDToTransfer)
-    // Attempt to send cUSD back
-    await testLocallyWithWeb3Node(
-      RGTransferDollars,
-      ['--contract', contractAddress, '--to', accounts[0], '--value', cUSDToTransfer],
-      web3
-    )
+    // Test that transfer succeeds when using the beneficiary (accounts[1])
+    await expect(
+      testLocallyWithWeb3Node(
+        RGTransferDollars,
+        ['--contract', contractAddress, '--to', accounts[0], '--value', cUSDToTransfer, '--privateKey', ACCOUNT_PRIVATE_KEYS[1]],
+        web3
+      )
+    ).resolves.toBeUndefined()
+    
     const balanceAfter = await kit.getTotalBalance(accounts[0])
-    expect(balanceBefore.cUSD).toEqual(balanceAfter.cUSD)
+    const contractBalanceAfter = await kit.getTotalBalance(contractAddress)
+    
+    // Verify the transfer succeeded by checking the contract is empty
+    expect(contractBalanceAfter.cUSD!.toFixed()).toEqual('0') // Contract should be empty after transfer
+    expect(balanceAfter.cUSD!.toFixed()).toEqual('1000000000000000000000') // Should be 1000 cUSD (500 initial + 500 transferred)
   })
 
-  test('should fail if contract has no celo dollars', async () => {
+  test('fails if contract has no celo dollars', async () => {
     const logSpy = jest.spyOn(console, 'log')
     const value = BigInt(1)
     await expect(
@@ -100,7 +145,7 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
       ]
     `)
   })
-  test('should fail if to address is sanctioned', async () => {
+  test('fails if to address is sanctioned', async () => {
     await topUpWithToken(
       kit,
       StableToken.cUSD,
@@ -124,5 +169,48 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))
+  })
+
+  test('fails if signing account is not the beneficiary or release owner', async () => {
+    await topUpWithToken(
+      kit,
+      StableToken.cUSD,
+      accounts[0],
+      new BigNumber(web3.utils.toWei('1000', 'ether'))
+    )
+    const spy = jest.spyOn(console, 'log')
+    const cUSDToTransfer = '500000000000000000000'
+    // Send cUSD to RG contract
+    await testLocallyWithWeb3Node(
+      TransferDollars,
+      ['--from', accounts[0], '--to', contractAddress, '--value', cUSDToTransfer],
+      web3
+    )
+
+    // Try to transfer using account[2] which is neither beneficiary nor release owner
+    await expect(
+      testLocallyWithWeb3Node(
+        RGTransferDollars,
+        [
+          '--contract',
+          contractAddress,
+          '--to',
+          accounts[3],
+          '--value',
+          '10',
+          '--privateKey',
+          ACCOUNT_PRIVATE_KEYS[2],
+        ],
+        web3
+      )
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
+
+    expect(
+      stripAnsiCodesFromNestedArray(spy.mock.calls).some((call) =>
+        call.some(
+          (arg) => typeof arg === 'string' && arg.includes('Signing Account is Beneficiary')
+        )
+      )
+    ).toBe(true)
   })
 })

--- a/packages/cli/src/commands/releasecelo/transfer-dollars.test.ts
+++ b/packages/cli/src/commands/releasecelo/transfer-dollars.test.ts
@@ -116,14 +116,23 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
     await expect(
       testLocallyWithWeb3Node(
         RGTransferDollars,
-        ['--contract', contractAddress, '--to', accounts[0], '--value', cUSDToTransfer, '--privateKey', ACCOUNT_PRIVATE_KEYS[1]],
+        [
+          '--contract',
+          contractAddress,
+          '--to',
+          accounts[0],
+          '--value',
+          cUSDToTransfer,
+          '--privateKey',
+          ACCOUNT_PRIVATE_KEYS[1],
+        ],
         web3
       )
     ).resolves.toBeUndefined()
-    
+
     const balanceAfter = await kit.getTotalBalance(accounts[0])
     const contractBalanceAfter = await kit.getTotalBalance(contractAddress)
-    
+
     // Verify the transfer succeeded by checking the contract is empty
     expect(contractBalanceAfter.cUSD!.toFixed()).toEqual('0') // Contract should be empty after transfer
     expect(balanceAfter.cUSD!.toFixed()).toEqual('1000000000000000000000') // Should be 1000 cUSD (500 initial + 500 transferred)

--- a/packages/cli/src/commands/releasecelo/transfer-dollars.ts
+++ b/packages/cli/src/commands/releasecelo/transfer-dollars.ts
@@ -35,18 +35,19 @@ export default class TransferDollars extends ReleaseGoldBaseCommand {
       { public: client, wallet },
       flags.contract
     )
-    
+
     const isRevoked = await releaseCeloContract.read.isRevoked()
 
     const account = isRevoked
       ? await releaseCeloContract.read.releaseOwner()
       : await releaseCeloContract.read.beneficiary()
 
-
     await newCheckBuilder(this)
       .isNotSanctioned(account)
       .isNotSanctioned(flags.to)
-      .addCheck(`Signing Account is ${isRevoked ? 'Release Owner' : 'Beneficiary'}`, () =>  isAddressEqual(account, wallet.account.address))
+      .addCheck(`Signing Account is ${isRevoked ? 'Release Owner' : 'Beneficiary'}`, () =>
+        isAddressEqual(account, wallet.account.address)
+      )
       .hasEnoughStable(flags.contract, flags.value, 'cUSD')
       .runChecks()
 


### PR DESCRIPTION
### Description

if an address instead of an account object is passed in as the third param to a viem contract action then viem thinks we are using and json rpc wallet. solution is to remove since the proper account is setting while creating the wallet from the private key.

#### Other changes
added checks that from matches the account from private key if both are present. 

### Tested

aded new tests.

### How to QA

ideally have a release gold contract with cusd. 
### Related issues

- Fixes #708
- fixes #709
