### PR TITLE
Require proposals description urls to return real url

### DIFF
--- a/.changeset/evil-facts-join.md
+++ b/.changeset/evil-facts-join.md
@@ -1,0 +1,5 @@
+---
+'@celo/celocli': minor
+---
+
+governance:propose now prevents submitting a descriptionUrl that does not exist.

--- a/packages/cli/src/commands/governance/propose.test.ts
+++ b/packages/cli/src/commands/governance/propose.test.ts
@@ -746,7 +746,7 @@ testWithAnvilL2(
       async () => {
         const mockFetch = require('cross-fetch')
         mockFetch.mockResolvedValue({
-          status: 404
+          status: 404,
         })
 
         await expect(
@@ -764,7 +764,9 @@ testWithAnvilL2(
             ],
             web3
           )
-        ).rejects.toThrow('The provided description URL "https://github.com/celo-org/governance/blob/main/CGPs/cgp-404.md" does not return HTTP 200 status code.')
+        ).rejects.toThrow(
+          'The provided description URL "https://github.com/celo-org/governance/blob/main/CGPs/cgp-404.md" does not return HTTP 200 status code.'
+        )
 
         mockFetch.mockRestore()
       },
@@ -792,7 +794,9 @@ testWithAnvilL2(
             ],
             web3
           )
-        ).rejects.toThrow('The provided description URL "https://github.com/celo-org/governance/blob/main/CGPs/cgp-error.md" does not return HTTP 200 status code.')
+        ).rejects.toThrow(
+          'The provided description URL "https://github.com/celo-org/governance/blob/main/CGPs/cgp-error.md" does not return HTTP 200 status code.'
+        )
 
         mockFetch.mockRestore()
       },

--- a/packages/cli/src/commands/governance/propose.test.ts
+++ b/packages/cli/src/commands/governance/propose.test.ts
@@ -781,7 +781,7 @@ testWithAnvilL2(
               "Running Checks:",
             ],
             [
-              "   ✘  URL gives HTTP 200 status:  The provided URL "https://github.com/celo-org/governance/blob/main/CGPs/cgp-404.md" does not exist or is not reachable.",
+              "   ✘  URL exists:  The provided URL "https://github.com/celo-org/governance/blob/main/CGPs/cgp-404.md" does not exist or is not reachable.",
             ],
             [
               "   ✔  Account has at least 100 CELO ",

--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -59,6 +59,7 @@ export default class Propose extends BaseCommand {
     const kit = await this.getKit()
     const res = await this.parse(Propose)
     const account = res.flags.from
+
     kit.defaultAccount = account
     const deposit = new BigNumber(res.flags.deposit)
     if (res.flags.useMultiSig && !res.flags.for) {
@@ -81,6 +82,19 @@ export default class Propose extends BaseCommand {
         ? res.flags.safeAddress!
         : account
 
+    await newCheckBuilder(this, proposer)
+      .urlDestinationExists(res.flags.descriptionURL)
+      .hasEnoughCelo(proposer, deposit)
+      .exceedsProposalMinDeposit(deposit)
+      .addConditionalCheck(`${account} is multisig signatory`, useMultiSig, () =>
+        proposerMultiSig!.isOwner(account)
+      )
+      .addConditionalCheck(`${account} is a safe owner`, useSafe, async () => {
+        const safe = await createSafeFromWeb3(await this.getWeb3(), account, proposer)
+        return safe.isOwner(account)
+      })
+      .runChecks()
+
     const builder = new ProposalBuilder(kit)
 
     if (res.flags.afterExecutingID) {
@@ -98,19 +112,6 @@ export default class Propose extends BaseCommand {
     if (!res.flags.noInfo) {
       printValueMapRecursive(await proposalToJSON(kit, proposal, builder.registryAdditions))
     }
-
-    await newCheckBuilder(this, proposer)
-      .descriptionUrlReturns200(res.flags.descriptionURL)
-      .hasEnoughCelo(proposer, deposit)
-      .exceedsProposalMinDeposit(deposit)
-      .addConditionalCheck(`${account} is multisig signatory`, useMultiSig, () =>
-        proposerMultiSig!.isOwner(account)
-      )
-      .addConditionalCheck(`${account} is a safe owner`, useSafe, async () => {
-        const safe = await createSafeFromWeb3(await this.getWeb3(), account, proposer)
-        return safe.isOwner(account)
-      })
-      .runChecks()
 
     if (!res.flags.force) {
       const ok = await checkProposal(proposal, kit)

--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -100,6 +100,7 @@ export default class Propose extends BaseCommand {
     }
 
     await newCheckBuilder(this, proposer)
+      .descriptionUrlReturns200(res.flags.descriptionURL)
       .hasEnoughCelo(proposer, deposit)
       .exceedsProposalMinDeposit(deposit)
       .addConditionalCheck(`${account} is multisig signatory`, useMultiSig, () =>

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -686,7 +686,7 @@ class CheckBuilder {
       `URL exists: `,
       async () => {
         try {
-          const response = await fetch(url, { method: 'HEAD' })
+          const response = await fetch(url)
           return response.status === 200
         } catch (error) {
           return false

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -681,9 +681,9 @@ class CheckBuilder {
       `${feeCurrency!} is not a valid fee currency.`
     )
   }
-  descriptionUrlReturns200 = (url: string) => {
+  urlDestinationExists = (url: string) => {
     return this.addCheck(
-      `Description URL returns HTTP 200`,
+      `URL gives HTTP 200 status: `,
       async () => {
         try {
           const response = await fetch(url, { method: 'HEAD' })
@@ -692,7 +692,7 @@ class CheckBuilder {
           return false
         }
       },
-      `The provided description URL "${url}" does not return HTTP 200 status code.`
+      `The provided URL "${url}" does not exist or is not reachable.`
     )
   }
 

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -683,7 +683,7 @@ class CheckBuilder {
   }
   urlDestinationExists = (url: string) => {
     return this.addCheck(
-      `URL gives HTTP 200 status: `,
+      `URL exists: `,
       async () => {
         try {
           const response = await fetch(url, { method: 'HEAD' })

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -681,6 +681,20 @@ class CheckBuilder {
       `${feeCurrency!} is not a valid fee currency.`
     )
   }
+  descriptionUrlReturns200 = (url: string) => {
+    return this.addCheck(
+      `Description URL returns HTTP 200`,
+      async () => {
+        try {
+          const response = await fetch(url, { method: 'HEAD' })
+          return response.status === 200
+        } catch (error) {
+          return false
+        }
+      },
+      `The provided description URL "${url}" does not return HTTP 200 status code.`
+    )
+  }
 
   async runChecks({ failFast = false }: { failFast?: boolean } = {}) {
     console.log(`Running Checks:`)


### PR DESCRIPTION
### Description

it is a very big problem if the wrong url is submitted on chain. it will cause mondo to break. 

#### Other changes

n.a
### Tested

new tests

### How to QA

try to submited a proposals with a url that points to a cgp that does not exist. 

### Related issues

- Fixes #

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a check in the `governance:propose` command to ensure that the `descriptionURL` provided exists and is reachable. It adds error handling for when the URL is not valid and includes tests for these scenarios.

### Detailed summary
- Added `urlDestinationExists` method in `checks.ts` to verify URL existence.
- Updated `Propose` class to use the new URL check.
- Implemented tests for scenarios where `descriptionURL` returns a non-200 status and when it throws an error.
- Enhanced error messages for invalid URLs in the proposal process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->