### PR TITLE
refactor(cli): migrate lockedcelo, multisig, network, oracle, transfer to viem [7/8]

### DIFF
--- a/packages/cli/src/commands/identity/withdraw-attestation-rewards.ts
+++ b/packages/cli/src/commands/identity/withdraw-attestation-rewards.ts
@@ -1,7 +1,7 @@
 import { ux } from '@oclif/core'
 
 import { BaseCommand } from '../../base'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class AttestationRewardsWithdraw extends BaseCommand {
@@ -21,6 +21,7 @@ export default class AttestationRewardsWithdraw extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags } = await this.parse(AttestationRewardsWithdraw)
     const [accounts, attestations] = await Promise.all([
       kit.contracts.getAccounts(),
@@ -43,7 +44,11 @@ export default class AttestationRewardsWithdraw extends BaseCommand {
     }
 
     ux.action.start(`Withdrawing ${pendingWithdrawals.toString()} rewards to ${accountAddress}`)
-    await displaySendTx('withdraw', attestations.withdraw(tokenAddress), { from: flags.from })
+    await displayViemTx(
+      'withdraw',
+      attestations.withdraw(tokenAddress, { from: flags.from }),
+      publicClient
+    )
     ux.action.stop()
   }
 }

--- a/packages/cli/src/commands/lockedcelo/delegate-info.test.ts
+++ b/packages/cli/src/commands/lockedcelo/delegate-info.test.ts
@@ -1,6 +1,6 @@
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { testLocallyWithNode } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Delegate from './delegate'
 import DelegateInfo from './delegate-info'
