### PR TITLE
Update release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       attestations: write
       id-token: write
       repository-projects: write
-    uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@develop
+    uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@develop-npm-publishing-oidc
     with:
       node-version: 20
       version-command: yarn version-then-update-files


### PR DESCRIPTION
Use `develop-npm-publishing-oidc` for NPM packages.

PR is draft, will set as ready for review when this is configured in NPM registry for all packages

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflow configuration for releasing by modifying the `uses` directive to point to a different version of the `npm-publish.yaml` file, which likely includes changes related to OIDC (OpenID Connect) for token management.

### Detailed summary
- Changed `uses` from `celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@develop` 
  to `celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@develop-npm-publishing-oidc`
- Retained `id-token: write` and `repository-projects: write` permissions
- Kept `node-version: 20` and `version-command: yarn version-then-update-files` settings

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->