### PR TITLE
revert checks added for patched bug

### DIFF
--- a/.changeset/early-windows-mate.md
+++ b/.changeset/early-windows-mate.md
@@ -1,0 +1,5 @@
+---
+'@celo/contractkit': patch
+---
+
+Removes checks for validation checks for elected accounts when switching epochs


### PR DESCRIPTION
### Description

removes a check added to prevent the accidental trigger of a now patched bug. 

#### Other changes

nope


### How to QA


### Related issues

- reverts https://github.com/celo-org/developer-tooling/pull/590

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the epoch transition process by removing validation checks for elected accounts when switching epochs in the `EpochManagerWrapper` class.

### Detailed summary
- Removed checks for elected accounts' affiliation with a group in the `startNextEpochProcessTx` method.
- Eliminated the try-catch block that validated if elected accounts were validators and affiliated with a group.
- Kept the check for whether the epoch process has already started.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->