### PR TITLE
fix: npm-publish workflow bump

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       attestations: write
       id-token: write
       repository-projects: write
-    uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v3.0.0
+    uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v3.0.1
     with:
       node-version: 20
       version-command: yarn version-then-update-files


### PR DESCRIPTION
### Description

_Tell us why these changes are being made_

#### Other changes

_Describe any minor or "drive-by" changes here. If none delete this section_

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How to QA

_List of steps required to QA the change if applicable_

### Related issues

- Fixes #[issue number here]


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the reusable workflow used for publishing npm packages in the `.github/workflows/release.yaml` file.

### Detailed summary
- Updated the `uses` directive from `celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v3.0.0` to `celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v3.0.1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->