### PR TITLE
Revert "fix: npm-publish workflow bump"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       attestations: write
       id-token: write
       repository-projects: write
-    uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v3.0.1
+    uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v3.0.0
     with:
       node-version: 20
       version-command: yarn version-then-update-files


### PR DESCRIPTION
Reverts celo-org/developer-tooling#728

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the reusable workflow used for publishing npm packages in the `.github/workflows/release.yaml` file from `v3.0.1` to `v3.0.0`.

### Detailed summary
- Changed the `uses` field in `.github/workflows/release.yaml` from `celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v3.0.1` to `celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v3.0.0`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->