@@ -8,21 +8,22 @@ import Lock from './lock'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('lockedgold:delegate-info cmd', (web3: Web3) => {
+testWithAnvilL2('lockedgold:delegate-info cmd', (provider) => {
   test('gets the info', async () => {
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
     const account = accounts[0]
     const account2 = accounts[1]
-    await testLocallyWithWeb3Node(Register, ['--from', account], web3)
-    await testLocallyWithWeb3Node(Register, ['--from', account2], web3)
-    await testLocallyWithWeb3Node(Lock, ['--from', account, '--value', '200'], web3)
+    await testLocallyWithNode(Register, ['--from', account], provider)
+    await testLocallyWithNode(Register, ['--from', account2], provider)
+    await testLocallyWithNode(Lock, ['--from', account, '--value', '200'], provider)
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       Delegate,
       ['--from', account, '--to', account2, '--percent', '100'],
-      web3
+      provider
     )
 
-    await testLocallyWithWeb3Node(DelegateInfo, ['--account', account], web3)
+    await testLocallyWithNode(DelegateInfo, ['--account', account], provider)
   })
 })

--- a/packages/cli/src/commands/lockedcelo/delegate.test.ts
+++ b/packages/cli/src/commands/lockedcelo/delegate.test.ts
@@ -1,8 +1,7 @@
 import { serializeSignature, StrongAddress } from '@celo/base'
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import Register from '../account/register'
 import Authorize from '../releasecelo/authorize'
@@ -12,13 +11,13 @@ import Lock from './lock'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('lockedgold:delegate cmd', (web3: Web3) => {
+testWithAnvilL2('lockedgold:delegate cmd', (provider) => {
   it('can not delegate when not an account or a vote signer', async () => {
-    const [delegator, delegatee] = await web3.eth.getAccounts()
-    const kit = newKitFromWeb3(web3)
+    const kit = newKitFromProvider(provider)
+    const [delegator, delegatee] = await kit.connection.getAccounts()
     const lockedGold = await kit.contracts.getLockedGold()
 
-    await testLocallyWithWeb3Node(Register, ['--from', delegatee], web3)
+    await testLocallyWithNode(Register, ['--from', delegatee], provider)
 
     const delegateeVotingPower = await lockedGold.getAccountTotalGovernanceVotingPower(delegatee)
 
@@ -28,10 +27,10 @@ testWithAnvilL2('lockedgold:delegate cmd', (web3: Web3) => {
     const logMock = jest.spyOn(console, 'log')
 
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         Delegate,
         ['--from', delegator, '--to', delegatee, '--percent', '45'],
-        web3
+        provider
       )
     ).rejects.toMatchInlineSnapshot(`[Error: Some checks didn't pass!]`)
 
@@ -58,23 +57,23 @@ testWithAnvilL2('lockedgold:delegate cmd', (web3: Web3) => {
   })
 
   test('can delegate', async () => {
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
     const account = accounts[0]
     const account2 = accounts[1]
-    const kit = newKitFromWeb3(web3)
     const lockedGold = await kit.contracts.getLockedGold()
-    await testLocallyWithWeb3Node(Register, ['--from', account], web3)
-    await testLocallyWithWeb3Node(Register, ['--from', account2], web3)
-    await testLocallyWithWeb3Node(Lock, ['--from', account, '--value', '200'], web3)
+    await testLocallyWithNode(Register, ['--from', account], provider)
+    await testLocallyWithNode(Register, ['--from', account2], provider)
+    await testLocallyWithNode(Lock, ['--from', account, '--value', '200'], provider)
 
     const account2OriginalVotingPower =
       await lockedGold.getAccountTotalGovernanceVotingPower(account2)
     expect(account2OriginalVotingPower.toFixed()).toBe('0')
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       Delegate,
       ['--from', account, '--to', account2, '--percent', '100'],
-      web3
+      provider
     )
 
     const account2VotingPower = await lockedGold.getAccountTotalGovernanceVotingPower(account2)
@@ -82,20 +81,20 @@ testWithAnvilL2('lockedgold:delegate cmd', (web3: Web3) => {
   })
 
   it('can delegate as a vote signer for releasecelo contract', async () => {
+    const kit = newKitFromProvider(provider)
     const [beneficiary, owner, voteSigner, refundAddress, delegateeAddress] =
-      (await web3.eth.getAccounts()) as StrongAddress[]
-    const kit = newKitFromWeb3(web3)
+      (await kit.connection.getAccounts()) as StrongAddress[]
     const accountsWrapper = await kit.contracts.getAccounts()
     const releaseGoldContractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       owner,
       beneficiary,
       owner,
       refundAddress
     )
 
-    await testLocallyWithWeb3Node(CreateAccount, ['--contract', releaseGoldContractAddress], web3)
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(CreateAccount, ['--contract', releaseGoldContractAddress], provider)
+    await testLocallyWithNode(
       Authorize,
       [
         '--contract',
@@ -109,17 +108,17 @@ testWithAnvilL2('lockedgold:delegate cmd', (web3: Web3) => {
           await accountsWrapper.generateProofOfKeyPossession(releaseGoldContractAddress, voteSigner)
         ),
       ],
-      web3
+      provider
     )
-    await testLocallyWithWeb3Node(Lock, ['--from', beneficiary, '--value', '100'], web3)
+    await testLocallyWithNode(Lock, ['--from', beneficiary, '--value', '100'], provider)
 
-    const createAccountTx = await accountsWrapper.createAccount().send({ from: delegateeAddress })
-    await createAccountTx.waitReceipt()
+    const createHash = await accountsWrapper.createAccount({ from: delegateeAddress })
+    await kit.connection.viemClient.waitForTransactionReceipt({ hash: createHash as `0x${string}` })
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       Delegate,
       ['--from', voteSigner, '--to', delegateeAddress, '--percent', '100'],
-      web3
+      provider
     )
 
     const lockedGold = await kit.contracts.getLockedGold()

--- a/packages/cli/src/commands/lockedcelo/delegate.ts
+++ b/packages/cli/src/commands/lockedcelo/delegate.ts
@@ -3,7 +3,7 @@ import { Flags } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 import { LockedGoldArgs } from '../../utils/lockedgold'
 
@@ -31,6 +31,7 @@ export default class Delegate extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(Delegate)
     const address = res.flags.from
     const to = res.flags.to
@@ -50,10 +51,7 @@ export default class Delegate extends BaseCommand {
 
     const lockedGold = await kit.contracts.getLockedGold()
 
-    console.log('value', percent.toString())
-    console.log('valueFixed', percentFixed.toFixed())
-
     const tx = lockedGold.delegate(to, percentFixed.toFixed())
-    await displaySendTx('delegate', tx)
+    await displayViemTx('delegate', tx, publicClient)
   }
 }

--- a/packages/cli/src/commands/lockedcelo/lock.test.ts
+++ b/packages/cli/src/commands/lockedcelo/lock.test.ts
@@ -1,12 +1,11 @@
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
-import Web3 from 'web3'
 import {
   LONG_TIMEOUT_MS,
   stripAnsiCodesFromNestedArray,
-  testLocallyWithWeb3Node,
+  testLocallyWithNode,
 } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from './lock'
@@ -14,20 +13,20 @@ import Unlock from './unlock'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('lockedgold:lock cmd', (web3: Web3) => {
+testWithAnvilL2('lockedgold:lock cmd', (provider) => {
   test(
     'can lock with pending withdrawals',
     async () => {
-      const accounts = await web3.eth.getAccounts()
+      const kit = newKitFromProvider(provider)
+      const accounts = await kit.connection.getAccounts()
       const account = accounts[0]
-      const kit = newKitFromWeb3(web3)
       const lockedGold = await kit.contracts.getLockedGold()
-      await testLocallyWithWeb3Node(Register, ['--from', account], web3)
-      await testLocallyWithWeb3Node(Lock, ['--from', account, '--value', '100'], web3)
-      await testLocallyWithWeb3Node(Unlock, ['--from', account, '--value', '50'], web3)
-      await testLocallyWithWeb3Node(Lock, ['--from', account, '--value', '75'], web3)
-      await testLocallyWithWeb3Node(Unlock, ['--from', account, '--value', '50'], web3)
-      await testLocallyWithWeb3Node(Lock, ['--from', account, '--value', '50'], web3)
+      await testLocallyWithNode(Register, ['--from', account], provider)
+      await testLocallyWithNode(Lock, ['--from', account, '--value', '100'], provider)
+      await testLocallyWithNode(Unlock, ['--from', account, '--value', '50'], provider)
+      await testLocallyWithNode(Lock, ['--from', account, '--value', '75'], provider)
+      await testLocallyWithNode(Unlock, ['--from', account, '--value', '50'], provider)
+      await testLocallyWithNode(Lock, ['--from', account, '--value', '50'], provider)
       const pendingWithdrawalsTotalValue = await lockedGold.getPendingWithdrawalsTotalValue(account)
       expect(pendingWithdrawalsTotalValue.toFixed()).toBe('0')
     },
@@ -35,9 +34,9 @@ testWithAnvilL2('lockedgold:lock cmd', (web3: Web3) => {
   )
   describe('when EOA is not yet an account', () => {
     it('performs the registration and locks the value', async () => {
-      const eoaAddresses = await web3.eth.getAccounts()
+      const kit = newKitFromProvider(provider)
+      const eoaAddresses = await kit.connection.getAccounts()
       const eoa = eoaAddresses[1]
-      const kit = newKitFromWeb3(web3)
       const accountsContract = await kit.contracts.getAccounts()
       const lockedGoldContract = await kit.contracts.getLockedGold()
 
@@ -47,7 +46,7 @@ testWithAnvilL2('lockedgold:lock cmd', (web3: Web3) => {
       // pre check
       expect(await accountsContract.isAccount(eoa)).toBe(false)
 
-      await testLocallyWithWeb3Node(Lock, ['--from', eoa, '--value', '100'], web3)
+      await testLocallyWithNode(Lock, ['--from', eoa, '--value', '100'], provider)
 
       expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
         [

--- a/packages/cli/src/commands/lockedcelo/lock.ts
+++ b/packages/cli/src/commands/lockedcelo/lock.ts
@@ -3,7 +3,7 @@ import { Flags } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 import { LockedGoldArgs } from '../../utils/lockedgold'
 
@@ -26,6 +26,7 @@ export default class Lock extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(Lock)
     const address = res.flags.from as StrongAddress
 
@@ -45,7 +46,7 @@ export default class Lock extends BaseCommand {
 
     if (!isAccount) {
       console.log('Address will be registered with Account contract to enable locking.')
-      await displaySendTx('register', accountsContract.createAccount())
+      await displayViemTx('register', accountsContract.createAccount(), publicClient)
     }
 
     const pendingWithdrawalsValue = await lockedGold.getPendingWithdrawalsTotalValue(address)
@@ -54,13 +55,13 @@ export default class Lock extends BaseCommand {
 
     await newCheckBuilder(this).hasEnoughCelo(address, lockValue).runChecks()
 
-    const txos = await lockedGold.relock(address, relockValue)
-    for (const txo of txos) {
-      await displaySendTx('relock', txo, { from: address })
+    const hashes = await lockedGold.relock(address, relockValue, { from: address })
+    for (const hash of hashes) {
+      await displayViemTx('relock', Promise.resolve(hash), publicClient)
     }
     if (lockValue.gt(new BigNumber(0))) {
-      const tx = lockedGold.lock()
-      await displaySendTx('lock', tx, { value: lockValue.toFixed() })
+      const tx = lockedGold.lock({ value: lockValue.toFixed() })
+      await displayViemTx('lock', tx, publicClient)
     }
   }
 }

--- a/packages/cli/src/commands/lockedcelo/revoke-delegate.test.ts
+++ b/packages/cli/src/commands/lockedcelo/revoke-delegate.test.ts
@@ -1,7 +1,6 @@
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { testLocallyWithNode } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Delegate from './delegate'
 import Lock from './lock'
@@ -9,30 +8,30 @@ import RevokeDelegate from './revoke-delegate'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('lockedgold:revoke-delegate cmd', (web3: Web3) => {
+testWithAnvilL2('lockedgold:revoke-delegate cmd', (provider) => {
   test('can revoke delegate', async () => {
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
     const account = accounts[0]
     const account2 = accounts[1]
-    const kit = newKitFromWeb3(web3)
     const lockedGold = await kit.contracts.getLockedGold()
-    await testLocallyWithWeb3Node(Register, ['--from', account], web3)
-    await testLocallyWithWeb3Node(Register, ['--from', account2], web3)
-    await testLocallyWithWeb3Node(Lock, ['--from', account, '--value', '200'], web3)
+    await testLocallyWithNode(Register, ['--from', account], provider)
+    await testLocallyWithNode(Register, ['--from', account2], provider)
+    await testLocallyWithNode(Lock, ['--from', account, '--value', '200'], provider)
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       Delegate,
       ['--from', account, '--to', account2, '--percent', '100'],
-      web3
+      provider
     )
 
     const account2VotingPower = await lockedGold.getAccountTotalGovernanceVotingPower(account2)
     expect(account2VotingPower.toFixed()).toBe('200')
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       RevokeDelegate,
       ['--from', account, '--to', account2, '--percent', '100'],
-      web3
+      provider
     )
 
     const account2VotingPowerAfterRevoke =

--- a/packages/cli/src/commands/lockedcelo/revoke-delegate.ts
+++ b/packages/cli/src/commands/lockedcelo/revoke-delegate.ts
@@ -3,7 +3,7 @@ import { Flags } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 import { LockedGoldArgs } from '../../utils/lockedgold'
 
@@ -31,6 +31,7 @@ export default class RevokeDelegate extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(RevokeDelegate)
     const address = res.flags.from
     const to = res.flags.to
@@ -51,6 +52,6 @@ export default class RevokeDelegate extends BaseCommand {
     const lockedGold = await kit.contracts.getLockedGold()
 
     const tx = lockedGold.revokeDelegated(to, percentFixed.toFixed())
-    await displaySendTx('revokeDelegated', tx)
+    await displayViemTx('revokeDelegated', tx, publicClient)
   }
 }

--- a/packages/cli/src/commands/lockedcelo/unlock.test.ts
+++ b/packages/cli/src/commands/lockedcelo/unlock.test.ts
@@ -1,8 +1,7 @@
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
-import Web3 from 'web3'
-import { LONG_TIMEOUT_MS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { LONG_TIMEOUT_MS, testLocallyWithNode } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Vote from '../election/vote'
 import ValidatorAffiliate from '../validator/affiliate'
@@ -14,57 +13,57 @@ import Unlock from './unlock'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('lockedcelo:unlock cmd', (web3: Web3) => {
+testWithAnvilL2('lockedcelo:unlock cmd', (provider) => {
   test(
     'can unlock correctly from registered validator group',
     async () => {
-      const accounts = await web3.eth.getAccounts()
+      const kit = newKitFromProvider(provider)
+      const accounts = await kit.connection.getAccounts()
       const account = accounts[0]
       const validator = accounts[1]
-      const kit = newKitFromWeb3(web3)
       const lockedGold = await kit.contracts.getLockedGold()
-      await testLocallyWithWeb3Node(Register, ['--from', account], web3)
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(Register, ['--from', account], provider)
+      await testLocallyWithNode(
         Lock,
         ['--from', account, '--value', '20000000000000000000000'],
-        web3
+        provider
       )
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         ValidatorGroupRegister,
         ['--from', account, '--commission', '0', '--yes'],
-        web3
+        provider
       )
-      await testLocallyWithWeb3Node(Register, ['--from', validator], web3)
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(Register, ['--from', validator], provider)
+      await testLocallyWithNode(
         Lock,
         ['--from', validator, '--value', '20000000000000000000000'],
-        web3
+        provider
       )
-      const ecdsaPublicKey = await addressToPublicKey(validator, web3.eth.sign)
-      await testLocallyWithWeb3Node(
+      const ecdsaPublicKey = await addressToPublicKey(validator, kit.connection.sign)
+      await testLocallyWithNode(
         ValidatorRegister,
         ['--from', validator, '--ecdsaKey', ecdsaPublicKey, '--yes'],
-        web3
+        provider
       )
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         ValidatorAffiliate,
         ['--yes', '--from', validator, account],
-        web3
+        provider
       )
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         ValidatorGroupMember,
         ['--yes', '--from', account, '--accept', validator],
-        web3
+        provider
       )
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         Vote,
         ['--from', account, '--for', account, '--value', '10000000000000000000000'],
-        web3
+        provider
       )
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         Unlock,
         ['--from', account, '--value', '10000000000000000000000'],
-        web3
+        provider
       )
       const pendingWithdrawalsTotalValue = await lockedGold.getPendingWithdrawalsTotalValue(account)
       expect(pendingWithdrawalsTotalValue.toFixed()).toBe('10000000000000000000000')

--- a/packages/cli/src/commands/lockedcelo/unlock.ts
+++ b/packages/cli/src/commands/lockedcelo/unlock.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 import { LockedGoldArgs } from '../../utils/lockedgold'
 
@@ -25,6 +25,7 @@ export default class Unlock extends BaseCommand {
   async run() {
     const res = await this.parse(Unlock)
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const lockedgold = await kit.contracts.getLockedGold()
     const value = new BigNumber(res.flags.value)
 
@@ -34,6 +35,6 @@ export default class Unlock extends BaseCommand {
       .hasEnoughLockedGoldToUnlock(value)
       .runChecks()
 
-    await displaySendTx('unlock', lockedgold.unlock(value))
+    await displayViemTx('unlock', lockedgold.unlock(value), publicClient)
   }
 }

--- a/packages/cli/src/commands/lockedcelo/update-delegated-amount.test.ts
+++ b/packages/cli/src/commands/lockedcelo/update-delegated-amount.test.ts
@@ -1,6 +1,6 @@
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { LONG_TIMEOUT_MS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { LONG_TIMEOUT_MS, testLocallyWithNode } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Delegate from './delegate'
 import Lock from './lock'
@@ -8,26 +8,27 @@ import UpdateDelegatedAmount from './update-delegated-amount'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('lockedgold:update-delegated-amount cmd', (web3: Web3) => {
+testWithAnvilL2('lockedgold:update-delegated-amount cmd', (provider) => {
   test(
     'can update delegated amount',
     async () => {
-      const accounts = await web3.eth.getAccounts()
+      const kit = newKitFromProvider(provider)
+      const accounts = await kit.connection.getAccounts()
       const account = accounts[0]
       const account2 = accounts[1]
-      await testLocallyWithWeb3Node(Register, ['--from', account], web3)
-      await testLocallyWithWeb3Node(Register, ['--from', account2], web3)
-      await testLocallyWithWeb3Node(Lock, ['--from', account, '--value', '200'], web3)
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(Register, ['--from', account], provider)
+      await testLocallyWithNode(Register, ['--from', account2], provider)
+      await testLocallyWithNode(Lock, ['--from', account, '--value', '200'], provider)
+      await testLocallyWithNode(
         Delegate,
         ['--from', account, '--to', account2, '--percent', '100'],
-        web3
+        provider
       )
 
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         UpdateDelegatedAmount,
         ['--from', account, '--to', account2],
-        web3
+        provider
       )
     },
     LONG_TIMEOUT_MS

--- a/packages/cli/src/commands/lockedcelo/update-delegated-amount.ts
+++ b/packages/cli/src/commands/lockedcelo/update-delegated-amount.ts
@@ -1,6 +1,6 @@
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class UpdateDelegatedAmount extends BaseCommand {
@@ -23,6 +23,7 @@ export default class UpdateDelegatedAmount extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(UpdateDelegatedAmount)
     const address = res.flags.from
     const to = res.flags.to
@@ -34,6 +35,6 @@ export default class UpdateDelegatedAmount extends BaseCommand {
     const lockedGold = await kit.contracts.getLockedGold()
 
     const tx = lockedGold.updateDelegatedAmount(address, to)
-    await displaySendTx('updateDelegatedAmount', tx)
+    await displayViemTx('updateDelegatedAmount', tx, publicClient)
   }
 }

--- a/packages/cli/src/commands/lockedcelo/withdraw.ts
+++ b/packages/cli/src/commands/lockedcelo/withdraw.ts
@@ -1,6 +1,6 @@
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class Withdraw extends BaseCommand {
@@ -18,6 +18,7 @@ export default class Withdraw extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags } = await this.parse(Withdraw)
     kit.defaultAccount = flags.from
     const lockedgold = await kit.contracts.getLockedGold()
@@ -34,7 +35,7 @@ export default class Withdraw extends BaseCommand {
           console.log(
             `Found available pending withdrawal of value ${pendingWithdrawal.value.toFixed()}, withdrawing`
           )
-          await displaySendTx('withdraw', lockedgold.withdraw(i))
+          await displayViemTx('withdraw', lockedgold.withdraw(i), publicClient)
           madeWithdrawal = true
         }
       }

--- a/packages/cli/src/commands/multisig/approve.test.ts
+++ b/packages/cli/src/commands/multisig/approve.test.ts
@@ -1,15 +1,14 @@
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import ApproveMultiSig from './approve'
 import ProposeMultiSig from './propose'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('multisig:approve integration tests', (web3: Web3) => {
+testWithAnvilL2('multisig:approve integration tests', (provider) => {
   let kit: ContractKit
   let accounts: StrongAddress[]
   let multisigAddress: StrongAddress
@@ -19,8 +18,8 @@ testWithAnvilL2('multisig:approve integration tests', (web3: Web3) => {
   let nonOwner: StrongAddress
 
   beforeAll(async () => {
-    kit = newKitFromWeb3(web3)
-    accounts = (await web3.eth.getAccounts()) as StrongAddress[]
+    kit = newKitFromProvider(provider)
+    accounts = (await kit.connection.getAccounts()) as StrongAddress[]
 
     // Set up test accounts
     owner1 = accounts[0]
@@ -52,14 +51,14 @@ testWithAnvilL2('multisig:approve integration tests', (web3: Web3) => {
       const value = (10 ** 18).toString() // 1 CELO in wei
 
       // Propose transaction using owner1
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         ProposeMultiSig,
         [multisigAddress, '--from', owner1, '--to', recipient, '--value', value],
-        web3
+        provider
       )
 
       // Now approve the transaction using owner2
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         ApproveMultiSig,
         [
           '--from',
@@ -69,7 +68,7 @@ testWithAnvilL2('multisig:approve integration tests', (web3: Web3) => {
           '--tx',
           '0', // First transaction
         ],
-        web3
+        provider
       )
       expect(logMock).toHaveBeenCalledWith(
         expect.stringContaining(`The provided address is an owner of the multisig`)
@@ -78,17 +77,17 @@ testWithAnvilL2('multisig:approve integration tests', (web3: Web3) => {
 
     it('fails when non-owner tries to approve', async () => {
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           ApproveMultiSig,
           ['--from', nonOwner, '--for', multisigAddress, '--tx', '0'],
-          web3
+          provider
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     })
 
     it('fails when approving non-existent transaction', async () => {
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           ApproveMultiSig,
           [
             '--from',
@@ -98,17 +97,17 @@ testWithAnvilL2('multisig:approve integration tests', (web3: Web3) => {
             '--tx',
             '999', // Non-existent transaction
           ],
-          web3
+          provider
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     })
 
     it('fails with invalid multisig address', async () => {
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           ApproveMultiSig,
           ['--from', owner1, '--for', '0x0000000000000000000000000000000000000000', '--tx', '0'],
-          web3
+          provider
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         "The contract function "getOwners" returned no data ("0x").
@@ -134,10 +133,10 @@ testWithAnvilL2('multisig:approve integration tests', (web3: Web3) => {
       const logMock = jest.spyOn(console, 'log')
 
       // Propose transaction using owner1
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         ProposeMultiSig,
         [multisigAddress, '--from', owner1, '--to', recipient, '--value', value],
-        web3
+        provider
       )
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [
@@ -167,10 +166,10 @@ testWithAnvilL2('multisig:approve integration tests', (web3: Web3) => {
 
       // Approve with owner2
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           ApproveMultiSig,
           ['--from', owner2, '--for', multisigAddress, '--tx', '0'],
-          web3
+          provider
         )
       ).resolves.toBeUndefined()
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
@@ -219,10 +218,10 @@ testWithAnvilL2('multisig:approve integration tests', (web3: Web3) => {
 
       // Try to approve again with owner3 (should fail if already approved)
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           ApproveMultiSig,
           ['--from', owner3, '--for', multisigAddress, '--tx', '1'],
-          web3
+          provider
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     })

--- a/packages/cli/src/commands/multisig/propose.test.ts
+++ b/packages/cli/src/commands/multisig/propose.test.ts
@@ -1,11 +1,10 @@
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
 import {
   stripAnsiCodesAndTxHashes,
   testLocally,
-  testLocallyWithWeb3Node,
+  testLocallyWithNode,
 } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import ProposeMultiSig from './propose'
@@ -50,7 +49,7 @@ describe('multisig:propose cmd', () => {
   })
 })
 
-testWithAnvilL2('multisig:propose integration tests', (web3: Web3) => {
+testWithAnvilL2('multisig:propose integration tests', (provider) => {
   let kit: ContractKit
   let accounts: StrongAddress[]
   let multisigAddress: StrongAddress
@@ -60,8 +59,8 @@ testWithAnvilL2('multisig:propose integration tests', (web3: Web3) => {
   let nonOwner: StrongAddress
 
   beforeAll(async () => {
-    kit = newKitFromWeb3(web3)
-    accounts = (await web3.eth.getAccounts()) as StrongAddress[]
+    kit = newKitFromProvider(provider)
+    accounts = (await kit.connection.getAccounts()) as StrongAddress[]
 
     // Set up test accounts
     owner1 = accounts[0]
@@ -100,10 +99,10 @@ testWithAnvilL2('multisig:propose integration tests', (web3: Web3) => {
       const recipient = accounts[4]
       const value = (10 ** 18).toString() // 1 CELO in wei
 
-      const result = await testLocallyWithWeb3Node(
+      const result = await testLocallyWithNode(
         ProposeMultiSig,
         [multisigAddress, '--from', owner1, '--to', recipient, '--value', value],
-        web3
+        provider
       )
       expectLogs(logMock).toMatchInlineSnapshot(`
         [
@@ -118,10 +117,10 @@ testWithAnvilL2('multisig:propose integration tests', (web3: Web3) => {
       const data =
         '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000000064'
 
-      const result = await testLocallyWithWeb3Node(
+      const result = await testLocallyWithNode(
         ProposeMultiSig,
         [multisigAddress, '--from', owner2, '--to', recipient, '--data', data],
-        web3
+        provider
       )
       expectLogs(logMock).toMatchInlineSnapshot(`
         [
@@ -137,10 +136,10 @@ testWithAnvilL2('multisig:propose integration tests', (web3: Web3) => {
       const value = '500000000000000000' // 0.5 CELO in wei
       const data = '0x'
 
-      const result = await testLocallyWithWeb3Node(
+      const result = await testLocallyWithNode(
         ProposeMultiSig,
         [multisigAddress, '--from', owner3, '--to', recipient, '--value', value, '--data', data],
-        web3
+        provider
       )
       expectLogs(logMock).toMatchInlineSnapshot(`
         [
@@ -156,10 +155,10 @@ testWithAnvilL2('multisig:propose integration tests', (web3: Web3) => {
       const value = '100000000000000000'
 
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           ProposeMultiSig,
           [multisigAddress, '--from', nonOwner, '--to', recipient, '--value', value],
-          web3
+          provider
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     })
@@ -169,7 +168,7 @@ testWithAnvilL2('multisig:propose integration tests', (web3: Web3) => {
       const value = '100000000000000000'
 
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           ProposeMultiSig,
           [
             '0x0000000000000000000000000000000000000000',
@@ -181,7 +180,7 @@ testWithAnvilL2('multisig:propose integration tests', (web3: Web3) => {
             value,
           ],
 
-          web3
+          provider
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         "The contract function "getOwners" returned no data ("0x").
@@ -204,7 +203,7 @@ testWithAnvilL2('multisig:propose integration tests', (web3: Web3) => {
       const value = '100000000000000000'
 
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           ProposeMultiSig,
           [
             multisigAddress,
@@ -216,7 +215,7 @@ testWithAnvilL2('multisig:propose integration tests', (web3: Web3) => {
             value,
           ],
 
-          web3
+          provider
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         "Parsing --to 

--- a/packages/cli/src/commands/multisig/show.test.ts
+++ b/packages/cli/src/commands/multisig/show.test.ts
@@ -1,15 +1,14 @@
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import ProposeMultiSig from './propose'
 import ShowMultiSig from './show'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('multisig:show integration tests', (web3: Web3) => {
+testWithAnvilL2('multisig:show integration tests', (provider) => {
   let kit: ContractKit
   let accounts: StrongAddress[]
   let multisigAddress: StrongAddress
@@ -18,8 +17,8 @@ testWithAnvilL2('multisig:show integration tests', (web3: Web3) => {
   let owner3: StrongAddress
 
   beforeAll(async () => {
-    kit = newKitFromWeb3(web3)
-    accounts = (await web3.eth.getAccounts()) as StrongAddress[]
+    kit = newKitFromProvider(provider)
+    accounts = (await kit.connection.getAccounts()) as StrongAddress[]
 
     // Set up test accounts
     owner1 = accounts[0]
@@ -45,7 +44,7 @@ testWithAnvilL2('multisig:show integration tests', (web3: Web3) => {
   describe('show multisig information', () => {
     it('shows basic multisig information', async () => {
       const logMock = jest.spyOn(console, 'log')
-      await testLocallyWithWeb3Node(ShowMultiSig, [multisigAddress], web3)
+      await testLocallyWithNode(ShowMultiSig, [multisigAddress], provider)
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [
           [
@@ -66,18 +65,18 @@ testWithAnvilL2('multisig:show integration tests', (web3: Web3) => {
       const recipient = accounts[4]
       const value = (10 ** 18).toString() // 1 CELO in wei
 
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         ProposeMultiSig,
         [multisigAddress, '--from', owner1, '--to', recipient, '--value', value],
-        web3
+        provider
       )
       const logMock = jest.spyOn(console, 'log')
 
       // Now show the specific transaction
-      const result = await testLocallyWithWeb3Node(
+      const result = await testLocallyWithNode(
         ShowMultiSig,
         [multisigAddress, '--tx', '0'],
-        web3
+        provider
       )
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [
@@ -124,7 +123,7 @@ testWithAnvilL2('multisig:show integration tests', (web3: Web3) => {
     it('shows raw transaction data', async () => {
       const logMock = jest.spyOn(console, 'log')
 
-      await testLocallyWithWeb3Node(ShowMultiSig, [multisigAddress, '--all', '--raw'], web3)
+      await testLocallyWithNode(ShowMultiSig, [multisigAddress, '--all', '--raw'], provider)
 
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [
@@ -144,7 +143,7 @@ testWithAnvilL2('multisig:show integration tests', (web3: Web3) => {
 
     it('fails with invalid multisig address', async () => {
       await expect(
-        testLocallyWithWeb3Node(ShowMultiSig, ['0x0000000000000000000000000000000000000000'], web3)
+        testLocallyWithNode(ShowMultiSig, ['0x0000000000000000000000000000000000000000'], provider)
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         "The contract function "getTransactionCount" returned no data ("0x").
 
@@ -167,7 +166,7 @@ testWithAnvilL2('multisig:show integration tests', (web3: Web3) => {
       const logMock = jest.spyOn(console, 'log')
 
       await expect(
-        testLocallyWithWeb3Node(ShowMultiSig, [multisigAddress, '--tx', '999271717'], web3)
+        testLocallyWithNode(ShowMultiSig, [multisigAddress, '--tx', '999271717'], provider)
       ).resolves.toBeUndefined()
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [
@@ -195,19 +194,19 @@ testWithAnvilL2('multisig:show integration tests', (web3: Web3) => {
       const data =
         '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000000064'
 
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         ProposeMultiSig,
         [multisigAddress, '--from', owner3, '--to', recipient, '--data', data],
-        web3
+        provider
       )
       const logMock = jest.spyOn(console, 'log')
 
       // Show the transaction with data
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           ShowMultiSig,
           [multisigAddress, '--tx', '2'], // Third transaction
-          web3
+          provider
         )
       ).resolves.toBeUndefined()
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`

--- a/packages/cli/src/commands/multisig/transfer.test.ts
+++ b/packages/cli/src/commands/multisig/transfer.test.ts
@@ -1,14 +1,13 @@
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import MultiSigTransfer from './transfer'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
+testWithAnvilL2('multisig:transfer integration tests', (provider) => {
   let kit: ContractKit
   let accounts: StrongAddress[]
   let multisigAddress: StrongAddress
@@ -18,8 +17,8 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
   let nonOwner: StrongAddress
 
   beforeAll(async () => {
-    kit = newKitFromWeb3(web3)
-    accounts = (await web3.eth.getAccounts()) as StrongAddress[]
+    kit = newKitFromProvider(provider)
+    accounts = (await kit.connection.getAccounts()) as StrongAddress[]
     console.warn('Accounts:', accounts)
     // Set up test accounts
     owner1 = accounts[0]
@@ -48,10 +47,10 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
       const recipient = accounts[4]
       const amount = (10 ** 18).toString() // 1 CELO in wei
 
-      const result = await testLocallyWithWeb3Node(
+      const result = await testLocallyWithNode(
         MultiSigTransfer,
         [multisigAddress, '--to', recipient, '--amount', amount, '--from', owner1],
-        web3
+        provider
       )
 
       expect(result).toBeUndefined()
@@ -62,17 +61,17 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
       const amount = '2000000000000000000' // 2 CELO in wei
 
       // First owner proposes the transfer
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         MultiSigTransfer,
         [multisigAddress, '--to', recipient, '--amount', amount, '--from', owner1],
-        web3
+        provider
       )
 
       // Second owner approves the same transfer (should find existing transaction)
-      const result = await testLocallyWithWeb3Node(
+      const result = await testLocallyWithNode(
         MultiSigTransfer,
         [multisigAddress, '--to', recipient, '--amount', amount, '--from', owner2],
-        web3
+        provider
       )
 
       expect(result).toBeUndefined()
@@ -83,7 +82,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
       const recipient = accounts[6]
       const amount = '100000000000000000'
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           MultiSigTransfer,
           [
             multisigAddress,
@@ -98,7 +97,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
             '--transferFrom',
           ],
 
-          web3
+          provider
         )
       ).rejects.toThrow("Some checks didn't pass!")
       expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
@@ -118,7 +117,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
       const amount = '100000000000000000'
 
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           MultiSigTransfer,
           [
             '0x0000000000000000000000000000000000000000',
@@ -130,7 +129,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
             owner1,
           ],
 
-          web3
+          provider
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         "The contract function "getOwners" returned no data ("0x").
@@ -153,7 +152,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
       const amount = '100000000000000000'
 
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           MultiSigTransfer,
           [
             multisigAddress,
@@ -165,7 +164,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
             owner1,
           ],
 
-          web3
+          provider
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         "Parsing --to 
@@ -178,10 +177,10 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
       const recipient = accounts[8]
 
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           MultiSigTransfer,
           [multisigAddress, '--to', recipient, '--amount', 'not-a-number', '--from', owner1],
-          web3
+          provider
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         "Parsing --amount 
@@ -194,7 +193,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
       const recipient = accounts[9]
 
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           MultiSigTransfer,
           [
             multisigAddress,
@@ -207,7 +206,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
             owner1,
           ],
 
-          web3
+          provider
         )
       ).rejects.toThrow()
     })
@@ -217,7 +216,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
       const recipient = accounts[6]
       const amount = '3000000000000000000' // 3 CELO in wei
 
-      const result = await testLocallyWithWeb3Node(
+      const result = await testLocallyWithNode(
         MultiSigTransfer,
         [
           multisigAddress,
@@ -231,7 +230,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
           '--from',
           owner1,
         ],
-        web3
+        provider
       )
 
       expect(result).toBeUndefined()
@@ -245,7 +244,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
       const logMock = jest.spyOn(console, 'log')
 
       // First owner proposes the transferFrom
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         MultiSigTransfer,
         [
           multisigAddress,
@@ -259,7 +258,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
           '--from',
           owner1,
         ],
-        web3
+        provider
       )
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [
@@ -282,7 +281,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
       `)
 
       // Second owner approves the same transferFrom (should find existing transaction)
-      const result = await testLocallyWithWeb3Node(
+      const result = await testLocallyWithNode(
         MultiSigTransfer,
         [
           multisigAddress,
@@ -296,7 +295,7 @@ testWithAnvilL2('multisig:transfer integration tests', (web3: Web3) => {
           '--from',
           owner2,
         ],
-        web3
+        provider
       )
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [

--- a/packages/cli/src/commands/network/contracts.test.ts
+++ b/packages/cli/src/commands/network/contracts.test.ts
@@ -1,56 +1,60 @@
-import { newICeloVersionedContract } from '@celo/abis/web3/ICeloVersionedContract'
+import { Connection } from '@celo/connect'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import write from '@oclif/core/lib/cli-ux/write'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { testLocallyWithNode } from '../../test-utils/cliUtils'
 import Contracts from './contracts'
 process.env.NO_SYNCCHECK = 'true'
-jest.mock('@celo/abis/web3/ICeloVersionedContract')
 
-testWithAnvilL2('network:contracts', (web3) => {
+testWithAnvilL2('network:contracts', (provider) => {
   describe('when version can be obtained', () => {
-    beforeEach(() => {
-      jest.unmock('@celo/abis/web3/ICeloVersionedContract')
-      jest.resetModules()
-      const actual = jest.requireActual('@celo/abis/web3/ICeloVersionedContract')
-      // @ts-expect-error
-      newICeloVersionedContract.mockImplementation(actual.newICeloVersionedContract)
-    })
     test('runs', async () => {
       const spy = jest.spyOn(write, 'stdout')
       const warnSpy = jest.spyOn(console, 'warn')
       expect(warnSpy.mock.calls).toMatchInlineSnapshot(`[]`)
-      await testLocallyWithWeb3Node(Contracts, ['--output', 'json'], web3)
+      await testLocallyWithNode(Contracts, ['--output', 'json'], provider)
       expect(spy.mock.calls).toMatchSnapshot()
     })
   })
   describe('when version cant be obtained', () => {
+    // Capture the real viemClient getter before any spying
+    const realViemClientGetter = Object.getOwnPropertyDescriptor(
+      Connection.prototype,
+      'viemClient'
+    )!.get!
+
+    let viemClientSpy: jest.SpyInstance
     beforeEach(() => {
-      // @ts-expect-error
-      newICeloVersionedContract.mockImplementation((_, address) => {
-        return {
-          methods: {
-            getVersionNumber: jest.fn().mockImplementation(() => {
-              // fake governance slasher
-              if (address === '0x76C05a43234EB2804aa83Cd40BA10080a43d07AE') {
-                return { call: jest.fn().mockRejectedValue(new Error('Error: execution reverted')) }
-              } else {
-                // return a fake normal version
-                return { call: jest.fn().mockResolvedValue([1, 2, 3, 4]) }
+      const modifiedClients = new WeakSet()
+      viemClientSpy = jest
+        .spyOn(Connection.prototype, 'viemClient', 'get')
+        .mockImplementation(function (this: Connection) {
+          const client = realViemClientGetter.call(this)
+          if (!modifiedClients.has(client)) {
+            const origCall = client.call.bind(client)
+            // Intercept getVersionNumber() calls (selector 0x54255be0)
+            // and return ABI-encoded [1, 2, 3, 4] for deterministic version output
+            client.call = async (params: any) => {
+              if (params?.data?.startsWith?.('0x54255be0')) {
+                return {
+                  data: '0x0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004',
+                }
               }
-            }),
-          },
-        }
-      })
+              return origCall(params)
+            }
+            modifiedClients.add(client)
+          }
+          return client
+        })
     })
     afterEach(() => {
+      viemClientSpy.mockRestore()
       jest.clearAllMocks()
-      jest.resetModules()
     })
     it('still prints rest of contracts', async () => {
       const spy = jest.spyOn(write, 'stdout')
       const warnSpy = jest.spyOn(console, 'warn')
 
-      await testLocallyWithWeb3Node(Contracts, ['--output', 'json'], web3)
+      await testLocallyWithNode(Contracts, ['--output', 'json'], provider)
       expect(warnSpy.mock.calls).toMatchInlineSnapshot(`[]`)
       expect(spy.mock.calls).toMatchSnapshot() // see the file for the snapshot
     })

--- a/packages/cli/src/commands/network/contracts.ts
+++ b/packages/cli/src/commands/network/contracts.ts
@@ -1,5 +1,5 @@
-import { newICeloVersionedContract } from '@celo/abis/web3/ICeloVersionedContract'
-import { newProxy } from '@celo/abis/web3/Proxy'
+import { decodeFunctionResult, encodeFunctionData } from 'viem'
+import { iCeloVersionedContractABI, proxyABI } from '@celo/abis'
 import { concurrentMap } from '@celo/base'
 import { CeloContract } from '@celo/contractkit'
 import { ux } from '@oclif/core'
@@ -39,7 +39,21 @@ export default class Contracts extends BaseCommand {
           implementation = 'NONE'
         } else {
           try {
-            implementation = await newProxy(kit.web3, proxy).methods._getImplementation().call()
+            const proxyContract = kit.connection.getCeloContract(proxyABI as any, proxy)
+            const implCallData = encodeFunctionData({
+              abi: proxyContract.abi,
+              functionName: '_getImplementation',
+              args: [],
+            })
+            const { data: implResultData } = await kit.connection.viemClient.call({
+              to: proxyContract.address,
+              data: implCallData,
+            })
+            implementation = decodeFunctionResult({
+              abi: proxyContract.abi,
+              functionName: '_getImplementation',
+              data: implResultData!,
+            }) as string
           } catch (e) {
             // if we fail to get implementation that means it doesnt have one so set it to NONE
             implementation = 'NONE'
@@ -51,9 +65,24 @@ export default class Contracts extends BaseCommand {
           version = 'NONE'
         } else {
           try {
-            const raw = await newICeloVersionedContract(kit.web3, implementation)
-              .methods.getVersionNumber()
-              .call()
+            const versionContract = kit.connection.getCeloContract(
+              iCeloVersionedContractABI as any,
+              implementation
+            )
+            const versionCallData = encodeFunctionData({
+              abi: versionContract.abi,
+              functionName: 'getVersionNumber',
+              args: [],
+            })
+            const { data: versionResultData } = await kit.connection.viemClient.call({
+              to: versionContract.address,
+              data: versionCallData,
+            })
+            const raw = decodeFunctionResult({
+              abi: versionContract.abi,
+              functionName: 'getVersionNumber',
+              data: versionResultData!,
+            }) as readonly [unknown, unknown, unknown, unknown]
             version = `${raw[0]}.${raw[1]}.${raw[2]}.${raw[3]}`
           } catch (e) {
             console.warn(`Failed to get version for ${contract} at ${proxy}`)

--- a/packages/cli/src/commands/network/info.test.ts
+++ b/packages/cli/src/commands/network/info.test.ts
@@ -1,28 +1,28 @@
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { timeTravel } from '@celo/dev-utils/ganache-test'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import EpochsSwitch from '../epochs/switch'
 import Info from './info'
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('network:info', (web3) => {
+testWithAnvilL2('network:info', (provider) => {
   beforeAll(async () => {
-    const kit = newKitFromWeb3(web3)
+    const kit = newKitFromProvider(provider)
     const epochManager = await kit.contracts.getEpochManager()
     const epochDuration = await epochManager.epochDuration()
-    const accounts = await web3.eth.getAccounts()
+    const accounts = await kit.connection.getAccounts()
 
     // Switch epochs 3 times
     for (let i = 0; i < 3; i++) {
-      await timeTravel(epochDuration * 2, web3)
-      await testLocallyWithWeb3Node(EpochsSwitch, ['--from', accounts[0], '--delay', '1'], web3)
+      await timeTravel(epochDuration * 2, provider)
+      await testLocallyWithNode(EpochsSwitch, ['--from', accounts[0], '--delay', '1'], provider)
     }
-  })
+  }, 60000)
 
   it('runs for latest epoch', async () => {
     const spy = jest.spyOn(console, 'log')
-    await testLocallyWithWeb3Node(Info, [], web3)
+    await testLocallyWithNode(Info, [], provider)
 
     expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
       [
@@ -39,7 +39,7 @@ testWithAnvilL2('network:info', (web3) => {
 
   it('runs for last 3 epochs', async () => {
     const spy = jest.spyOn(console, 'log')
-    await testLocallyWithWeb3Node(Info, ['--lastN', '3'], web3)
+    await testLocallyWithNode(Info, ['--lastN', '3'], provider)
 
     expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
       [
@@ -65,7 +65,7 @@ testWithAnvilL2('network:info', (web3) => {
 
   it('runs for last 100 epochs, but displays only epoch that exist', async () => {
     const spy = jest.spyOn(console, 'log')
-    await testLocallyWithWeb3Node(Info, ['--lastN', '100'], web3)
+    await testLocallyWithNode(Info, ['--lastN', '100'], provider)
 
     expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
       [

--- a/packages/cli/src/commands/network/parameters.test.ts
+++ b/packages/cli/src/commands/network/parameters.test.ts
@@ -1,13 +1,13 @@
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import Parameters from './parameters'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('network:parameters', (web3) => {
+testWithAnvilL2('network:parameters', (provider) => {
   test('runs', async () => {
     const spy = jest.spyOn(console, 'log')
-    await testLocallyWithWeb3Node(Parameters, [], web3)
+    await testLocallyWithNode(Parameters, [], provider)
     expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
       [
         [

--- a/packages/cli/src/commands/network/whitelist.test.ts
+++ b/packages/cli/src/commands/network/whitelist.test.ts
@@ -1,12 +1,11 @@
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { ux } from '@oclif/core'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import Whitelist from './whitelist'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('network:whitelist cmd', (web3: Web3) => {
+testWithAnvilL2('network:whitelist cmd', (provider) => {
   const writeMock = jest.spyOn(ux.write, 'stdout')
 
   afterAll(() => {
@@ -14,7 +13,7 @@ testWithAnvilL2('network:whitelist cmd', (web3: Web3) => {
   })
 
   it('can print the whitelist', async () => {
-    await testLocallyWithWeb3Node(Whitelist, [], web3)
+    await testLocallyWithNode(Whitelist, [], provider)
 
     expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
       [
@@ -42,7 +41,7 @@ testWithAnvilL2('network:whitelist cmd', (web3: Web3) => {
     `)
   })
   it('modifies output when formating flag is passed', async () => {
-    await testLocallyWithWeb3Node(Whitelist, ['--output=json'], web3)
+    await testLocallyWithNode(Whitelist, ['--output=json'], provider)
 
     expect(writeMock.mock.calls).toMatchInlineSnapshot(`
       [

--- a/packages/cli/src/commands/oracle/remove-expired-reports.ts
+++ b/packages/cli/src/commands/oracle/remove-expired-reports.ts
@@ -1,7 +1,7 @@
 import { CeloContract } from '@celo/contractkit'
 import { Args } from '@oclif/core'
 import { BaseCommand } from '../../base'
-import { displaySendTx, failWith } from '../../utils/cli'
+import { displayViemTx, failWith } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class RemoveExpiredReports extends BaseCommand {
@@ -31,10 +31,11 @@ export default class RemoveExpiredReports extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(RemoveExpiredReports)
 
     const sortedOracles = await kit.contracts.getSortedOracles().catch((e) => failWith(e))
-    const txo = await sortedOracles.removeExpiredReports(res.args.arg1 as string)
-    await displaySendTx('removeExpiredReports', txo)
+    const txo = sortedOracles.removeExpiredReports(res.args.arg1 as string)
+    await displayViemTx('removeExpiredReports', txo, publicClient)
   }
 }

--- a/packages/cli/src/commands/oracle/report.ts
+++ b/packages/cli/src/commands/oracle/report.ts
@@ -2,7 +2,7 @@ import { CeloContract } from '@celo/contractkit'
 import { Args, Flags } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import { BaseCommand } from '../../base'
-import { displaySendTx, failWith } from '../../utils/cli'
+import { displayViemTx, failWith } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class ReportPrice extends BaseCommand {
@@ -33,15 +33,17 @@ export default class ReportPrice extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(ReportPrice)
     const sortedOracles = await kit.contracts.getSortedOracles()
     const value = new BigNumber(res.flags.value)
 
-    await displaySendTx(
+    await displayViemTx(
       'sortedOracles.report',
-      await sortedOracles
+      sortedOracles
         .report(res.args.arg1 as string, value, res.flags.from)
-        .catch((e) => failWith(e))
+        .catch((e) => failWith(e)),
+      publicClient
     )
     this.log(`Reported oracle value: ${value.toString()} ${res.args.arg1} == 1 CELO`)
   }

--- a/packages/cli/src/commands/rewards/show.test.ts
+++ b/packages/cli/src/commands/rewards/show.test.ts
@@ -1,4 +1,4 @@
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { ElectionWrapper } from '@celo/contractkit/lib/wrappers/Election'
 import { LockedGoldWrapper } from '@celo/contractkit/lib/wrappers/LockedGold'
 import { ValidatorsWrapper } from '@celo/contractkit/lib/wrappers/Validators'
@@ -6,16 +6,15 @@ import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { timeTravel } from '@celo/dev-utils/ganache-test'
 import { ux } from '@oclif/core'
 import BigNumber from 'bignumber.js'
-import Web3 from 'web3'
 import { registerAccount } from '../../test-utils/chain-setup'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import Switch from '../epochs/switch'
 import Show from './show'
 
 process.env.NO_SYNCCHECK = 'true'
 const KNOWN_DEVCHAIN_VALIDATOR = '0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f'
 
-testWithAnvilL2('rewards:show cmd', (web3: Web3) => {
+testWithAnvilL2('rewards:show cmd', (provider) => {
   let kit: ContractKit
   let accounts: string[]
   const writeMock = jest.spyOn(ux.write, 'stdout')
@@ -23,17 +22,17 @@ testWithAnvilL2('rewards:show cmd', (web3: Web3) => {
   const infoMock = jest.spyOn(console, 'info')
 
   beforeEach(async () => {
-    kit = newKitFromWeb3(web3)
-    accounts = await web3.eth.getAccounts()
+    kit = newKitFromProvider(provider)
+    accounts = await kit.connection.getAccounts()
     const epochManager = await kit.contracts.getEpochManager()
-    await timeTravel((await epochManager.epochDuration()) + 1, web3)
-    await testLocallyWithWeb3Node(Switch, ['--from', accounts[0]], web3)
+    await timeTravel((await epochManager.epochDuration()) + 1, provider)
+    await testLocallyWithNode(Switch, ['--from', accounts[0]], provider)
     jest.clearAllMocks()
-  })
+  }, 60000)
 
   describe('no arguments', () => {
     test('default', async () => {
-      await expect(testLocallyWithWeb3Node(Show, [], web3)).resolves.toBeUndefined()
+      await expect(testLocallyWithNode(Show, [], provider)).resolves.toBeUndefined()
       expect(stripAnsiCodesFromNestedArray(infoMock.mock.calls)).toMatchInlineSnapshot(`
         [
           [
@@ -49,7 +48,7 @@ testWithAnvilL2('rewards:show cmd', (web3: Web3) => {
         .mockImplementationOnce(async () => {
           throw new Error('test missing trie node')
         })
-      await expect(testLocallyWithWeb3Node(Show, [], web3)).rejects.toMatchInlineSnapshot(`
+      await expect(testLocallyWithNode(Show, [], provider)).rejects.toMatchInlineSnapshot(`
         [Error: Exact voter information is available only for 1024 blocks after each epoch.
         Supply --estimate to estimate rewards based on current votes, or use an archive node.]
       `)
@@ -59,10 +58,10 @@ testWithAnvilL2('rewards:show cmd', (web3: Web3) => {
   describe('--validator', () => {
     test('invalid', async () => {
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           Show,
           ['--validator', '0x1234567890123456789012345678901234567890'],
-          web3
+          provider
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
@@ -78,7 +77,7 @@ testWithAnvilL2('rewards:show cmd', (web3: Web3) => {
     })
 
     test('valid', async () => {
-      await testLocallyWithWeb3Node(Show, ['--validator', KNOWN_DEVCHAIN_VALIDATOR], web3)
+      await testLocallyWithNode(Show, ['--validator', KNOWN_DEVCHAIN_VALIDATOR], provider)
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [
           [
@@ -148,7 +147,7 @@ testWithAnvilL2('rewards:show cmd', (web3: Web3) => {
         },
       ])
 
-      await testLocallyWithWeb3Node(Show, ['--validator', KNOWN_DEVCHAIN_VALIDATOR], web3)
+      await testLocallyWithNode(Show, ['--validator', KNOWN_DEVCHAIN_VALIDATOR], provider)
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [
           [
@@ -194,10 +193,10 @@ testWithAnvilL2('rewards:show cmd', (web3: Web3) => {
   describe('--voter', () => {
     test('invalid', async () => {
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           Show,
           ['--voter', '0x1234567890123456789012345678901234567890'],
-          web3
+          provider
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
@@ -214,7 +213,7 @@ testWithAnvilL2('rewards:show cmd', (web3: Web3) => {
     test('valid', async () => {
       await registerAccount(kit, accounts[0])
       await expect(
-        testLocallyWithWeb3Node(Show, ['--voter', accounts[0], '--estimate'], web3)
+        testLocallyWithNode(Show, ['--voter', accounts[0], '--estimate'], provider)
       ).resolves.toMatchInlineSnapshot(`undefined`)
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [

--- a/packages/cli/src/commands/rewards/show.ts
+++ b/packages/cli/src/commands/rewards/show.ts
@@ -89,7 +89,7 @@ export default class Show extends BaseCommand {
         const electedValidators = (await Promise.all(
           (
             await epochManager!.getElectedSigners()
-          ).map(async (x) => ({
+          ).map(async (x: string) => ({
             address: x,
             score: await scoreManager.getValidatorScore(x),
           }))

--- a/packages/cli/src/commands/transfer/celo.test.ts
+++ b/packages/cli/src/commands/transfer/celo.test.ts
@@ -1,18 +1,17 @@
 import { goldTokenABI } from '@celo/abis'
 import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
-import { ContractKit, newKitFromWeb3, StableToken } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider, StableToken } from '@celo/contractkit'
 import { setBalance, testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { TEST_GAS_PRICE } from '@celo/dev-utils/test-utils'
 import BigNumber from 'bignumber.js'
 import { Address, createPublicClient, formatEther, http, parseEther } from 'viem'
 import { celo } from 'viem/chains'
-import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
 import {
-  extractHostFromWeb3,
+  extractHostFromProvider,
   stripAnsiCodesFromNestedArray,
   TEST_SANCTIONED_ADDRESS,
-  testLocallyWithWeb3Node,
+  testLocallyWithNode,
 } from '../../test-utils/cliUtils'
 import { mockRpcFetch } from '../../test-utils/mockRpc'
 import TransferCelo from './celo'
@@ -22,15 +21,15 @@ process.env.NO_SYNCCHECK = 'true'
 // Lots of commands, sometimes times out
 jest.setTimeout(15000)
 
-testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
+testWithAnvilL2('transfer:celo cmd', (provider) => {
   let accounts: string[] = []
   let kit: ContractKit
   let restoreMock: () => void
 
   beforeEach(async () => {
     restoreMock = mockRpcFetch({ method: 'eth_gasPrice', result: TEST_GAS_PRICE })
-    kit = newKitFromWeb3(web3)
-    accounts = await web3.eth.getAccounts()
+    kit = newKitFromProvider(provider)
+    accounts = await kit.connection.getAccounts()
 
     jest.spyOn(console, 'log').mockImplementation(() => {
       // noop
@@ -63,7 +62,7 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
     const receiverBalanceBefore = await kit.getTotalBalance(accounts[1])
     const amountToTransfer = '500000000000000000000'
     // Send USDm to RG contract
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferCelo,
       [
         '--from',
@@ -75,21 +74,23 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
         '--gasCurrency',
         (await kit.contracts.getStableToken(StableToken.USDm)).address,
       ],
-      web3
+      provider
     )
     // RG USDm balance should match the amount sent
     const receiverBalance = await kit.getTotalBalance(accounts[1])
     expect(receiverBalance.CELO!.toFixed()).toEqual(
       receiverBalanceBefore.CELO!.plus(amountToTransfer).toFixed()
     )
-    let block = await web3.eth.getBlock('latest')
-    let transactionReceipt = await web3.eth.getTransactionReceipt(block.transactions[0])
+    let block = await kit.connection.viemClient.getBlock({ blockTag: 'latest' })
+    let transactionReceipt = await kit.connection.viemClient.getTransactionReceipt({
+      hash: block.transactions[0],
+    })
 
     // Safety check if the latest transaction was originated by expected account
     expect(transactionReceipt.from.toLowerCase()).toEqual(accounts[0].toLowerCase())
 
     // Attempt to send USDm back
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferCelo,
       [
         '--from',
@@ -101,10 +102,12 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
         '--gasCurrency',
         (await kit.contracts.getStableToken(StableToken.USDm)).address,
       ],
-      web3
+      provider
     )
-    block = await web3.eth.getBlock('latest')
-    transactionReceipt = await web3.eth.getTransactionReceipt(block.transactions[0])
+    block = await kit.connection.viemClient.getBlock({ blockTag: 'latest' })
+    transactionReceipt = await kit.connection.viemClient.getTransactionReceipt({
+      hash: block.transactions[0],
+    })
 
     // Safety check if the latest transaction was originated by expected account
     expect(transactionReceipt.from.toLowerCase()).toEqual(accounts[1].toLowerCase())
@@ -113,7 +116,7 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
     // the balance should be close to initial minus the fees for gas times 2 (one for each transfer)
     const estimatedBalance = BigInt(
       balanceBefore
-        .minus(transactionReceipt.effectiveGasPrice * transactionReceipt.gasUsed * 2)
+        .minus((transactionReceipt.effectiveGasPrice * transactionReceipt.gasUsed * 2n).toString())
         .toFixed()
     )
     expect(Number(formatEther(BigInt(balanceAfter)))).toBeCloseTo(
@@ -126,10 +129,10 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
     const spy = jest.spyOn(console, 'log')
     const balance = (await kit.getTotalBalance(accounts[0])).CELO!
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferCelo,
         ['--from', accounts[0], '--to', accounts[1], '--value', balance.toFixed()],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
@@ -161,7 +164,7 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
     const spy = jest.spyOn(console, 'log')
 
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferCelo,
         [
           '--from',
@@ -175,7 +178,7 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
           '--comment',
           'Goodbye balance',
         ],
-        web3
+        provider
       )
     ).resolves.toBeUndefined()
 
@@ -219,16 +222,20 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
   })
 
   test('can transfer very large amounts of CELO', async () => {
-    const balanceBefore = new BigNumber(await web3.eth.getBalance(accounts[0]))
+    const balanceBefore = new BigNumber(
+      (
+        await kit.connection.viemClient.getBalance({ address: accounts[0] as `0x${string}` })
+      ).toString()
+    )
 
     const amountToTransfer = parseEther('20000000')
     await setBalance(
-      web3,
+      provider,
       accounts[0] as Address,
       balanceBefore.plus(amountToTransfer.toString(10))
     )
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferCelo,
       [
         '--from',
@@ -240,30 +247,36 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
         '--gasCurrency',
         (await kit.contracts.getStableToken(StableToken.USDm)).address,
       ],
-      web3
+      provider
     )
 
-    const block = await web3.eth.getBlock('latest')
-    const transactionReceipt = await web3.eth.getTransactionReceipt(block.transactions[0])
+    const block = await kit.connection.viemClient.getBlock({ blockTag: 'latest' })
+    const transactionReceipt = await kit.connection.viemClient.getTransactionReceipt({
+      hash: block.transactions[0],
+    })
 
     // Safety check if the latest transaction was originated by expected account
     expect(transactionReceipt.from.toLowerCase()).toEqual(accounts[0].toLowerCase())
-    expect(transactionReceipt.cumulativeGasUsed).toBeGreaterThan(0)
-    expect(transactionReceipt.effectiveGasPrice).toBeGreaterThan(0)
-    expect(transactionReceipt.gasUsed).toBeGreaterThan(0)
+    expect(transactionReceipt.cumulativeGasUsed).toBeGreaterThan(0n)
+    expect(transactionReceipt.effectiveGasPrice).toBeGreaterThan(0n)
+    expect(transactionReceipt.gasUsed).toBeGreaterThan(0n)
     expect(transactionReceipt.to).toEqual(accounts[1].toLowerCase())
-    expect(transactionReceipt.status).toEqual(true)
+    expect(transactionReceipt.status).toEqual('success')
 
-    const balanceAfter = new BigNumber(await web3.eth.getBalance(accounts[0]))
+    const balanceAfter = new BigNumber(
+      (
+        await kit.connection.viemClient.getBalance({ address: accounts[0] as `0x${string}` })
+      ).toString()
+    )
 
     expect(BigInt(balanceAfter.toFixed())).toBeLessThan(BigInt(balanceBefore.toFixed()))
   })
 
   test('can transfer celo with comment', async () => {
-    const start = await web3.eth.getBlock('latest')
+    const start = await kit.connection.viemClient.getBlock({ blockTag: 'latest' })
     const amountToTransfer = '500000000000000000000'
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferCelo,
       [
         '--from',
@@ -275,11 +288,11 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
         '--comment',
         'Hello World',
       ],
-      web3
+      provider
     )
 
     // Attempt to send USDm back
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferCelo,
       [
         '--from',
@@ -291,17 +304,18 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
         '--comment',
         'Hello World Back',
       ],
-      web3
+      provider
     )
 
-    const client = createPublicClient({
-      // @ts-expect-error
-      transport: http(kit.web3.currentProvider.existingProvider.host),
+    const eventClient = createPublicClient({
+      transport: http(
+        (kit.connection.currentProvider.existingProvider as unknown as { host: string }).host
+      ),
     })
-    const events = await client.getContractEvents({
+    const events = await eventClient.getContractEvents({
       abi: goldTokenABI,
       eventName: 'TransferComment',
-      fromBlock: BigInt(start.number),
+      fromBlock: start.number,
       address: (await kit.contracts.getCeloToken()).address,
     })
 
@@ -311,8 +325,8 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
   })
 
   test('passes feeCurrency to estimateGas', async () => {
-    const chainId = await kit.web3.eth.getChainId()
-    const nodeUrl = extractHostFromWeb3(web3)
+    const chainId = await kit.connection.viemClient.getChainId()
+    const nodeUrl = extractHostFromProvider(provider)
     const publicClient = createPublicClient({
       chain: {
         name: 'Custom Chain',
@@ -334,7 +348,7 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
     const amountToTransfer = '1'
     const USDmAddress = (await kit.contracts.getStableToken(StableToken.USDm)).address
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferCelo,
       [
         '--from',
@@ -346,7 +360,7 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
         '--gasCurrency',
         USDmAddress,
       ],
-      web3
+      provider
     )
 
     expect(estimateGasSpy).toHaveBeenCalledWith({
@@ -360,10 +374,10 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
   test('should fail if to address is sanctioned', async () => {
     const spy = jest.spyOn(console, 'log')
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferCelo,
         ['--from', accounts[1], '--to', TEST_SANCTIONED_ADDRESS, '--value', '1'],
-        web3
+        provider
       )
     ).rejects.toThrow()
     expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))
@@ -372,10 +386,10 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
   test('should fail if from address is sanctioned', async () => {
     const spy = jest.spyOn(console, 'log')
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferCelo,
         ['--from', TEST_SANCTIONED_ADDRESS, '--to', accounts[0], '--value', '1'],
-        web3
+        provider
       )
     ).rejects.toThrow()
     expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))
@@ -384,10 +398,10 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
   test("should fail if the feeCurrency isn't correctly formatted", async () => {
     const wrongFee = '0x123'
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferCelo,
         ['--from', accounts[0], '--to', accounts[1], '--value', '1', '--gasCurrency', wrongFee],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       "Parsing --gasCurrency 
@@ -401,7 +415,7 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
     const receiverBalanceBefore = await kit.getTotalBalance(accounts[1])
     const amountToTransfer = '1'
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferCelo,
         [
           '--from',
@@ -413,15 +427,16 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
           '--gasCurrency',
           (await kit.contracts.getStableToken(StableToken.USDm)).address.toUpperCase(),
         ],
-        web3
+        provider
       )
     ).resolves.toBeUndefined()
 
     const balanceAfter = await kit.getTotalBalance(accounts[0])
     const receiverBalanceAfter = await kit.getTotalBalance(accounts[1])
-    const transactionReceipt = await web3.eth.getTransactionReceipt(
-      (await web3.eth.getBlock('latest')).transactions[0]
-    )
+    const latestBlock = await kit.connection.viemClient.getBlock({ blockTag: 'latest' })
+    const transactionReceipt = await kit.connection.viemClient.getTransactionReceipt({
+      hash: latestBlock.transactions[0],
+    })
 
     // Safety check if the latest transaction was originated by expected account
     expect(transactionReceipt.from.toLowerCase()).toEqual(accounts[0].toLowerCase())
@@ -431,7 +446,7 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
     )
     expect(
       balanceAfter
-        .CELO!.plus(transactionReceipt.effectiveGasPrice * transactionReceipt.gasUsed)
+        .CELO!.plus((transactionReceipt.effectiveGasPrice * transactionReceipt.gasUsed).toString())
         .toFixed()
     ).toEqual(balanceBefore.CELO!.minus(amountToTransfer).toFixed())
   })
@@ -440,10 +455,10 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
     const spy = jest.spyOn(console, 'log')
     const wrongFee = '0x1234567890123456789012345678901234567890'
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferCelo,
         ['--from', accounts[0], '--to', accounts[1], '--value', '1', '--gasCurrency', wrongFee],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     expect(spy).toHaveBeenCalledWith(
@@ -453,11 +468,11 @@ testWithAnvilL2('transfer:celo cmd', (web3: Web3) => {
 
   test('should fail if using with --useAKV', async () => {
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferCelo,
         ['--from', accounts[0], '--to', accounts[1], '--value', '1', '--useAKV'],
 
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"--useAKV flag is no longer supported"`)
   })

--- a/packages/cli/src/commands/transfer/dollars.test.ts
+++ b/packages/cli/src/commands/transfer/dollars.test.ts
@@ -1,14 +1,13 @@
 import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
-import { ContractKit, newKitFromWeb3, StableToken } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider, StableToken } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { TEST_GAS_PRICE } from '@celo/dev-utils/test-utils'
 import BigNumber from 'bignumber.js'
-import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
 import {
   stripAnsiCodesFromNestedArray,
   TEST_SANCTIONED_ADDRESS,
-  testLocallyWithWeb3Node,
+  testLocallyWithNode,
 } from '../../test-utils/cliUtils'
 import { mockRpcFetch } from '../../test-utils/mockRpc'
 import TransferUSDM from './dollars'
@@ -18,13 +17,13 @@ process.env.NO_SYNCCHECK = 'true'
 // Lots of commands, sometimes times out
 jest.setTimeout(15000)
 
-testWithAnvilL2('transfer:dollars cmd', (web3: Web3) => {
+testWithAnvilL2('transfer:dollars cmd', (provider) => {
   let accounts: string[] = []
   let kit: ContractKit
   let logMock: jest.SpyInstance
   beforeEach(async () => {
-    kit = newKitFromWeb3(web3)
-    accounts = await web3.eth.getAccounts()
+    kit = newKitFromProvider(provider)
+    accounts = await kit.connection.getAccounts()
     logMock = jest.spyOn(console, 'log').mockImplementation(() => {
       // noop
     })
@@ -54,10 +53,10 @@ testWithAnvilL2('transfer:dollars cmd', (web3: Web3) => {
     const receiverBalanceBefore = await kit.getTotalBalance(accounts[1])
     const amountToTransfer = '500000000000000000000'
     // Send USDm to RG contract
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferUSDM,
       ['--from', accounts[0], '--to', accounts[1], '--value', amountToTransfer],
-      web3
+      provider
     )
     // RG USDm balance should match the amount sent
     const receiverBalance = await kit.getTotalBalance(accounts[1])
@@ -65,10 +64,10 @@ testWithAnvilL2('transfer:dollars cmd', (web3: Web3) => {
       receiverBalanceBefore.USDm!.plus(amountToTransfer).toFixed()
     )
     // Attempt to send USDm back
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferUSDM,
       ['--from', accounts[1], '--to', accounts[0], '--value', amountToTransfer],
-      web3
+      provider
     )
     const balanceAfter = await kit.getTotalBalance(accounts[0])
     expect(balanceBefore.USDm).toEqual(balanceAfter.USDm)
@@ -77,10 +76,10 @@ testWithAnvilL2('transfer:dollars cmd', (web3: Web3) => {
     const cusdWrapper = await kit.contracts.getStableToken(StableToken.USDm)
     const balance = await cusdWrapper.balanceOf(accounts[0])
     expect(balance.toFixed()).toEqBigNumber('1000000000000000000000')
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferUSDM,
       ['--from', accounts[0], '--to', accounts[1], '--value', balance.toFixed()],
-      web3
+      provider
     )
     const balanceAfter = await cusdWrapper.balanceOf(accounts[0])
     expect(balanceAfter.toFixed()).toEqBigNumber('0')
@@ -102,7 +101,7 @@ testWithAnvilL2('transfer:dollars cmd', (web3: Web3) => {
         const balance = await cusdWrapper.balanceOf(accounts[0])
         expect(balance.toFixed()).toEqBigNumber('1000000000000000000000')
         await expect(
-          testLocallyWithWeb3Node(
+          testLocallyWithNode(
             TransferUSDM,
             [
               '--from',
@@ -115,7 +114,7 @@ testWithAnvilL2('transfer:dollars cmd', (web3: Web3) => {
               cusdAddress,
             ],
 
-            web3
+            provider
           )
         ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
 
@@ -160,7 +159,7 @@ testWithAnvilL2('transfer:dollars cmd', (web3: Web3) => {
         const euroWrapper = await kit.contracts.getStableToken(StableToken.EURm)
         const balance = await cusdWrapper.balanceOf(accounts[0])
         expect(balance.toFixed()).toEqBigNumber('1000000000000000000000')
-        await testLocallyWithWeb3Node(
+        await testLocallyWithNode(
           TransferUSDM,
           [
             '--from',
@@ -172,7 +171,7 @@ testWithAnvilL2('transfer:dollars cmd', (web3: Web3) => {
             '--gasCurrency',
             euroWrapper.address,
           ],
-          web3
+          provider
         )
         const balanceAfter = await cusdWrapper.balanceOf(accounts[0])
         expect(balanceAfter.toFixed()).toEqBigNumber('0')
@@ -185,7 +184,7 @@ testWithAnvilL2('transfer:dollars cmd', (web3: Web3) => {
       const amountToTransfer = '10000000000000000000'
       const comment = 'Test transfer'
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           TransferUSDM,
           [
             '--from',
@@ -197,7 +196,7 @@ testWithAnvilL2('transfer:dollars cmd', (web3: Web3) => {
             '--comment',
             comment,
           ],
-          web3
+          provider
         )
       ).resolves.toBeUndefined()
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
@@ -237,10 +236,10 @@ testWithAnvilL2('transfer:dollars cmd', (web3: Web3) => {
   test('should fail if to address is sanctioned', async () => {
     const spy = jest.spyOn(console, 'log')
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferUSDM,
         ['--from', accounts[1], '--to', TEST_SANCTIONED_ADDRESS, '--value', '1'],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))

--- a/packages/cli/src/commands/transfer/erc20.test.ts
+++ b/packages/cli/src/commands/transfer/erc20.test.ts
@@ -1,11 +1,10 @@
 import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
-import { ContractKit, newKitFromWeb3, StableToken } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider, StableToken } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { TEST_GAS_PRICE } from '@celo/dev-utils/test-utils'
 import BigNumber from 'bignumber.js'
-import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { TEST_SANCTIONED_ADDRESS, testLocallyWithNode } from '../../test-utils/cliUtils'
 import { mockRpcFetch } from '../../test-utils/mockRpc'
 import TransferERC20 from './erc20'
 
@@ -14,7 +13,7 @@ process.env.NO_SYNCCHECK = 'true'
 // Lots of commands, sometimes times out
 jest.setTimeout(15000)
 
-testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
+testWithAnvilL2('transfer:erc20 cmd', (provider) => {
   let accounts: string[] = []
   let kit: ContractKit
 
@@ -28,8 +27,8 @@ testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
   })
 
   beforeEach(async () => {
-    kit = newKitFromWeb3(web3)
-    accounts = await web3.eth.getAccounts()
+    kit = newKitFromProvider(provider)
+    accounts = await kit.connection.getAccounts()
 
     await topUpWithToken(
       kit,
@@ -67,7 +66,7 @@ testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
 
     const cusdAddress = await kit.celoTokens.getAddress(StableToken.USDm)
     // Send cusd as erc20
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferERC20,
       [
         '--from',
@@ -79,7 +78,7 @@ testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
         '--erc20Address',
         cusdAddress,
       ],
-      web3
+      provider
     )
     // Send cusd as erc20
     const receiverBalance = await kit.getTotalBalance(reciever)
@@ -87,7 +86,7 @@ testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
       receiverBalanceBefore.USDm!.plus(amountToTransfer).toFixed()
     )
     // Attempt to send erc20, back
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferERC20,
       [
         '--from',
@@ -99,7 +98,7 @@ testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
         '--erc20Address',
         cusdAddress,
       ],
-      web3
+      provider
     )
     const balanceAfter = await kit.getTotalBalance(sender)
     expect(balanceBefore.USDm).toEqual(balanceAfter.USDm)
@@ -112,7 +111,7 @@ testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
     const cusdAddress = await kit.celoTokens.getAddress(StableToken.USDm)
 
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferERC20,
         [
           '--from',
@@ -124,7 +123,7 @@ testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
           '--erc20Address',
           cusdAddress,
         ],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))
@@ -132,17 +131,17 @@ testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
 
   test("should fail if erc20 address isn't correct", async () => {
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferERC20,
         ['--from', accounts[0], '--to', accounts[1], '--value', '1', '--erc20Address', accounts[2]],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Invalid erc20 address"`)
   })
 
   test('should fail if using with --useAKV', async () => {
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferERC20,
         [
           '--from',
@@ -156,7 +155,7 @@ testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
           '--useAKV',
         ],
 
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"--useAKV flag is no longer supported"`)
   })
@@ -169,7 +168,7 @@ testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
     const cusdAddress = await kit.celoTokens.getAddress(StableToken.USDm)
 
     // Transfer ERC20 with gas paid in CELO (default)
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferERC20,
       [
         '--from',
@@ -181,7 +180,7 @@ testWithAnvilL2('transfer:erc20 cmd', (web3: Web3) => {
         '--erc20Address',
         cusdAddress,
       ],
-      web3
+      provider
     )
 
     // Verify the transfer was successful

--- a/packages/cli/src/commands/transfer/euros.test.ts
+++ b/packages/cli/src/commands/transfer/euros.test.ts
@@ -1,10 +1,9 @@
 import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
-import { ContractKit, newKitFromWeb3, StableToken } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider, StableToken } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import BigNumber from 'bignumber.js'
-import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { TEST_SANCTIONED_ADDRESS, testLocallyWithNode } from '../../test-utils/cliUtils'
 import TransferEURO from './euros'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -12,13 +11,13 @@ process.env.NO_SYNCCHECK = 'true'
 // Lots of commands, sometimes times out
 jest.setTimeout(15000)
 
-testWithAnvilL2('transfer:euros cmd', (web3: Web3) => {
+testWithAnvilL2('transfer:euros cmd', (provider) => {
   let accounts: string[] = []
   let kit: ContractKit
 
   beforeEach(async () => {
-    kit = newKitFromWeb3(web3)
-    accounts = await web3.eth.getAccounts()
+    kit = newKitFromProvider(provider)
+    accounts = await kit.connection.getAccounts()
     jest.spyOn(console, 'log').mockImplementation(() => {
       // noop
     })
@@ -49,10 +48,10 @@ testWithAnvilL2('transfer:euros cmd', (web3: Web3) => {
     const receiverBalanceBefore = await kit.getTotalBalance(accounts[1])
     const amountToTransfer = '500000000000000000000'
     // Send EURm to RG contract
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferEURO,
       ['--from', accounts[0], '--to', accounts[1], '--value', amountToTransfer],
-      web3
+      provider
     )
     // RG EURm balance should match the amount sent
     const receiverBalance = await kit.getTotalBalance(accounts[1])
@@ -60,10 +59,10 @@ testWithAnvilL2('transfer:euros cmd', (web3: Web3) => {
       receiverBalanceBefore.EURm!.plus(amountToTransfer).toFixed()
     )
     // Attempt to send EURm back
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferEURO,
       ['--from', accounts[1], '--to', accounts[0], '--value', amountToTransfer],
-      web3
+      provider
     )
     const balanceAfter = await kit.getTotalBalance(accounts[0])
     expect(balanceBefore.EURm).toEqual(balanceAfter.EURm)
@@ -72,10 +71,10 @@ testWithAnvilL2('transfer:euros cmd', (web3: Web3) => {
   test('should fail if to address is sanctioned', async () => {
     const spy = jest.spyOn(console, 'log')
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferEURO,
         ['--from', accounts[1], '--to', TEST_SANCTIONED_ADDRESS, '--value', '1'],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))

--- a/packages/cli/src/commands/transfer/reals.test.ts
+++ b/packages/cli/src/commands/transfer/reals.test.ts
@@ -1,10 +1,9 @@
 import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
-import { ContractKit, StableToken, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, StableToken, newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import BigNumber from 'bignumber.js'
-import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { TEST_SANCTIONED_ADDRESS, testLocallyWithNode } from '../../test-utils/cliUtils'
 import TransferReals from './reals'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -12,7 +11,7 @@ process.env.NO_SYNCCHECK = 'true'
 // Lots of commands, sometimes times out
 jest.setTimeout(15000)
 
-testWithAnvilL2('transfer:reals cmd', (web3: Web3) => {
+testWithAnvilL2('transfer:reals cmd', (provider) => {
   let accounts: string[] = []
   let kit: ContractKit
 
@@ -26,8 +25,8 @@ testWithAnvilL2('transfer:reals cmd', (web3: Web3) => {
   })
 
   beforeEach(async () => {
-    kit = newKitFromWeb3(web3)
-    accounts = await web3.eth.getAccounts()
+    kit = newKitFromProvider(provider)
+    accounts = await kit.connection.getAccounts()
 
     await topUpWithToken(
       kit,
@@ -52,10 +51,10 @@ testWithAnvilL2('transfer:reals cmd', (web3: Web3) => {
     const receiverBalanceBefore = await kit.getTotalBalance(accounts[1])
     const amountToTransfer = '500000000000000000000'
     // Send BRLm, to RG contract
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferReals,
       ['--from', accounts[0], '--to', accounts[1], '--value', amountToTransfer],
-      web3
+      provider
     )
     // RG BRLm, balance should match the amount sent
     const receiverBalance = await kit.getTotalBalance(accounts[1])
@@ -63,10 +62,10 @@ testWithAnvilL2('transfer:reals cmd', (web3: Web3) => {
       receiverBalanceBefore.BRLm!.plus(amountToTransfer).toFixed()
     )
     // Attempt to send BRLm, back
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferReals,
       ['--from', accounts[1], '--to', accounts[0], '--value', amountToTransfer],
-      web3
+      provider
     )
     const balanceAfter = await kit.getTotalBalance(accounts[0])
     expect(balanceBefore.BRLm).toEqual(balanceAfter.BRLm)
@@ -78,10 +77,10 @@ testWithAnvilL2('transfer:reals cmd', (web3: Web3) => {
     })
 
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferReals,
         ['--from', accounts[1], '--to', TEST_SANCTIONED_ADDRESS, '--value', '1'],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))

--- a/packages/cli/src/commands/transfer/stable.test.ts
+++ b/packages/cli/src/commands/transfer/stable.test.ts
@@ -1,10 +1,9 @@
 import { COMPLIANT_ERROR_RESPONSE } from '@celo/compliance'
-import { ContractKit, StableToken, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, StableToken, newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import BigNumber from 'bignumber.js'
-import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { TEST_SANCTIONED_ADDRESS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { TEST_SANCTIONED_ADDRESS, testLocallyWithNode } from '../../test-utils/cliUtils'
 import TransferStable from './stable'
 
 process.env.NO_SYNCCHECK = 'true'
@@ -12,7 +11,7 @@ process.env.NO_SYNCCHECK = 'true'
 // Lots of commands, sometimes times out
 jest.setTimeout(15000)
 
-testWithAnvilL2('transfer:stable cmd', (web3: Web3) => {
+testWithAnvilL2('transfer:stable cmd', (provider) => {
   let accounts: string[] = []
   let kit: ContractKit
 
@@ -26,8 +25,8 @@ testWithAnvilL2('transfer:stable cmd', (web3: Web3) => {
   })
 
   beforeEach(async () => {
-    kit = newKitFromWeb3(web3)
-    accounts = await web3.eth.getAccounts()
+    kit = newKitFromProvider(provider)
+    accounts = await kit.connection.getAccounts()
 
     await topUpWithToken(
       kit,
@@ -48,7 +47,7 @@ testWithAnvilL2('transfer:stable cmd', (web3: Web3) => {
     const amountToTransfer = '5000000000000000000'
 
     // Send cusd as erc20
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferStable,
       [
         '--from',
@@ -60,7 +59,7 @@ testWithAnvilL2('transfer:stable cmd', (web3: Web3) => {
         '--stableToken',
         StableToken.USDm,
       ],
-      web3
+      provider
     )
     // Send cusd as erc20
     const receiverBalance = await kit.getTotalBalance(reciever)
@@ -68,7 +67,7 @@ testWithAnvilL2('transfer:stable cmd', (web3: Web3) => {
       receiverBalanceBefore.USDm!.plus(amountToTransfer).toFixed()
     )
     // Attempt to send erc20, back
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferStable,
       [
         '--from',
@@ -80,7 +79,7 @@ testWithAnvilL2('transfer:stable cmd', (web3: Web3) => {
         '--stableToken',
         StableToken.USDm,
       ],
-      web3
+      provider
     )
   })
 
@@ -90,7 +89,7 @@ testWithAnvilL2('transfer:stable cmd', (web3: Web3) => {
     })
 
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferStable,
         [
           '--from',
@@ -102,7 +101,7 @@ testWithAnvilL2('transfer:stable cmd', (web3: Web3) => {
           '--stableToken',
           StableToken.USDm,
         ],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))
@@ -110,7 +109,7 @@ testWithAnvilL2('transfer:stable cmd', (web3: Web3) => {
 
   test('should fail if using with --useAKV', async () => {
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferStable,
         [
           '--from',
@@ -124,7 +123,7 @@ testWithAnvilL2('transfer:stable cmd', (web3: Web3) => {
           '--useAKV',
         ],
 
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"--useAKV flag is no longer supported"`)
   })


### PR DESCRIPTION
## Stack
> [A](#766) → [B](#767) → [C](#768) → [D1](#769) → [D2](#770) → [D3](#771) → D4 → **D5** (CI)

## Changes
Replace web3-based transaction patterns with viem equivalents across `lockedcelo/`, `multisig/`, `network/`, `oracle/`, `identity/`, `rewards/`, and `transfer/` CLI commands and their tests.

_Part of the web3 → viem migration. No CI requirement on this PR._