### PR TITLE
refactor(cli): migrate releasecelo, validator, validatorgroup to viem [8/8]

### DIFF
--- a/packages/cli/src/commands/election/activate.test.ts
+++ b/packages/cli/src/commands/election/activate.test.ts
@@ -190,9 +190,6 @@ testWithAnvilL2(
             [
               "txHash: 0xtxhash",
             ],
-            [
-              "txHash: 0xtxhash",
-            ],
           ]
         `)
         expect(writeMock.mock.calls).toMatchInlineSnapshot(`[]`)
@@ -334,9 +331,6 @@ testWithAnvilL2(
           ],
           [
             "SendTransaction: activate",
-          ],
-          [
-            "txHash: 0xtxhash",
           ],
           [
             "txHash: 0xtxhash",

--- a/packages/cli/src/commands/election/activate.test.ts
+++ b/packages/cli/src/commands/election/activate.test.ts
@@ -182,6 +182,9 @@ testWithAnvilL2(
               "SendTransaction: finishNextEpoch",
             ],
             [
+              "txHash: 0xtxhash",
+            ],
+            [
               "SendTransaction: activate",
             ],
             [
@@ -319,6 +322,9 @@ testWithAnvilL2(
           ],
           [
             "SendTransaction: finishNextEpoch",
+          ],
+          [
+            "txHash: 0xtxhash",
           ],
           [
             "SendTransaction: activate",

--- a/packages/cli/src/commands/releasecelo/admin-revoke.test.ts
+++ b/packages/cli/src/commands/releasecelo/admin-revoke.test.ts
@@ -1,17 +1,17 @@
-import { newReleaseGold } from '@celo/abis/web3/ReleaseGold'
+import { releaseGoldABI } from '@celo/abis'
 import { StableToken, StrongAddress } from '@celo/base'
 import { serializeSignature } from '@celo/base/lib/signatureUtils'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { AccountsWrapper } from '@celo/contractkit/lib/wrappers/Accounts'
 import { GovernanceWrapper } from '@celo/contractkit/lib/wrappers/Governance'
 import { ReleaseGoldWrapper } from '@celo/contractkit/lib/wrappers/ReleaseGold'
 import { setBalance, testWithAnvilL2, withImpersonatedAccount } from '@celo/dev-utils/anvil-test'
 import { getContractFromEvent, timeTravel } from '@celo/dev-utils/ganache-test'
 import BigNumber from 'bignumber.js'
+import { parseEther } from 'viem'
 import { privateKeyToAddress } from 'viem/accounts'
-import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import Approve from '../governance/approve'
@@ -24,17 +24,17 @@ import LockedCelo from './locked-gold'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:admin-revoke cmd', (provider) => {
   let kit: ContractKit
   let contractAddress: StrongAddress
   let releaseGoldWrapper: ReleaseGoldWrapper
   let accounts: StrongAddress[]
 
   beforeEach(async () => {
-    accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
+    accounts = (await kit.connection.getAccounts()) as StrongAddress[]
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
       accounts[1],
       accounts[0],
@@ -42,16 +42,16 @@ testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
     )
     releaseGoldWrapper = new ReleaseGoldWrapper(
       kit.connection,
-      newReleaseGold(web3, contractAddress),
+      kit.connection.getCeloContract(releaseGoldABI as any, contractAddress) as any,
       kit.contracts
     )
   })
 
   test('will revoke', async () => {
-    await testLocallyWithWeb3Node(AdminRevoke, ['--contract', contractAddress, '--yesreally'], web3)
+    await testLocallyWithNode(AdminRevoke, ['--contract', contractAddress, '--yesreally'], provider)
     const revokedContract = await getContractFromEvent(
       'ReleaseScheduleRevoked(uint256,uint256)',
-      web3
+      provider
     )
     expect(revokedContract).toBe(contractAddress)
   })
@@ -59,19 +59,22 @@ testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
   test('will rescue all USDm balance', async () => {
     await topUpWithToken(kit, StableToken.USDm, accounts[0], new BigNumber('100'))
     const stableToken = await kit.contracts.getStableToken()
-    await stableToken.transfer(contractAddress, 100).send({
+    const transferHash = await stableToken.transfer(contractAddress, 100, {
       from: accounts[0],
     })
-    await testLocallyWithWeb3Node(AdminRevoke, ['--contract', contractAddress, '--yesreally'], web3)
+    await kit.connection.viemClient.waitForTransactionReceipt({
+      hash: transferHash as `0x${string}`,
+    })
+    await testLocallyWithNode(AdminRevoke, ['--contract', contractAddress, '--yesreally'], provider)
     const balance = await stableToken.balanceOf(contractAddress)
     expect(balance.isZero()).toBeTruthy()
   })
 
   test('will refund and finalize', async () => {
-    await testLocallyWithWeb3Node(AdminRevoke, ['--contract', contractAddress, '--yesreally'], web3)
+    await testLocallyWithNode(AdminRevoke, ['--contract', contractAddress, '--yesreally'], provider)
     const destroyedContract = await getContractFromEvent(
       'ReleaseGoldInstanceDestroyed(address,address)',
-      web3
+      provider
     )
     expect(destroyedContract).toBe(contractAddress)
   })
@@ -81,20 +84,20 @@ testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
 
     beforeEach(async () => {
       // Make sure the release gold contract has enough funds
-      await setBalance(web3, contractAddress, new BigNumber(web3.utils.toWei('10', 'ether')))
-      await testLocallyWithWeb3Node(CreateAccount, ['--contract', contractAddress], web3)
-      await testLocallyWithWeb3Node(
+      await setBalance(provider, contractAddress, new BigNumber(parseEther('10').toString()))
+      await testLocallyWithNode(CreateAccount, ['--contract', contractAddress], provider)
+      await testLocallyWithNode(
         LockedCelo,
         ['--contract', contractAddress, '--action', 'lock', '--value', value, '--yes'],
-        web3
+        provider
       )
     })
 
     test('will unlock all gold', async () => {
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         AdminRevoke,
         ['--contract', contractAddress, '--yesreally'],
-        web3
+        provider
       )
       const lockedGold = await kit.contracts.getLockedGold()
       const lockedAmount = await lockedGold.getAccountTotalLockedGold(releaseGoldWrapper.address)
@@ -115,7 +118,7 @@ testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
           voteSigner,
           PRIVATE_KEY1
         )
-        await testLocallyWithWeb3Node(
+        await testLocallyWithNode(
           Authorize,
           [
             '--contract',
@@ -127,15 +130,15 @@ testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
             '--signature',
             serializeSignature(pop),
           ],
-          web3
+          provider
         )
       })
 
       it('will rotate vote signer', async () => {
-        await testLocallyWithWeb3Node(
+        await testLocallyWithNode(
           AdminRevoke,
           ['--contract', contractAddress, '--yesreally'],
-          web3
+          provider
         )
         const newVoteSigner = await accountsWrapper.getVoteSigner(contractAddress)
         expect(newVoteSigner).not.toEqual(voteSigner)
@@ -148,26 +151,30 @@ testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
           // from vote.test.ts
           governance = await kit.contracts.getGovernance()
           const minDeposit = (await governance.minDeposit()).toFixed()
-          await governance
-            .propose([], 'URL')
-            .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
+          const proposeHash1 = await governance.propose([], 'URL', {
+            from: accounts[0],
+            value: minDeposit,
+          })
+          await kit.connection.viemClient.waitForTransactionReceipt({
+            hash: proposeHash1 as `0x${string}`,
+          })
 
           const dequeueFrequency = (await governance.dequeueFrequency()).toNumber()
-          await timeTravel(dequeueFrequency + 1, web3)
+          await timeTravel(dequeueFrequency + 1, provider)
           const multiApprover = await governance.getApproverMultisig()
           await setBalance(
-            web3,
+            provider,
             multiApprover.address,
-            new BigNumber(web3.utils.toWei('10', 'ether'))
+            new BigNumber(parseEther('10').toString())
           )
-          await withImpersonatedAccount(web3, multiApprover.address, async () => {
-            await testLocallyWithWeb3Node(
+          await withImpersonatedAccount(provider, multiApprover.address, async () => {
+            await testLocallyWithNode(
               Approve,
               ['--from', multiApprover.address, '--proposalID', '1'],
-              web3
+              provider
             )
           })
-          await testLocallyWithWeb3Node(
+          await testLocallyWithNode(
             GovernanceVote,
             [
               '--from',
@@ -179,28 +186,36 @@ testWithAnvilL2('releasegold:admin-revoke cmd', (web3: Web3) => {
               '--privateKey',
               PRIVATE_KEY1,
             ],
-            web3
+            provider
           )
-          await governance
-            .propose([], 'URL')
-            .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
-          await governance
-            .propose([], 'URL')
-            .sendAndWaitForReceipt({ from: accounts[0], value: minDeposit })
-          await testLocallyWithWeb3Node(
+          const proposeHash2 = await governance.propose([], 'URL', {
+            from: accounts[0],
+            value: minDeposit,
+          })
+          await kit.connection.viemClient.waitForTransactionReceipt({
+            hash: proposeHash2 as `0x${string}`,
+          })
+          const proposeHash3 = await governance.propose([], 'URL', {
+            from: accounts[0],
+            value: minDeposit,
+          })
+          await kit.connection.viemClient.waitForTransactionReceipt({
+            hash: proposeHash3 as `0x${string}`,
+          })
+          await testLocallyWithNode(
             GovernanceUpvote,
             ['--from', voteSigner, '--proposalID', '3', '--privateKey', PRIVATE_KEY1],
-            web3
+            provider
           )
         })
 
         it('will revoke governance votes and upvotes', async () => {
           const isVotingBefore = await governance.isVoting(contractAddress)
           expect(isVotingBefore).toBeTruthy()
-          await testLocallyWithWeb3Node(
+          await testLocallyWithNode(
             AdminRevoke,
             ['--contract', contractAddress, '--yesreally'],
-            web3
+            provider
           )
           const isVotingAfter = await governance.isVoting(contractAddress)
           expect(isVotingAfter).toBeFalsy()

--- a/packages/cli/src/commands/releasecelo/admin-revoke.ts
+++ b/packages/cli/src/commands/releasecelo/admin-revoke.ts
@@ -1,7 +1,7 @@
 import { StrongAddress } from '@celo/base'
 import { Flags } from '@oclif/core'
 import prompts from 'prompts'
-import { displaySendTx, printValueMap } from '../../utils/cli'
+import { displayViemTx, printValueMap } from '../../utils/cli'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 
 export default class AdminRevoke extends ReleaseGoldBaseCommand {
@@ -20,6 +20,7 @@ export default class AdminRevoke extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags: _flags } = await this.parse(AdminRevoke)
     if (!_flags.yesreally) {
       const response = await prompts({
@@ -38,11 +39,10 @@ export default class AdminRevoke extends ReleaseGoldBaseCommand {
 
     const isRevoked = await this.releaseGoldWrapper.isRevoked()
     if (!isRevoked) {
-      await displaySendTx(
+      await displayViemTx(
         'releasegold: revokeBeneficiary',
         this.releaseGoldWrapper.revokeBeneficiary(),
-        undefined,
-        'ReleaseScheduleRevoked'
+        publicClient
       )
     }
 
@@ -55,11 +55,10 @@ export default class AdminRevoke extends ReleaseGoldBaseCommand {
       if (voteSigner !== contractAddress) {
         voteSigner = kit.defaultAccount
         const pop = await accounts.generateProofOfKeyPossession(contractAddress, voteSigner)
-        await displaySendTx(
+        await displayViemTx(
           'accounts: rotateVoteSigner',
-          await this.releaseGoldWrapper.authorizeVoteSigner(voteSigner, pop),
-          undefined,
-          'VoteSignerAuthorized'
+          this.releaseGoldWrapper.authorizeVoteSigner(voteSigner, pop),
+          publicClient
         )
       }
 
@@ -69,13 +68,10 @@ export default class AdminRevoke extends ReleaseGoldBaseCommand {
 
       // handle election votes
       if (isElectionVoting) {
-        const txos = await this.releaseGoldWrapper.revokeAllVotesForAllGroups()
+        const hashes = await this.releaseGoldWrapper.revokeAllVotesForAllGroups()
 
-        for (const txo of txos) {
-          await displaySendTx('election: revokeVotes', txo, { from: voteSigner }, [
-            'ValidatorGroupPendingVoteRevoked',
-            'ValidatorGroupActiveVoteRevoked',
-          ])
+        for (const hash of hashes) {
+          await displayViemTx('election: revokeVotes', Promise.resolve(hash), publicClient)
         }
       }
 
@@ -86,30 +82,23 @@ export default class AdminRevoke extends ReleaseGoldBaseCommand {
       if (isGovernanceVoting) {
         const isUpvoting = await governance.isUpvoting(contractAddress)
         if (isUpvoting) {
-          await displaySendTx(
+          await displayViemTx(
             'governance: revokeUpvote',
-            await governance.revokeUpvote(contractAddress),
-            { from: voteSigner },
-            'ProposalUpvoteRevoked'
+            governance.revokeUpvote(contractAddress),
+            publicClient
           )
         }
 
         const isVotingReferendum = await governance.isVotingReferendum(contractAddress)
         if (isVotingReferendum) {
-          await displaySendTx(
-            'governance: revokeVotes',
-            governance.revokeVotes(),
-            { from: voteSigner },
-            'ProposalVoteRevoked'
-          )
+          await displayViemTx('governance: revokeVotes', governance.revokeVotes(), publicClient)
         }
       }
 
-      await displaySendTx(
+      await displayViemTx(
         'releasegold: unlockAllGold',
-        await this.releaseGoldWrapper.unlockAllGold(),
-        undefined,
-        'GoldUnlocked'
+        this.releaseGoldWrapper.unlockAllGold(),
+        publicClient
       )
     }
 
@@ -117,22 +106,20 @@ export default class AdminRevoke extends ReleaseGoldBaseCommand {
     const stabletoken = await kit.contracts.getStableToken()
     const cusdBalance = await stabletoken.balanceOf(contractAddress)
     if (cusdBalance.isGreaterThan(0)) {
-      await displaySendTx(
+      await displayViemTx(
         'releasegold: rescueCUSD',
         this.releaseGoldWrapper.transfer(kit.defaultAccount, cusdBalance),
-        undefined,
-        'Transfer'
+        publicClient
       )
     }
 
     // attempt to refund and finalize, surface pending withdrawals
     const remainingLockedGold = await this.releaseGoldWrapper.getRemainingLockedBalance()
     if (remainingLockedGold.isZero()) {
-      await displaySendTx(
+      await displayViemTx(
         'releasegold: refundAndFinalize',
         this.releaseGoldWrapper.refundAndFinalize(),
-        undefined,
-        'ReleaseGoldInstanceDestroyed'
+        publicClient
       )
     } else {
       console.log('Some celo is still locked, printing pending withdrawals...')

--- a/packages/cli/src/commands/releasecelo/authorize.test.ts
+++ b/packages/cli/src/commands/releasecelo/authorize.test.ts
@@ -1,29 +1,29 @@
 import { NULL_ADDRESS, StrongAddress } from '@celo/base'
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newKitFromProvider } from '@celo/contractkit'
 import { setBalance, testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { addressToPublicKey, serializeSignature } from '@celo/utils/lib/signatureUtils'
 import BigNumber from 'bignumber.js'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import ValidatorRegister from '../validator/register'
 import Authorize from './authorize'
 import CreateAccount from './create-account'
 import LockedCelo from './locked-gold'
+import { parseEther } from 'viem'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:authorize cmd', (provider) => {
   let contractAddress: string
   let kit: any
   let logSpy: jest.SpyInstance
 
   beforeEach(async () => {
-    const accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
+    const accounts = (await kit.connection.getAccounts()) as StrongAddress[]
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
       accounts[1],
       accounts[0],
@@ -32,11 +32,11 @@ testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
     )
     // contract needs to have sufficient funds to lock CELO
     await setBalance(
-      web3,
+      provider,
       contractAddress as StrongAddress,
-      new BigNumber(web3.utils.toWei('100000', 'ether'))
+      new BigNumber(parseEther('100000').toString())
     )
-    await testLocallyWithWeb3Node(CreateAccount, ['--contract', contractAddress], web3)
+    await testLocallyWithNode(CreateAccount, ['--contract', contractAddress], provider)
   })
 
   describe('can authorize account signers', () => {
@@ -44,7 +44,7 @@ testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
     let accounts: any
 
     beforeEach(async () => {
-      accounts = await web3.eth.getAccounts()
+      accounts = await kit.connection.getAccounts()
       const accountsWrapper = await kit.contracts.getAccounts()
       pop = await accountsWrapper.generateProofOfKeyPossession(contractAddress, accounts[1])
       logSpy = jest.spyOn(console, 'log')
@@ -52,7 +52,7 @@ testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
 
     test('can authorize account vote signer ', async () => {
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           Authorize,
           [
             '--contract',
@@ -64,7 +64,7 @@ testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
             '--signature',
             serializeSignature(pop),
           ],
-          web3
+          provider
         )
       ).resolves.toBeUndefined()
       expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
@@ -90,7 +90,7 @@ testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
 
     test('can authorize account validator signer', async () => {
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           Authorize,
           [
             '--contract',
@@ -102,7 +102,7 @@ testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
             '--signature',
             serializeSignature(pop),
           ],
-          web3
+          provider
         )
       ).resolves.toBeUndefined()
       expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
@@ -149,7 +149,7 @@ testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
 
     test('can authorize account attestation signer', async () => {
       await expect(
-        testLocallyWithWeb3Node(
+        testLocallyWithNode(
           Authorize,
           [
             '--contract',
@@ -161,7 +161,7 @@ testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
             '--signature',
             serializeSignature(pop),
           ],
-          web3
+          provider
         )
       ).resolves.toBeUndefined()
       expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
@@ -205,13 +205,13 @@ testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
   })
 
   test('can register as a validator from an authorized signer', async () => {
-    const accounts = await web3.eth.getAccounts()
+    const accounts = await kit.connection.getAccounts()
     const accountsWrapper = await kit.contracts.getAccounts()
     const signer = accounts[1]
     const pop = await accountsWrapper.generateProofOfKeyPossession(contractAddress, signer)
-    const ecdsaPublicKey = await addressToPublicKey(signer, web3.eth.sign)
+    const ecdsaPublicKey = await addressToPublicKey(signer, kit.connection.sign)
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         LockedCelo,
         [
           '--contract',
@@ -222,11 +222,11 @@ testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
           '10000000000000000000000',
           '--yes',
         ],
-        web3
+        provider
       )
     ).resolves.toBeUndefined()
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         Authorize,
         [
           '--contract',
@@ -238,22 +238,22 @@ testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
           '--signature',
           serializeSignature(pop),
         ],
-        web3
+        provider
       )
     ).resolves.toBeUndefined()
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         ValidatorRegister,
         ['--from', signer, '--ecdsaKey', ecdsaPublicKey, '--yes'],
-        web3
+        provider
       )
     ).resolves.toBeUndefined()
   })
 
   test('fails if contract is not registered as an account', async () => {
-    const accounts = await web3.eth.getAccounts()
+    const accounts = await kit.connection.getAccounts()
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         Authorize,
         [
           '--contract',
@@ -266,7 +266,7 @@ testWithAnvilL2('releasegold:authorize cmd', (web3: Web3) => {
           '0x1b9fca4bbb5bfb1dbe69ef1cddbd9b4202dcb6b134c5170611e1e36ecfa468d7b46c85328d504934fce6c2a1571603a50ae224d2b32685e84d4d1a1eebad8452eb',
         ],
 
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"Unable to parse signature (expected signer 0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb)"`

--- a/packages/cli/src/commands/releasecelo/authorize.ts
+++ b/packages/cli/src/commands/releasecelo/authorize.ts
@@ -1,6 +1,6 @@
 import { Flags as oclifFlags } from '@oclif/core'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 export default class Authorize extends ReleaseGoldBaseCommand {
@@ -36,6 +36,7 @@ export default class Authorize extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags } = await this.parse(Authorize)
 
     const role = flags.role
@@ -73,6 +74,6 @@ export default class Authorize extends ReleaseGoldBaseCommand {
       this.error('Invalid role provided')
       return
     }
-    await displaySendTx('authorize' + role + 'Tx', tx)
+    await displayViemTx('authorize' + role + 'Tx', tx, publicClient)
   }
 }

--- a/packages/cli/src/commands/releasecelo/create-account.test.ts
+++ b/packages/cli/src/commands/releasecelo/create-account.test.ts
@@ -1,24 +1,23 @@
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import CreateAccount from './create-account'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('releasegold:create-account cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:create-account cmd', (provider) => {
   let contractAddress: string
   let kit: ContractKit
 
   beforeEach(async () => {
-    const accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
+    const accounts = (await kit.connection.getAccounts()) as StrongAddress[]
 
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
       accounts[1],
       accounts[0],
@@ -31,7 +30,7 @@ testWithAnvilL2('releasegold:create-account cmd', (web3: Web3) => {
 
     expect(await accountWrapper.isAccount(contractAddress)).toBeFalsy()
 
-    await testLocallyWithWeb3Node(CreateAccount, ['--contract', contractAddress], web3)
+    await testLocallyWithNode(CreateAccount, ['--contract', contractAddress], provider)
 
     expect(await accountWrapper.isAccount(contractAddress)).toBeTruthy()
   })

--- a/packages/cli/src/commands/releasecelo/create-account.ts
+++ b/packages/cli/src/commands/releasecelo/create-account.ts
@@ -1,5 +1,5 @@
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 export default class CreateAccount extends ReleaseGoldBaseCommand {
   static description = 'Creates a new account for the ReleaseGold instance'
@@ -14,6 +14,7 @@ export default class CreateAccount extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const isRevoked = await this.releaseGoldWrapper.isRevoked()
     await newCheckBuilder(this)
       .isNotAccount(this.releaseGoldWrapper.address)
@@ -21,6 +22,6 @@ export default class CreateAccount extends ReleaseGoldBaseCommand {
       .runChecks()
 
     kit.defaultAccount = await this.releaseGoldWrapper.getBeneficiary()
-    await displaySendTx('createAccount', this.releaseGoldWrapper.createAccount())
+    await displayViemTx('createAccount', this.releaseGoldWrapper.createAccount(), publicClient)
   }
 }

--- a/packages/cli/src/commands/releasecelo/locked-gold.test.ts
+++ b/packages/cli/src/commands/releasecelo/locked-gold.test.ts
@@ -1,8 +1,7 @@
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { LONG_TIMEOUT_MS, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { LONG_TIMEOUT_MS, testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import CreateAccount from './create-account'
@@ -10,48 +9,48 @@ import LockedCelo from './locked-gold'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('releasegold:locked-gold cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:locked-gold cmd', (provider) => {
   let contractAddress: string
   let kit: ContractKit
 
   beforeEach(async () => {
-    const accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
+    const accounts = (await kit.connection.getAccounts()) as StrongAddress[]
 
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
       accounts[1],
       accounts[0],
       accounts[2]
     )
 
-    await testLocallyWithWeb3Node(CreateAccount, ['--contract', contractAddress], web3)
+    await testLocallyWithNode(CreateAccount, ['--contract', contractAddress], provider)
   })
 
   test(
     'can lock celo with pending withdrawals',
     async () => {
       const lockedGold = await kit.contracts.getLockedGold()
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         LockedCelo,
         ['--contract', contractAddress, '--action', 'lock', '--value', '100'],
-        web3
+        provider
       )
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         LockedCelo,
         ['--contract', contractAddress, '--action', 'unlock', '--value', '50'],
-        web3
+        provider
       )
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         LockedCelo,
         ['--contract', contractAddress, '--action', 'lock', '--value', '75'],
-        web3
+        provider
       )
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         LockedCelo,
         ['--contract', contractAddress, '--action', 'unlock', '--value', '50'],
-        web3
+        provider
       )
       const pendingWithdrawalsTotalValue =
         await lockedGold.getPendingWithdrawalsTotalValue(contractAddress)

--- a/packages/cli/src/commands/releasecelo/locked-gold.ts
+++ b/packages/cli/src/commands/releasecelo/locked-gold.ts
@@ -3,7 +3,7 @@ import { Flags } from '@oclif/core'
 
 import BigNumber from 'bignumber.js'
 import { newCheckBuilder } from '../../utils/checks'
-import { binaryPrompt, displaySendTx } from '../../utils/cli'
+import { binaryPrompt, displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 
@@ -36,6 +36,7 @@ export default class LockedCelo extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags } = await this.parse(LockedCelo)
     const value = new BigNumber(flags.value)
     const contractAddress = await this.contractAddress()
@@ -56,9 +57,9 @@ export default class LockedCelo extends ReleaseGoldBaseCommand {
       await newCheckBuilder(this, contractAddress)
         .hasEnoughCelo(contractAddress, lockValue)
         .runChecks()
-      const txos = await this.releaseGoldWrapper.relockGold(relockValue)
-      for (const txo of txos) {
-        await displaySendTx('lockedCeloRelock', txo, { from: beneficiary })
+      const hashes = await this.releaseGoldWrapper.relockGold(relockValue)
+      for (const hash of hashes) {
+        await displayViemTx('lockedCeloRelock', Promise.resolve(hash), publicClient)
       }
       if (lockValue.gt(new BigNumber(0))) {
         const accounts = await kit.contracts.getAccounts()
@@ -82,11 +83,19 @@ export default class LockedCelo extends ReleaseGoldBaseCommand {
             return
           }
         }
-        await displaySendTx('lockedCeloLock', this.releaseGoldWrapper.lockGold(lockValue))
+        await displayViemTx(
+          'lockedCeloLock',
+          this.releaseGoldWrapper.lockGold(lockValue),
+          publicClient
+        )
       }
     } else if (flags.action === 'unlock') {
       await checkBuilder.isNotVoting(contractAddress).hasEnoughLockedGoldToUnlock(value).runChecks()
-      await displaySendTx('lockedCeloUnlock', this.releaseGoldWrapper.unlockGold(flags.value))
+      await displayViemTx(
+        'lockedCeloUnlock',
+        this.releaseGoldWrapper.unlockGold(flags.value),
+        publicClient
+      )
     } else if (flags.action === 'withdraw') {
       await checkBuilder.runChecks()
       const currentTime = Math.round(new Date().getTime() / 1000)
@@ -99,7 +108,11 @@ export default class LockedCelo extends ReleaseGoldBaseCommand {
             console.log(
               `Found available pending withdrawal of value ${pendingWithdrawal.value.toFixed()}, withdrawing`
             )
-            await displaySendTx('lockedGoldWithdraw', this.releaseGoldWrapper.withdrawLockedGold(i))
+            await displayViemTx(
+              'lockedGoldWithdraw',
+              this.releaseGoldWrapper.withdrawLockedGold(i),
+              publicClient
+            )
             madeWithdrawal = true
           }
         }

--- a/packages/cli/src/commands/releasecelo/refund-and-finalize.test.ts
+++ b/packages/cli/src/commands/releasecelo/refund-and-finalize.test.ts
@@ -1,11 +1,10 @@
-import { newReleaseGold } from '@celo/abis/web3/ReleaseGold'
+import { releaseGoldABI } from '@celo/abis'
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { ReleaseGoldWrapper } from '@celo/contractkit/lib/wrappers/ReleaseGold'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { getContractFromEvent } from '@celo/dev-utils/ganache-test'
-import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import RefundAndFinalize from './refund-and-finalize'
@@ -13,16 +12,16 @@ import Revoke from './revoke'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('releasegold:refund-and-finalize cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:refund-and-finalize cmd', (provider) => {
   let contractAddress: any
   let kit: ContractKit
 
   beforeEach(async () => {
-    const accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
+    const accounts = (await kit.connection.getAccounts()) as StrongAddress[]
 
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
       accounts[1],
       accounts[0],
@@ -31,15 +30,15 @@ testWithAnvilL2('releasegold:refund-and-finalize cmd', (web3: Web3) => {
   })
 
   test('can refund celo', async () => {
-    await testLocallyWithWeb3Node(Revoke, ['--contract', contractAddress, '--yesreally'], web3)
+    await testLocallyWithNode(Revoke, ['--contract', contractAddress, '--yesreally'], provider)
     const releaseGoldWrapper = new ReleaseGoldWrapper(
       kit.connection,
-      newReleaseGold(web3, contractAddress),
+      kit.connection.getCeloContract(releaseGoldABI as any, contractAddress) as any,
       kit.contracts
     )
     const refundAddress = await releaseGoldWrapper.getRefundAddress()
     const balanceBefore = await kit.getTotalBalance(refundAddress)
-    await testLocallyWithWeb3Node(RefundAndFinalize, ['--contract', contractAddress], web3)
+    await testLocallyWithNode(RefundAndFinalize, ['--contract', contractAddress], provider)
     const balanceAfter = await kit.getTotalBalance(refundAddress)
     expect(balanceBefore.CELO!.toNumber()).toBeLessThan(balanceAfter.CELO!.toNumber())
   })
@@ -47,22 +46,22 @@ testWithAnvilL2('releasegold:refund-and-finalize cmd', (web3: Web3) => {
   test('can finalize the contract', async () => {
     const releaseGoldWrapper = new ReleaseGoldWrapper(
       kit.connection,
-      newReleaseGold(web3, contractAddress),
+      kit.connection.getCeloContract(releaseGoldABI as any, contractAddress) as any,
       kit.contracts
     )
 
     expect(await releaseGoldWrapper.isRevoked()).toBe(false)
-    await testLocallyWithWeb3Node(Revoke, ['--contract', contractAddress, '--yesreally'], web3)
+    await testLocallyWithNode(Revoke, ['--contract', contractAddress, '--yesreally'], provider)
     expect(await releaseGoldWrapper.isRevoked()).toBe(true)
 
     // Contract still should have some balance
     expect((await kit.getTotalBalance(contractAddress)).CELO).not.toEqBigNumber(0)
 
-    await testLocallyWithWeb3Node(RefundAndFinalize, ['--contract', contractAddress], web3)
+    await testLocallyWithNode(RefundAndFinalize, ['--contract', contractAddress], provider)
 
     const destroyedContractAddress = await getContractFromEvent(
       'ReleaseGoldInstanceDestroyed(address,address)',
-      web3
+      provider
     )
 
     expect(destroyedContractAddress).toBe(contractAddress)

--- a/packages/cli/src/commands/releasecelo/refund-and-finalize.ts
+++ b/packages/cli/src/commands/releasecelo/refund-and-finalize.ts
@@ -1,5 +1,5 @@
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 
 export default class RefundAndFinalize extends ReleaseGoldBaseCommand {
@@ -16,6 +16,7 @@ export default class RefundAndFinalize extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const isRevoked = await this.releaseGoldWrapper.isRevoked()
     const remainingLockedBalance = await this.releaseGoldWrapper.getRemainingLockedBalance()
 
@@ -25,6 +26,10 @@ export default class RefundAndFinalize extends ReleaseGoldBaseCommand {
       .runChecks()
 
     kit.defaultAccount = await this.releaseGoldWrapper.getReleaseOwner()
-    await displaySendTx('refundAndFinalize', await this.releaseGoldWrapper.refundAndFinalize())
+    await displayViemTx(
+      'refundAndFinalize',
+      this.releaseGoldWrapper.refundAndFinalize(),
+      publicClient
+    )
   }
 }

--- a/packages/cli/src/commands/releasecelo/revoke-votes.ts
+++ b/packages/cli/src/commands/releasecelo/revoke-votes.ts
@@ -1,8 +1,7 @@
-import { CeloTransactionObject } from '@celo/connect'
 import { Flags } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 
@@ -41,6 +40,7 @@ export default class RevokeVotes extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags } = await this.parse(RevokeVotes)
 
     await newCheckBuilder(this).isAccount(this.releaseGoldWrapper.address).runChecks()
@@ -51,13 +51,13 @@ export default class RevokeVotes extends ReleaseGoldBaseCommand {
 
     kit.defaultAccount = isRevoked ? releaseOwner : beneficiary
 
-    let txos: CeloTransactionObject<void>[]
+    let hashes: `0x${string}`[]
     if (flags.allVotes && flags.allGroups) {
-      txos = await this.releaseGoldWrapper.revokeAllVotesForAllGroups()
+      hashes = await this.releaseGoldWrapper.revokeAllVotesForAllGroups()
     } else if (flags.allVotes && flags.group) {
-      txos = await this.releaseGoldWrapper.revokeAllVotesForGroup(flags.group)
+      hashes = await this.releaseGoldWrapper.revokeAllVotesForGroup(flags.group)
     } else if (flags.votes && flags.group) {
-      txos = await this.releaseGoldWrapper.revokeValueFromVotes(
+      hashes = await this.releaseGoldWrapper.revokeValueFromVotes(
         flags.group,
         new BigNumber(flags.votes)
       )
@@ -67,8 +67,8 @@ export default class RevokeVotes extends ReleaseGoldBaseCommand {
       )
     }
 
-    for (const txo of txos) {
-      await displaySendTx('revokeVotes', txo)
+    for (const hash of hashes) {
+      await displayViemTx('revokeVotes', Promise.resolve(hash), publicClient)
     }
   }
 }

--- a/packages/cli/src/commands/releasecelo/revoke.ts
+++ b/packages/cli/src/commands/releasecelo/revoke.ts
@@ -1,7 +1,7 @@
 import { Flags } from '@oclif/core'
 import prompts from 'prompts'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 export default class Revoke extends ReleaseGoldBaseCommand {
   static description =
@@ -18,6 +18,7 @@ export default class Revoke extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
 
     const { flags } = await this.parse(Revoke)
 
@@ -43,6 +44,6 @@ export default class Revoke extends ReleaseGoldBaseCommand {
     }
 
     kit.defaultAccount = await this.releaseGoldWrapper.getReleaseOwner()
-    await displaySendTx('revokeReleasing', await this.releaseGoldWrapper.revokeReleasing())
+    await displayViemTx('revokeReleasing', this.releaseGoldWrapper.revokeReleasing(), publicClient)
   }
 }

--- a/packages/cli/src/commands/releasecelo/set-account-wallet-address.ts
+++ b/packages/cli/src/commands/releasecelo/set-account-wallet-address.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 
@@ -28,6 +28,7 @@ export default class SetAccountWalletAddress extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags } = await this.parse(SetAccountWalletAddress)
     const isRevoked = await this.releaseGoldWrapper.isRevoked()
 
@@ -58,9 +59,10 @@ export default class SetAccountWalletAddress extends ReleaseGoldBaseCommand {
     }
 
     kit.defaultAccount = await this.releaseGoldWrapper.getBeneficiary()
-    await displaySendTx(
+    await displayViemTx(
       'setAccountWalletAddressTx',
-      this.releaseGoldWrapper.setAccountWalletAddress(flags.walletAddress, sig.v, sig.r, sig.s)
+      this.releaseGoldWrapper.setAccountWalletAddress(flags.walletAddress, sig.v, sig.r, sig.s),
+      publicClient
     )
   }
 }

--- a/packages/cli/src/commands/releasecelo/set-account.test.ts
+++ b/packages/cli/src/commands/releasecelo/set-account.test.ts
@@ -1,8 +1,7 @@
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import CreateAccount from './create-account'
@@ -10,23 +9,23 @@ import SetAccount from './set-account'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('releasegold:set-account cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:set-account cmd', (provider) => {
   let contractAddress: string
   let kit: ContractKit
 
   beforeEach(async () => {
-    const accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
+    const accounts = (await kit.connection.getAccounts()) as StrongAddress[]
 
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
-      accounts[1],
       accounts[0],
+      accounts[1],
       accounts[2]
     )
 
-    await testLocallyWithWeb3Node(CreateAccount, ['--contract', contractAddress], web3)
+    await testLocallyWithNode(CreateAccount, ['--contract', contractAddress], provider)
   })
 
   it('sets all the properties', async () => {
@@ -34,13 +33,13 @@ testWithAnvilL2('releasegold:set-account cmd', (web3: Web3) => {
       '0x041bb96e35f9f4b71ca8de561fff55a249ddf9d13ab582bdd09a09e75da68ae4cd0ab7038030f41b237498b4d76387ae878dc8d98fd6f6db2c15362d1a3bf11216'
     const accountWrapper = await kit.contracts.getAccounts()
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetAccount,
       ['--contract', contractAddress, '--property', 'name', '--value', 'test-name'],
-      web3
+      provider
     )
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetAccount,
       [
         '--contract',
@@ -50,13 +49,13 @@ testWithAnvilL2('releasegold:set-account cmd', (web3: Web3) => {
         '--value',
         TEST_ENCRYPTION_KEY,
       ],
-      web3
+      provider
     )
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetAccount,
       ['--contract', contractAddress, '--property', 'metaURL', '--value', 'test-url'],
-      web3
+      provider
     )
 
     expect(await accountWrapper.getName(contractAddress)).toEqual('test-name')
@@ -66,10 +65,10 @@ testWithAnvilL2('releasegold:set-account cmd', (web3: Web3) => {
 
   it('fails if unknown property', async () => {
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         SetAccount,
         ['--contract', contractAddress, '--property', 'unknown', '--value', 'test-value'],
-        web3
+        provider
       )
     ).rejects.toMatchInlineSnapshot(`
       [Error: Expected --property=unknown to be one of: name, dataEncryptionKey, metaURL

--- a/packages/cli/src/commands/releasecelo/set-account.ts
+++ b/packages/cli/src/commands/releasecelo/set-account.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 export default class SetAccount extends ReleaseGoldBaseCommand {
   static description =
@@ -31,6 +31,7 @@ export default class SetAccount extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags } = await this.parse(SetAccount)
     const isRevoked = await this.releaseGoldWrapper.isRevoked()
 
@@ -39,6 +40,7 @@ export default class SetAccount extends ReleaseGoldBaseCommand {
       .addCheck('Contract is not revoked', () => !isRevoked)
       .runChecks()
 
+    kit.defaultAccount = await this.releaseGoldWrapper.getBeneficiary()
     let tx: any
     if (flags.property === 'name') {
       tx = this.releaseGoldWrapper.setAccountName(flags.value)
@@ -50,7 +52,6 @@ export default class SetAccount extends ReleaseGoldBaseCommand {
       return this.error(`Invalid property provided`)
     }
 
-    kit.defaultAccount = await this.releaseGoldWrapper.getBeneficiary()
-    await displaySendTx('setAccount' + flags.property + 'Tx', tx)
+    await displayViemTx('setAccount' + flags.property + 'Tx', tx, publicClient)
   }
 }

--- a/packages/cli/src/commands/releasecelo/set-beneficiary.test.ts
+++ b/packages/cli/src/commands/releasecelo/set-beneficiary.test.ts
@@ -1,17 +1,16 @@
-import { newReleaseGold } from '@celo/abis/web3/ReleaseGold'
+import { releaseGoldABI } from '@celo/abis'
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { ReleaseGoldWrapper } from '@celo/contractkit/lib/wrappers/ReleaseGold'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import SetBeneficiary from './set-beneficiary'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('releasegold:set-beneficiary cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:set-beneficiary cmd', (provider) => {
   let contractAddress: any
   let kit: ContractKit
   let releaseGoldWrapper: ReleaseGoldWrapper
@@ -23,8 +22,8 @@ testWithAnvilL2('releasegold:set-beneficiary cmd', (web3: Web3) => {
   let refundAddress: StrongAddress
 
   beforeEach(async () => {
-    kit = newKitFromWeb3(web3)
-    const accounts = await web3.eth.getAccounts()
+    kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
 
     releaseOwner = accounts[0] as StrongAddress
     beneficiary = accounts[1] as StrongAddress
@@ -33,7 +32,7 @@ testWithAnvilL2('releasegold:set-beneficiary cmd', (web3: Web3) => {
     refundAddress = accounts[4] as StrongAddress
 
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
       beneficiary,
       releaseOwner,
@@ -42,7 +41,7 @@ testWithAnvilL2('releasegold:set-beneficiary cmd', (web3: Web3) => {
 
     releaseGoldWrapper = new ReleaseGoldWrapper(
       kit.connection,
-      newReleaseGold(web3, contractAddress),
+      kit.connection.getCeloContract(releaseGoldABI as any, contractAddress) as any,
       kit.contracts
     )
     beneficiary = await releaseGoldWrapper.getBeneficiary()
@@ -52,7 +51,7 @@ testWithAnvilL2('releasegold:set-beneficiary cmd', (web3: Web3) => {
 
   test('can change beneficiary', async () => {
     // First submit the tx from the release owner (accounts[0])
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetBeneficiary,
       [
         '--contract',
@@ -63,11 +62,11 @@ testWithAnvilL2('releasegold:set-beneficiary cmd', (web3: Web3) => {
         newBeneficiary,
         '--yesreally',
       ],
-      web3
+      provider
     )
     // The multisig tx should not confirm until both parties submit
     expect(await releaseGoldWrapper.getBeneficiary()).toEqual(beneficiary)
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetBeneficiary,
       [
         '--contract',
@@ -78,7 +77,7 @@ testWithAnvilL2('releasegold:set-beneficiary cmd', (web3: Web3) => {
         newBeneficiary,
         '--yesreally',
       ],
-      web3
+      provider
     )
     expect(await releaseGoldWrapper.getBeneficiary()).toEqual(newBeneficiary)
     // It should also update the multisig owners
@@ -87,7 +86,7 @@ testWithAnvilL2('releasegold:set-beneficiary cmd', (web3: Web3) => {
 
   test('if called by a different account, it should fail', async () => {
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         SetBeneficiary,
         [
           '--contract',
@@ -98,7 +97,7 @@ testWithAnvilL2('releasegold:set-beneficiary cmd', (web3: Web3) => {
           newBeneficiary,
           '--yesreally',
         ],
-        web3
+        provider
       )
     ).rejects.toThrow()
   })
@@ -106,7 +105,7 @@ testWithAnvilL2('releasegold:set-beneficiary cmd', (web3: Web3) => {
   test('if the owners submit different txs, nothing on the ReleaseGold contract should change', async () => {
     // ReleaseOwner tries to change the beneficiary to `newBeneficiary` while the beneficiary
     // tries to change to `otherAccount`. Nothing should change on the RG contract.
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetBeneficiary,
       [
         '--contract',
@@ -117,9 +116,9 @@ testWithAnvilL2('releasegold:set-beneficiary cmd', (web3: Web3) => {
         newBeneficiary,
         '--yesreally',
       ],
-      web3
+      provider
     )
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetBeneficiary,
       [
         '--contract',
@@ -130,7 +129,7 @@ testWithAnvilL2('releasegold:set-beneficiary cmd', (web3: Web3) => {
         otherAccount,
         '--yesreally',
       ],
-      web3
+      provider
     )
     expect(await releaseGoldWrapper.getBeneficiary()).toEqual(beneficiary)
     expect(await releaseGoldMultiSig.getOwners()).toEqual([releaseOwner, beneficiary])

--- a/packages/cli/src/commands/releasecelo/set-beneficiary.ts
+++ b/packages/cli/src/commands/releasecelo/set-beneficiary.ts
@@ -1,7 +1,7 @@
 import { Flags } from '@oclif/core'
 import prompts from 'prompts'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 
@@ -32,6 +32,7 @@ export default class SetBeneficiary extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags } = await this.parse(SetBeneficiary)
     const newBeneficiary = flags.beneficiary as string
 
@@ -55,22 +56,25 @@ export default class SetBeneficiary extends ReleaseGoldBaseCommand {
     }
 
     const currentBeneficiary = await this.releaseGoldWrapper.getBeneficiary()
-    const setBeneficiaryTx = this.releaseGoldWrapper.setBeneficiary(newBeneficiary)
-    const setBeneficiaryMultiSigTx = await releaseGoldMultiSig.submitOrConfirmTransaction(
-      await this.contractAddress(),
-      setBeneficiaryTx.txo
-    )
-    await displaySendTx<any>(
+    const setBeneficiaryData = this.releaseGoldWrapper.encodeFunctionData('setBeneficiary', [
+      newBeneficiary,
+    ])
+    await displayViemTx(
       'setBeneficiary',
-      setBeneficiaryMultiSigTx,
-      { from: flags.from as string },
-      'BeneficiarySet'
+      releaseGoldMultiSig.submitOrConfirmTransaction(
+        await this.contractAddress(),
+        setBeneficiaryData
+      ),
+      publicClient
     )
-    const replaceOwnerTx = releaseGoldMultiSig.replaceOwner(currentBeneficiary, newBeneficiary)
-    const replaceOwnerMultiSigTx = await releaseGoldMultiSig.submitOrConfirmTransaction(
-      releaseGoldMultiSig.address,
-      replaceOwnerTx.txo
+    const replaceOwnerData = releaseGoldMultiSig.encodeFunctionData('replaceOwner', [
+      currentBeneficiary,
+      newBeneficiary,
+    ])
+    await displayViemTx(
+      'replaceMultiSigOwner',
+      releaseGoldMultiSig.submitOrConfirmTransaction(releaseGoldMultiSig.address, replaceOwnerData),
+      publicClient
     )
-    await displaySendTx<any>('replaceMultiSigOwner', replaceOwnerMultiSigTx, { from: flags.from })
   }
 }

--- a/packages/cli/src/commands/releasecelo/set-can-expire.test.ts
+++ b/packages/cli/src/commands/releasecelo/set-can-expire.test.ts
@@ -1,26 +1,25 @@
-import { newReleaseGold } from '@celo/abis/web3/ReleaseGold'
+import { releaseGoldABI } from '@celo/abis'
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { ReleaseGoldWrapper } from '@celo/contractkit/lib/wrappers/ReleaseGold'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { stripAnsiCodesAndTxHashes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import SetCanExpire from './set-can-expire'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('releasegold:set-can-expire cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:set-can-expire cmd', (provider) => {
   let contractAddress: string
   let kit: ContractKit
 
   beforeEach(async () => {
-    const accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
+    const accounts = (await kit.connection.getAccounts()) as StrongAddress[]
 
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
       accounts[1],
       accounts[0],
@@ -32,10 +31,10 @@ testWithAnvilL2('releasegold:set-can-expire cmd', (web3: Web3) => {
     const logMock = jest.spyOn(console, 'log')
 
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         SetCanExpire,
         ['--contract', contractAddress, '--value', 'true', '--yesreally'],
-        web3
+        provider
       )
     ).rejects.toMatchInlineSnapshot(`[Error: Some checks didn't pass!]`)
 
@@ -56,22 +55,22 @@ testWithAnvilL2('releasegold:set-can-expire cmd', (web3: Web3) => {
   it('sets can expire to false and then true', async () => {
     const releaseGoldWrapper = new ReleaseGoldWrapper(
       kit.connection,
-      newReleaseGold(kit.connection.web3, contractAddress),
+      kit.connection.getCeloContract(releaseGoldABI as any, contractAddress) as any,
       kit.contracts
     )
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetCanExpire,
       ['--contract', contractAddress, '--value', 'false', '--yesreally'],
-      web3
+      provider
     )
 
     expect((await releaseGoldWrapper.getRevocationInfo()).canExpire).toBeFalsy()
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetCanExpire,
       ['--contract', contractAddress, '--value', 'true', '--yesreally'],
-      web3
+      provider
     )
 
     expect((await releaseGoldWrapper.getRevocationInfo()).canExpire).toBeTruthy()

--- a/packages/cli/src/commands/releasecelo/set-can-expire.ts
+++ b/packages/cli/src/commands/releasecelo/set-can-expire.ts
@@ -1,7 +1,7 @@
 import { Flags } from '@oclif/core'
 import prompts from 'prompts'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 
 export default class SetCanExpire extends ReleaseGoldBaseCommand {
@@ -29,6 +29,7 @@ export default class SetCanExpire extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags } = await this.parse(SetCanExpire)
     const canExpire = flags.value === 'true' || flags.value === 'True' ? true : false
 
@@ -53,6 +54,10 @@ export default class SetCanExpire extends ReleaseGoldBaseCommand {
     }
 
     kit.defaultAccount = await this.releaseGoldWrapper.getBeneficiary()
-    await displaySendTx('setCanExpire', this.releaseGoldWrapper.setCanExpire(canExpire))
+    await displayViemTx(
+      'setCanExpire',
+      this.releaseGoldWrapper.setCanExpire(canExpire),
+      publicClient
+    )
   }
 }

--- a/packages/cli/src/commands/releasecelo/set-liquidity-provision.test.ts
+++ b/packages/cli/src/commands/releasecelo/set-liquidity-provision.test.ts
@@ -1,26 +1,25 @@
-import { newReleaseGold } from '@celo/abis/web3/ReleaseGold'
+import { releaseGoldABI } from '@celo/abis'
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { ReleaseGoldWrapper } from '@celo/contractkit/lib/wrappers/ReleaseGold'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import SetLiquidityProvision from './set-liquidity-provision'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('releasegold:set-liquidity-provision cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:set-liquidity-provision cmd', (provider) => {
   let contractAddress: string
   let kit: ContractKit
 
   beforeEach(async () => {
-    const accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
+    const accounts = (await kit.connection.getAccounts()) as StrongAddress[]
 
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
       accounts[1],
       accounts[0],
@@ -31,16 +30,16 @@ testWithAnvilL2('releasegold:set-liquidity-provision cmd', (web3: Web3) => {
   it('sets liqudity provision', async () => {
     const releaseGoldWrapper = new ReleaseGoldWrapper(
       kit.connection,
-      newReleaseGold(kit.connection.web3, contractAddress),
+      kit.connection.getCeloContract(releaseGoldABI as any, contractAddress) as any,
       kit.contracts
     )
 
     expect(await releaseGoldWrapper.getLiquidityProvisionMet()).toBeFalsy()
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetLiquidityProvision,
       ['--contract', contractAddress, '--yesreally'],
-      web3
+      provider
     )
 
     expect(await releaseGoldWrapper.getLiquidityProvisionMet()).toBeTruthy()

--- a/packages/cli/src/commands/releasecelo/set-liquidity-provision.ts
+++ b/packages/cli/src/commands/releasecelo/set-liquidity-provision.ts
@@ -1,7 +1,7 @@
 import { Flags } from '@oclif/core'
 import prompts from 'prompts'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 export default class SetLiquidityProvision extends ReleaseGoldBaseCommand {
   static description =
@@ -20,6 +20,7 @@ export default class SetLiquidityProvision extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags } = await this.parse(SetLiquidityProvision)
 
     await newCheckBuilder(this)
@@ -43,6 +44,10 @@ export default class SetLiquidityProvision extends ReleaseGoldBaseCommand {
     }
 
     kit.defaultAccount = await this.releaseGoldWrapper.getReleaseOwner()
-    await displaySendTx('setLiquidityProvision', this.releaseGoldWrapper.setLiquidityProvision())
+    await displayViemTx(
+      'setLiquidityProvision',
+      this.releaseGoldWrapper.setLiquidityProvision(),
+      publicClient
+    )
   }
 }

--- a/packages/cli/src/commands/releasecelo/set-max-distribution.test.ts
+++ b/packages/cli/src/commands/releasecelo/set-max-distribution.test.ts
@@ -1,26 +1,26 @@
-import { newReleaseGold } from '@celo/abis/web3/ReleaseGold'
+import { releaseGoldABI } from '@celo/abis'
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { ReleaseGoldWrapper } from '@celo/contractkit/lib/wrappers/ReleaseGold'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { stripAnsiCodesAndTxHashes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import SetMaxDistribution from './set-max-distribution'
+import { parseEther } from 'viem'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('releasegold:set-max-distribution cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:set-max-distribution cmd', (provider) => {
   let contractAddress: string
   let kit: ContractKit
 
   beforeEach(async () => {
-    const accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
+    const accounts = (await kit.connection.getAccounts()) as StrongAddress[]
 
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
       accounts[1],
       accounts[0],
@@ -31,19 +31,19 @@ testWithAnvilL2('releasegold:set-max-distribution cmd', (web3: Web3) => {
   it('sets max distribution', async () => {
     const releaseGoldWrapper = new ReleaseGoldWrapper(
       kit.connection,
-      newReleaseGold(kit.connection.web3, contractAddress),
+      kit.connection.getCeloContract(releaseGoldABI as any, contractAddress) as any,
       kit.contracts
     )
 
     // This basically halves the total balance which is 40 CELO initially
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetMaxDistribution,
       ['--contract', contractAddress, '--distributionRatio', '500', '--yesreally'],
-      web3
+      provider
     )
 
     expect((await releaseGoldWrapper.getMaxDistribution()).toFixed()).toEqual(
-      web3.utils.toWei('20', 'ether')
+      parseEther('20').toString()
     )
   })
 
@@ -51,10 +51,10 @@ testWithAnvilL2('releasegold:set-max-distribution cmd', (web3: Web3) => {
     const logMock = jest.spyOn(console, 'log')
 
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         SetMaxDistribution,
         ['--contract', contractAddress, '--distributionRatio', '1500', '--yesreally'],
-        web3
+        provider
       )
     ).rejects.toMatchInlineSnapshot(`[Error: Some checks didn't pass!]`)
 

--- a/packages/cli/src/commands/releasecelo/set-max-distribution.ts
+++ b/packages/cli/src/commands/releasecelo/set-max-distribution.ts
@@ -1,7 +1,7 @@
 import { Flags } from '@oclif/core'
 import prompts from 'prompts'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 export default class SetMaxDistribution extends ReleaseGoldBaseCommand {
   static description = 'Set the maximum distribution of celo for the given contract'
@@ -26,6 +26,7 @@ export default class SetMaxDistribution extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags } = await this.parse(SetMaxDistribution)
     const distributionRatio = Number(flags.distributionRatio)
 
@@ -53,9 +54,10 @@ export default class SetMaxDistribution extends ReleaseGoldBaseCommand {
     }
 
     kit.defaultAccount = await this.releaseGoldWrapper.getReleaseOwner()
-    await displaySendTx(
+    await displayViemTx(
       'setMaxDistribution',
-      this.releaseGoldWrapper.setMaxDistribution(distributionRatio)
+      this.releaseGoldWrapper.setMaxDistribution(distributionRatio),
+      publicClient
     )
   }
 }

--- a/packages/cli/src/commands/releasecelo/show.test.ts
+++ b/packages/cli/src/commands/releasecelo/show.test.ts
@@ -1,27 +1,26 @@
-import { newReleaseGold } from '@celo/abis/web3/ReleaseGold'
+import { releaseGoldABI } from '@celo/abis'
 import { StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { unixSecondsTimestampToDateString } from '@celo/contractkit/lib/wrappers/BaseWrapper'
 import { ReleaseGoldWrapper } from '@celo/contractkit/lib/wrappers/ReleaseGold'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { stripAnsiCodesAndTxHashes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import Show from './show'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('releasegold:show cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:show cmd', (provider) => {
   let contractAddress: string
   let kit: ContractKit
 
   beforeEach(async () => {
-    const accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
+    const accounts = (await kit.connection.getAccounts()) as StrongAddress[]
 
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
       accounts[1],
       accounts[0],
@@ -33,11 +32,11 @@ testWithAnvilL2('releasegold:show cmd', (web3: Web3) => {
     const logMock = jest.spyOn(console, 'log')
     const releaseGoldWrapper = new ReleaseGoldWrapper(
       kit.connection,
-      newReleaseGold(kit.connection.web3, contractAddress),
+      kit.connection.getCeloContract(releaseGoldABI as any, contractAddress) as any,
       kit.contracts
     )
 
-    await testLocallyWithWeb3Node(Show, ['--contract', contractAddress], web3)
+    await testLocallyWithNode(Show, ['--contract', contractAddress], provider)
 
     const schedule = await releaseGoldWrapper.getReleaseSchedule()
 

--- a/packages/cli/src/commands/releasecelo/transfer-dollars.test.ts
+++ b/packages/cli/src/commands/releasecelo/transfer-dollars.test.ts
@@ -1,15 +1,14 @@
 import { StableToken, StrongAddress } from '@celo/base'
 import { COMPLIANT_ERROR_RESPONSE, SANCTIONED_ADDRESSES } from '@celo/compliance'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { mineBlocks } from '@celo/dev-utils/ganache-test'
 import { ACCOUNT_PRIVATE_KEYS } from '@celo/dev-utils/test-accounts'
 import { TEST_BASE_FEE, TEST_GAS_PRICE } from '@celo/dev-utils/test-utils'
 import BigNumber from 'bignumber.js'
-import { formatEther, toHex } from 'viem'
-import Web3 from 'web3'
+import { formatEther, parseEther, toHex } from 'viem'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import Register from '../account/register'
@@ -22,14 +21,14 @@ process.env.NO_SYNCCHECK = 'true'
 // Lots of commands, sometimes times out
 jest.setTimeout(15000)
 
-testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:transfer-dollars cmd', (provider) => {
   let accounts: StrongAddress[] = []
   let contractAddress: any
   let kit: ContractKit
 
   beforeEach(async () => {
-    accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
+    accounts = (await kit.connection.getAccounts()) as StrongAddress[]
     jest.spyOn(console, 'log').mockImplementation(() => {
       // noop
     })
@@ -38,7 +37,7 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
     })
 
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
       accounts[1],
       accounts[0],
@@ -50,8 +49,8 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
     jest.spyOn(kit.connection, 'getMaxPriorityFeePerGas').mockImplementation(async () => {
       return toHex(TEST_GAS_PRICE - TEST_BASE_FEE)
     })
-    await testLocallyWithWeb3Node(Register, ['--from', accounts[0]], web3)
-    await testLocallyWithWeb3Node(CreateAccount, ['--contract', contractAddress], web3)
+    await testLocallyWithNode(Register, ['--from', accounts[0]], provider)
+    await testLocallyWithNode(CreateAccount, ['--contract', contractAddress], provider)
   })
 
   afterEach(() => {
@@ -63,17 +62,17 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
       kit,
       StableToken.USDm,
       accounts[0],
-      new BigNumber(web3.utils.toWei('1000', 'ether'))
+      new BigNumber(parseEther('1000').toString())
     )
     jest.clearAllMocks()
     const logSpy = jest.spyOn(console, 'log')
     const USDmToTransfer = '500000000000000000000'
     // Send USDm to RG contract
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         TransferDollars,
         ['--from', accounts[0], '--to', contractAddress, '--value', USDmToTransfer],
-        web3
+        provider
       )
     ).resolves.toBeUndefined()
     expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
@@ -108,13 +107,13 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
       ]
     `)
     jest.clearAllMocks()
-    await mineBlocks(2, web3)
+    await mineBlocks(2, provider)
     // RG USDm balance should match the amount sent
     const contractBalance = await kit.getTotalBalance(contractAddress)
     expect(contractBalance.USDm!.toFixed()).toEqual(USDmToTransfer)
     // Test that transfer succeeds when using the beneficiary (accounts[1])
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         RGTransferDollars,
         [
           '--contract',
@@ -126,7 +125,7 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
           '--privateKey',
           ACCOUNT_PRIVATE_KEYS[1],
         ],
-        web3
+        provider
       )
     ).resolves.toBeUndefined()
 
@@ -142,10 +141,10 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
     const logSpy = jest.spyOn(console, 'log')
     const value = BigInt(1)
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         RGTransferDollars,
         ['--contract', contractAddress, '--to', accounts[0], '--value', value.toString()],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls).at(-1)).toMatchInlineSnapshot(`
@@ -159,22 +158,22 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
       kit,
       StableToken.USDm,
       accounts[0],
-      new BigNumber(web3.utils.toWei('1000', 'ether'))
+      new BigNumber(parseEther('1000').toString())
     )
     const spy = jest.spyOn(console, 'log')
     const USDmToTransfer = '500000000000000000000'
     // Send USDm to RG contract
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferDollars,
       ['--from', accounts[0], '--to', contractAddress, '--value', USDmToTransfer],
-      web3
+      provider
     )
 
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         RGTransferDollars,
         ['--contract', contractAddress, '--to', SANCTIONED_ADDRESSES[0], '--value', '10'],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
     expect(spy).toHaveBeenCalledWith(expect.stringContaining(COMPLIANT_ERROR_RESPONSE))
@@ -185,20 +184,20 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
       kit,
       StableToken.USDm,
       accounts[0],
-      new BigNumber(web3.utils.toWei('1000', 'ether'))
+      new BigNumber(parseEther('1000').toString())
     )
     const spy = jest.spyOn(console, 'log')
     const USDmToTransfer = '500000000000000000000'
     // Send USDm to RG contract
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       TransferDollars,
       ['--from', accounts[0], '--to', contractAddress, '--value', USDmToTransfer],
-      web3
+      provider
     )
 
     // Try to transfer using account[2] which is neither beneficiary nor release owner
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         RGTransferDollars,
         [
           '--contract',
@@ -210,7 +209,7 @@ testWithAnvilL2('releasegold:transfer-dollars cmd', (web3: Web3) => {
           '--privateKey',
           ACCOUNT_PRIVATE_KEYS[2],
         ],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
 

--- a/packages/cli/src/commands/releasecelo/withdraw.test.ts
+++ b/packages/cli/src/commands/releasecelo/withdraw.test.ts
@@ -1,14 +1,13 @@
-import { newReleaseGold } from '@celo/abis/web3/ReleaseGold'
+import { releaseGoldABI } from '@celo/abis'
 import { StableToken, StrongAddress } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { ReleaseGoldWrapper } from '@celo/contractkit/lib/wrappers/ReleaseGold'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { getContractFromEvent, timeTravel } from '@celo/dev-utils/ganache-test'
 import { DAY, MONTH } from '@celo/dev-utils/test-utils'
 import BigNumber from 'bignumber.js'
-import Web3 from 'web3'
 import { topUpWithToken } from '../../test-utils/chain-setup'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import { createMultisig } from '../../test-utils/multisigUtils'
 import { deployReleaseGoldContract } from '../../test-utils/release-gold'
 import CreateAccount from './create-account'
@@ -19,42 +18,42 @@ import Withdraw from './withdraw'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('releasegold:withdraw cmd', (web3: Web3) => {
+testWithAnvilL2('releasegold:withdraw cmd', (provider) => {
   let contractAddress: string
   let kit: ContractKit
 
   beforeEach(async () => {
-    const accounts = (await web3.eth.getAccounts()) as StrongAddress[]
-    kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
+    const accounts = (await kit.connection.getAccounts()) as StrongAddress[]
 
     contractAddress = await deployReleaseGoldContract(
-      web3,
+      provider,
       await createMultisig(kit, [accounts[0], accounts[1]] as StrongAddress[], 2, 2),
       accounts[1],
       accounts[0],
       accounts[2]
     )
-    await testLocallyWithWeb3Node(CreateAccount, ['--contract', contractAddress], web3)
+    await testLocallyWithNode(CreateAccount, ['--contract', contractAddress], provider)
     // make the whole balance available for withdrawal
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetMaxDistribution,
       ['--contract', contractAddress, '--yesreally', '--distributionRatio', '1000'],
-      web3
+      provider
     )
   })
 
   test('can withdraw released celo to beneficiary', async () => {
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetLiquidityProvision,
       ['--contract', contractAddress, '--yesreally'],
-      web3
+      provider
     )
     // Based on the release schedule, 3 months needs to pass
-    await timeTravel(MONTH * 3 + DAY, web3)
+    await timeTravel(MONTH * 3 + DAY, provider)
     const withdrawalAmount = '10000000000000000000'
     const releaseGoldWrapper = new ReleaseGoldWrapper(
       kit.connection,
-      newReleaseGold(web3, contractAddress),
+      kit.connection.getCeloContract(releaseGoldABI as any, contractAddress) as any,
       kit.contracts
     )
     const beneficiary = await releaseGoldWrapper.getBeneficiary()
@@ -62,24 +61,27 @@ testWithAnvilL2('releasegold:withdraw cmd', (web3: Web3) => {
     expect((await releaseGoldWrapper.getTotalWithdrawn()).toFixed()).toEqual('0')
 
     const balanceBefore = (await kit.getTotalBalance(beneficiary)).CELO!
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       Withdraw,
       ['--contract', contractAddress, '--value', withdrawalAmount],
-      web3
+      provider
     )
 
     const balanceAfter = (await kit.getTotalBalance(beneficiary)).CELO!
 
-    const latestTransactionReceipt = await web3.eth.getTransactionReceipt(
-      (await web3.eth.getBlock('latest')).transactions[0]
-    )
+    const latestBlock = await kit.connection.viemClient.getBlock({ blockTag: 'latest' })
+    const latestTransactionReceipt = await kit.connection.viemClient.getTransactionReceipt({
+      hash: latestBlock.transactions[0],
+    })
 
     // Safety check if the latest transaction was originated by the beneficiary
     expect(latestTransactionReceipt.from.toLowerCase()).toEqual(beneficiary.toLowerCase())
 
     const difference = new BigNumber(balanceAfter)
       .minus(balanceBefore)
-      .plus(latestTransactionReceipt.effectiveGasPrice * latestTransactionReceipt.gasUsed)
+      .plus(
+        (latestTransactionReceipt.effectiveGasPrice * latestTransactionReceipt.gasUsed).toString()
+      )
 
     expect(difference.toFixed()).toEqual(withdrawalAmount)
     expect((await releaseGoldWrapper.getTotalWithdrawn()).toFixed()).toEqual(withdrawalAmount)
@@ -87,18 +89,18 @@ testWithAnvilL2('releasegold:withdraw cmd', (web3: Web3) => {
 
   test.skip("can't withdraw the whole balance if there is a USDm balance", async () => {
     const spy = jest.spyOn(console, 'log')
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       SetLiquidityProvision,
       ['--contract', contractAddress, '--yesreally'],
-      web3
+      provider
     )
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining('The liquidity provision has not already been set')
     )
-    await timeTravel(MONTH * 12 + DAY, web3)
+    await timeTravel(MONTH * 12 + DAY, provider)
     const releaseGoldWrapper = new ReleaseGoldWrapper(
       kit.connection,
-      newReleaseGold(web3, contractAddress),
+      kit.connection.getCeloContract(releaseGoldABI as any, contractAddress) as any,
       kit.contracts
     )
     const beneficiary = await releaseGoldWrapper.getBeneficiary()
@@ -109,17 +111,20 @@ testWithAnvilL2('releasegold:withdraw cmd', (web3: Web3) => {
     const USDmAmount = 100
 
     await topUpWithToken(kit, StableToken.USDm, beneficiary, new BigNumber(USDmAmount))
-    await stableToken
-      .transfer(contractAddress, USDmAmount)
-      .sendAndWaitForReceipt({ from: beneficiary })
+    const transferHash = await stableToken.transfer(contractAddress, USDmAmount, {
+      from: beneficiary,
+    })
+    await kit.connection.viemClient.waitForTransactionReceipt({
+      hash: transferHash as `0x${string}`,
+    })
 
     spy.mockClear()
     // Can't withdraw since there is USDm balance still
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         Withdraw,
         ['--contract', contractAddress, '--value', remainingBalance.toString()],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
 
@@ -148,22 +153,22 @@ testWithAnvilL2('releasegold:withdraw cmd', (web3: Web3) => {
     spy.mockClear()
     // Move out the USDm balance
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         RGTransferDollars,
         ['--contract', contractAddress, '--to', beneficiary, '--value', '100'],
-        web3
+        provider
       )
     ).resolves.toBeUndefined()
     spy.mockClear()
 
     const totalWithdrawn = await releaseGoldWrapper.getTotalWithdrawn()
     expect(totalWithdrawn.toFixed()).toMatchInlineSnapshot(`"0"`)
-    await timeTravel(DAY * 31, web3)
+    await timeTravel(DAY * 31, provider)
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         Withdraw,
         ['--contract', contractAddress, '--value', remainingBalance.toString()],
-        web3
+        provider
       )
     ).resolves.toBeUndefined()
     expect(stripAnsiCodesFromNestedArray(spy.mock.calls)).toMatchInlineSnapshot(`
@@ -203,7 +208,7 @@ testWithAnvilL2('releasegold:withdraw cmd', (web3: Web3) => {
 
     const destroyedContractAddress = await getContractFromEvent(
       'ReleaseGoldInstanceDestroyed(address,address)',
-      web3
+      provider
     )
 
     expect(destroyedContractAddress).toBe(contractAddress)

--- a/packages/cli/src/commands/releasecelo/withdraw.ts
+++ b/packages/cli/src/commands/releasecelo/withdraw.ts
@@ -1,5 +1,5 @@
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 import { ReleaseGoldBaseCommand } from '../../utils/release-gold-base'
 
@@ -23,6 +23,7 @@ export default class Withdraw extends ReleaseGoldBaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { flags } = await this.parse(Withdraw)
     const value = flags.value
 
@@ -55,6 +56,6 @@ export default class Withdraw extends ReleaseGoldBaseCommand {
       .isNotSanctioned(kit.defaultAccount as string)
       .runChecks()
 
-    await displaySendTx('withdrawTx', this.releaseGoldWrapper.withdraw(value))
+    await displayViemTx('withdrawTx', this.releaseGoldWrapper.withdraw(value), publicClient)
   }
 }

--- a/packages/cli/src/commands/validator/affiliate.ts
+++ b/packages/cli/src/commands/validator/affiliate.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 import prompts from 'prompts'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx, humanizeRequirements } from '../../utils/cli'
+import { displayViemTx, humanizeRequirements } from '../../utils/cli'
 import { CustomArgs, CustomFlags } from '../../utils/command'
 
 export default class ValidatorAffiliate extends BaseCommand {
@@ -28,6 +28,7 @@ export default class ValidatorAffiliate extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(ValidatorAffiliate)
 
     const validators = await kit.contracts.getValidators()
@@ -54,6 +55,6 @@ Affiliating with a Validator Group could result in Locked Gold requirements of u
         process.exit(0)
       }
     }
-    await displaySendTx('affiliate', validators.affiliate(groupAddress))
+    await displayViemTx('affiliate', validators.affiliate(groupAddress), publicClient)
   }
 }

--- a/packages/cli/src/commands/validator/affilliate.test.ts
+++ b/packages/cli/src/commands/validator/affilliate.test.ts
@@ -1,41 +1,41 @@
 import { NULL_ADDRESS, StrongAddress } from '@celo/base'
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newKitFromProvider } from '@celo/contractkit'
 import { ValidatorsWrapper } from '@celo/contractkit/lib/wrappers/Validators'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from '../lockedcelo/lock'
 import ValidatorAffiliate from './affiliate'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validator:affiliate', (web3: Web3) => {
+testWithAnvilL2('validator:affiliate', (provider) => {
   let account: string
   let validatorContract: ValidatorsWrapper
   let groupAddress: StrongAddress
   beforeEach(async () => {
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
     account = accounts[0]
-    const kit = newKitFromWeb3(web3)
     kit.defaultAccount = account as StrongAddress
-    const ecdsaPublicKey = await addressToPublicKey(account, web3.eth.sign)
+    const ecdsaPublicKey = await addressToPublicKey(account, kit.connection.sign)
 
     validatorContract = await kit.contracts.getValidators()
 
     const groups = await validatorContract.getRegisteredValidatorGroupsAddresses()
     groupAddress = groups[0] as StrongAddress
 
-    await testLocallyWithWeb3Node(Register, ['--from', account], web3)
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(Register, ['--from', account], provider)
+    await testLocallyWithNode(
       Lock,
       ['--from', account, '--value', '10000000000000000000000'],
-      web3
+      provider
     )
 
     // Register a validator
-    await validatorContract.registerValidatorNoBls(ecdsaPublicKey).sendAndWaitForReceipt()
+    const hash = await validatorContract.registerValidatorNoBls(ecdsaPublicKey)
+    await kit.connection.viemClient.waitForTransactionReceipt({ hash: hash as `0x${string}` })
   })
 
   afterEach(() => {
@@ -45,10 +45,10 @@ testWithAnvilL2('validator:affiliate', (web3: Web3) => {
   test('affiliates validator with a group', async () => {
     const logMock = jest.spyOn(console, 'log')
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       ValidatorAffiliate,
       ['--from', account, groupAddress, '--yes'],
-      web3
+      provider
     )
 
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
@@ -85,15 +85,16 @@ testWithAnvilL2('validator:affiliate', (web3: Web3) => {
 
   it('fails when not a validator signer', async () => {
     const logMock = jest.spyOn(console, 'log')
-    const [_, nonSignerAccount] = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const [_, nonSignerAccount] = await kit.connection.getAccounts()
 
     logMock.mockClear()
 
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         ValidatorAffiliate,
         ['--from', nonSignerAccount, groupAddress, '--yes'],
-        web3
+        provider
       )
     ).rejects.toMatchInlineSnapshot(`[Error: Some checks didn't pass!]`)
 

--- a/packages/cli/src/commands/validator/deaffiliate.ts
+++ b/packages/cli/src/commands/validator/deaffiliate.ts
@@ -1,6 +1,6 @@
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class ValidatorDeAffiliate extends BaseCommand {
@@ -16,6 +16,7 @@ export default class ValidatorDeAffiliate extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(ValidatorDeAffiliate)
 
     const validators = await kit.contracts.getValidators()
@@ -26,6 +27,6 @@ export default class ValidatorDeAffiliate extends BaseCommand {
       .signerAccountIsValidator()
       .runChecks()
 
-    await displaySendTx('deaffiliate', validators.deaffiliate())
+    await displayViemTx('deaffiliate', validators.deaffiliate(), publicClient)
   }
 }

--- a/packages/cli/src/commands/validator/deaffilliate.test.ts
+++ b/packages/cli/src/commands/validator/deaffilliate.test.ts
@@ -1,10 +1,9 @@
 import { StrongAddress } from '@celo/base'
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newKitFromProvider } from '@celo/contractkit'
 import { ValidatorsWrapper } from '@celo/contractkit/lib/wrappers/Validators'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from '../lockedcelo/lock'
 import ValidatorAffiliate from './affiliate'
@@ -12,36 +11,37 @@ import ValidatorDeAffiliate from './deaffiliate'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validator:deaffiliate', (web3: Web3) => {
+testWithAnvilL2('validator:deaffiliate', (provider) => {
   let account: string
   let validatorContract: ValidatorsWrapper
   let groupAddress: StrongAddress
   beforeEach(async () => {
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
     account = accounts[0]
-    const kit = newKitFromWeb3(web3)
     kit.defaultAccount = account as StrongAddress
-    const ecdsaPublicKey = await addressToPublicKey(account, web3.eth.sign)
+    const ecdsaPublicKey = await addressToPublicKey(account, kit.connection.sign)
 
     validatorContract = await kit.contracts.getValidators()
 
     const groups = await validatorContract.getRegisteredValidatorGroupsAddresses()
     groupAddress = groups[0] as StrongAddress
 
-    await testLocallyWithWeb3Node(Register, ['--from', account], web3)
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(Register, ['--from', account], provider)
+    await testLocallyWithNode(
       Lock,
       ['--from', account, '--value', '10000000000000000000000'],
-      web3
+      provider
     )
 
     // Register a validator
-    await validatorContract.registerValidatorNoBls(ecdsaPublicKey).sendAndWaitForReceipt()
+    const hash = await validatorContract.registerValidatorNoBls(ecdsaPublicKey)
+    await kit.connection.viemClient.waitForTransactionReceipt({ hash: hash as `0x${string}` })
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       ValidatorAffiliate,
       ['--from', account, groupAddress, '--yes'],
-      web3
+      provider
     )
   })
 
@@ -54,7 +54,7 @@ testWithAnvilL2('validator:deaffiliate', (web3: Web3) => {
     const logMock = jest.spyOn(console, 'log')
     expect(validator.affiliation).toEqual(groupAddress)
 
-    await testLocallyWithWeb3Node(ValidatorDeAffiliate, ['--from', account], web3)
+    await testLocallyWithNode(ValidatorDeAffiliate, ['--from', account], provider)
 
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
       [

--- a/packages/cli/src/commands/validator/deregister.test.ts
+++ b/packages/cli/src/commands/validator/deregister.test.ts
@@ -1,5 +1,6 @@
+import { encodeFunctionData } from 'viem'
 import { StrongAddress } from '@celo/base'
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newKitFromProvider } from '@celo/contractkit'
 import { ValidatorsWrapper } from '@celo/contractkit/lib/wrappers/Validators'
 import {
   asCoreContractsOwner,
@@ -8,11 +9,10 @@ import {
 } from '@celo/dev-utils/anvil-test'
 import { timeTravel } from '@celo/dev-utils/ganache-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
-import Web3 from 'web3'
 import {
   EXTRA_LONG_TIMEOUT_MS,
   stripAnsiCodesFromNestedArray,
-  testLocallyWithWeb3Node,
+  testLocallyWithNode,
 } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from '../lockedcelo/lock'
@@ -23,7 +23,7 @@ import { default as ValidatorRegister } from './register'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validator:deregister', (web3: Web3) => {
+testWithAnvilL2('validator:deregister', (provider) => {
   let account: string
   let ecdsaPublicKey: string
   let groupAddress: StrongAddress
@@ -36,53 +36,78 @@ testWithAnvilL2('validator:deregister', (web3: Web3) => {
     jest.spyOn(console, 'error').mockImplementation(() => {
       // noop
     })
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
     account = accounts[0]
-    const kit = newKitFromWeb3(web3)
     validatorContract = await kit.contracts.getValidators()
     const groups = await validatorContract.getRegisteredValidatorGroupsAddresses()
     groupAddress = groups[0] as StrongAddress
-    ecdsaPublicKey = await addressToPublicKey(account, web3.eth.sign)
-    await testLocallyWithWeb3Node(Register, ['--from', account], web3)
-    await testLocallyWithWeb3Node(
+    ecdsaPublicKey = await addressToPublicKey(account, kit.connection.sign)
+    await testLocallyWithNode(Register, ['--from', account], provider)
+    await testLocallyWithNode(
       Lock,
       ['--from', account, '--value', '10000000000000000000000'],
-      web3
+      provider
     )
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       ValidatorRegister,
       ['--from', account, '--ecdsaKey', ecdsaPublicKey, '--yes'],
-      web3
+      provider
     )
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       ValidatorAffiliate,
       ['--from', account, groupAddress, '--yes'],
-      web3
+      provider
     )
-    await asCoreContractsOwner(web3, async (ownerAddress) => {
-      // @ts-expect-error (.contract)
-      await validatorContract.contract.methods.setMaxGroupSize(5).send({ from: ownerAddress })
-      // @ts-expect-error (.contract)
-      await validatorContract.contract.methods
-        .setValidatorLockedGoldRequirements(2, 10000)
-        .send({ from: ownerAddress })
-      // @ts-expect-error (.contract)
-      await validatorContract.contract.methods
-        .setGroupLockedGoldRequirements(2, 10000)
-        .send({ from: ownerAddress })
+    await asCoreContractsOwner(provider, async (ownerAddress) => {
+      const setMaxGroupSizeData = encodeFunctionData({
+        // @ts-expect-error (.contract)
+        abi: validatorContract.contract.abi,
+        functionName: 'setMaxGroupSize',
+        args: [BigInt(5)],
+      })
+      await kit.connection.sendTransaction({
+        // @ts-expect-error (.contract)
+        to: validatorContract.contract.address,
+        data: setMaxGroupSizeData,
+        from: ownerAddress,
+      })
+      const setValidatorLockedGoldData = encodeFunctionData({
+        // @ts-expect-error (.contract)
+        abi: validatorContract.contract.abi,
+        functionName: 'setValidatorLockedGoldRequirements',
+        args: [BigInt(2), BigInt(10000)],
+      })
+      await kit.connection.sendTransaction({
+        // @ts-expect-error (.contract)
+        to: validatorContract.contract.address,
+        data: setValidatorLockedGoldData,
+        from: ownerAddress,
+      })
+      const setGroupLockedGoldData = encodeFunctionData({
+        // @ts-expect-error (.contract)
+        abi: validatorContract.contract.abi,
+        functionName: 'setGroupLockedGoldRequirements',
+        args: [BigInt(2), BigInt(10000)],
+      })
+      await kit.connection.sendTransaction({
+        // @ts-expect-error (.contract)
+        to: validatorContract.contract.address,
+        data: setGroupLockedGoldData,
+        from: ownerAddress,
+      })
     })
-    await withImpersonatedAccount(web3, groupAddress, async () => {
-      await testLocallyWithWeb3Node(
+    await withImpersonatedAccount(provider, groupAddress, async () => {
+      await testLocallyWithNode(
         ValidatorGroupMembers,
         [account, '--from', groupAddress, '--accept', '--yes'],
-        web3
+        provider
       )
     })
-  })
+  }, 60000)
 
   afterEach(() => {
-    jest.resetAllMocks()
-    jest.clearAllMocks()
+    jest.restoreAllMocks()
   })
 
   it(
@@ -91,11 +116,11 @@ testWithAnvilL2('validator:deregister', (web3: Web3) => {
       // precondition
       const groupAtSettup = await validatorContract.getValidatorGroup(groupAddress, false)
       expect(groupAtSettup.members).toContain(account)
-      await withImpersonatedAccount(web3, groupAddress, async () => {
-        await testLocallyWithWeb3Node(
+      await withImpersonatedAccount(provider, groupAddress, async () => {
+        await testLocallyWithNode(
           ValidatorGroupMembers,
           [account, '--from', groupAddress, '--remove', '--yes'],
-          web3
+          provider
         )
       })
 
@@ -103,11 +128,11 @@ testWithAnvilL2('validator:deregister', (web3: Web3) => {
       const { lastRemovedFromGroupTimestamp } =
         await validatorContract.getValidatorMembershipHistoryExtraData(account)
       // travel in the evm
-      await timeTravel(duration.multipliedBy(2).toNumber(), web3)
+      await timeTravel(duration.multipliedBy(2).toNumber(), provider)
       // time travel in node land
       const jestTime = lastRemovedFromGroupTimestamp * 1000
       const futureTime = jestTime + duration.multipliedBy(2000).toNumber()
-      global.Date.now = jest.fn(() => futureTime)
+      jest.spyOn(Date, 'now').mockReturnValue(futureTime)
 
       const logMock = jest.spyOn(console, 'log')
       // this ensures that any spy that were allready attached to console.log from previous calls to spyOn are cleared
@@ -123,7 +148,7 @@ testWithAnvilL2('validator:deregister', (web3: Web3) => {
         duration.toNumber()
       )
       await expect(
-        testLocallyWithWeb3Node(ValidatorDeRegister, ['--from', account], web3)
+        testLocallyWithNode(ValidatorDeRegister, ['--from', account], provider)
       ).resolves.toMatchInlineSnapshot(`undefined`)
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
               [
@@ -157,8 +182,6 @@ testWithAnvilL2('validator:deregister', (web3: Web3) => {
               ]
           `)
       expect(validatorContract.isValidator(account)).resolves.toEqual(false)
-      // @ts-expect-error
-      global.Date.now.mockReset()
     },
     EXTRA_LONG_TIMEOUT_MS
   )
@@ -175,7 +198,7 @@ testWithAnvilL2('validator:deregister', (web3: Web3) => {
       logMock.mockClear()
 
       await expect(
-        testLocallyWithWeb3Node(ValidatorDeRegister, ['--from', account], web3)
+        testLocallyWithNode(ValidatorDeRegister, ['--from', account], provider)
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
 
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
@@ -196,7 +219,7 @@ testWithAnvilL2('validator:deregister', (web3: Web3) => {
             "   ✘  Account isn't a member of a validator group ",
           ],
           [
-            "   ✘  Enough time has passed since the account was removed from a validator group? ",
+            "   ✔  Enough time has passed since the account was removed from a validator group? ",
           ],
         ]
       `)
@@ -207,44 +230,45 @@ testWithAnvilL2('validator:deregister', (web3: Web3) => {
   it(
     'succeeds if not a member of any group',
     async () => {
-      const [_, notAffiliatedValidator] = await web3.eth.getAccounts()
+      const kit = newKitFromProvider(provider)
+      const [_, notAffiliatedValidator] = await kit.connection.getAccounts()
       const groupAtSetup = await validatorContract.getValidatorGroup(groupAddress, false)
 
       // Sanity check
       expect(groupAtSetup.members).not.toContain(notAffiliatedValidator)
 
       // Register, but not affiliate
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         Lock,
         ['--from', notAffiliatedValidator, '--value', '10000000000000000000000'],
-        web3
+        provider
       )
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         ValidatorRegister,
         [
           '--from',
           notAffiliatedValidator,
           '--ecdsaKey',
-          await addressToPublicKey(notAffiliatedValidator, web3.eth.sign),
+          await addressToPublicKey(notAffiliatedValidator, kit.connection.sign),
           '--yes',
         ],
-        web3
+        provider
       )
 
       const { duration } = await validatorContract.getValidatorLockedGoldRequirements()
       const { lastRemovedFromGroupTimestamp } =
         await validatorContract.getValidatorMembershipHistoryExtraData(account)
       // travel in the evm
-      await timeTravel(duration.multipliedBy(2).toNumber(), web3)
+      await timeTravel(duration.multipliedBy(2).toNumber(), provider)
       // time travel in node land
       const jestTime = lastRemovedFromGroupTimestamp * 1000
       const futureTime = jestTime + duration.multipliedBy(2000).toNumber()
-      global.Date.now = jest.fn(() => futureTime)
+      jest.spyOn(Date, 'now').mockReturnValue(futureTime)
 
       const logMock = jest.spyOn(console, 'log')
       logMock.mockClear()
 
-      await testLocallyWithWeb3Node(ValidatorDeRegister, ['--from', notAffiliatedValidator], web3)
+      await testLocallyWithNode(ValidatorDeRegister, ['--from', notAffiliatedValidator], provider)
 
       expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
         [

--- a/packages/cli/src/commands/validator/deregister.ts
+++ b/packages/cli/src/commands/validator/deregister.ts
@@ -1,6 +1,6 @@
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class ValidatorDeregister extends BaseCommand {
@@ -16,6 +16,7 @@ export default class ValidatorDeregister extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(ValidatorDeregister)
 
     const validators = await kit.contracts.getValidators()
@@ -29,6 +30,6 @@ export default class ValidatorDeregister extends BaseCommand {
       .runChecks()
 
     const validator = await validators.signerToAccount(res.flags.from)
-    await displaySendTx('deregister', await validators.deregisterValidator(validator))
+    await displayViemTx('deregister', validators.deregisterValidator(validator), publicClient)
   }
 }

--- a/packages/cli/src/commands/validator/list.test.ts
+++ b/packages/cli/src/commands/validator/list.test.ts
@@ -1,8 +1,8 @@
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
 import { ux } from '@oclif/core'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from '../lockedcelo/lock'
 import ListValidators from './list'
@@ -10,7 +10,7 @@ import ValidatorRegister from './register'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validator:list', (web3: Web3) => {
+testWithAnvilL2('validator:list', (provider) => {
   let account: string
   let ecdsaPublicKey: string
   const writeMock = jest.spyOn(ux.write, 'stdout').mockImplementation(() => {
@@ -21,19 +21,20 @@ testWithAnvilL2('validator:list', (web3: Web3) => {
     jest.spyOn(console, 'log').mockImplementation(() => {
       // noop
     })
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
     account = accounts[0]
-    ecdsaPublicKey = await addressToPublicKey(account, web3.eth.sign)
-    await testLocallyWithWeb3Node(Register, ['--from', account], web3)
-    await testLocallyWithWeb3Node(
+    ecdsaPublicKey = await addressToPublicKey(account, kit.connection.sign)
+    await testLocallyWithNode(Register, ['--from', account], provider)
+    await testLocallyWithNode(
       Lock,
       ['--from', account, '--value', '10000000000000000000000'],
-      web3
+      provider
     )
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       ValidatorRegister,
       ['--from', account, '--ecdsaKey', ecdsaPublicKey, '--yes'],
-      web3
+      provider
     )
   })
 
@@ -43,7 +44,7 @@ testWithAnvilL2('validator:list', (web3: Web3) => {
   })
 
   it('shows all registered validators', async () => {
-    await testLocallyWithWeb3Node(ListValidators, ['--csv'], web3)
+    await testLocallyWithNode(ListValidators, ['--csv'], provider)
     expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
       [
         [

--- a/packages/cli/src/commands/validator/register-L2.test.ts
+++ b/packages/cli/src/commands/validator/register-L2.test.ts
@@ -1,63 +1,64 @@
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { addressToPublicKey } from '@celo/utils/lib/signatureUtils'
-import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { testLocallyWithNode } from '../../test-utils/cliUtils'
 import Register from '../account/register'
 import Lock from '../lockedcelo/lock'
 import ValidatorRegister from './register'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validator:register', (web3: Web3) => {
+testWithAnvilL2('validator:register', (provider) => {
   let account: string
   let ecdsaPublicKey: string
 
   beforeEach(async () => {
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
     account = accounts[0]
-    ecdsaPublicKey = await addressToPublicKey(account, web3.eth.sign)
-    await testLocallyWithWeb3Node(Register, ['--from', account], web3)
-    await testLocallyWithWeb3Node(
+    ecdsaPublicKey = await addressToPublicKey(account, kit.connection.sign)
+    await testLocallyWithNode(Register, ['--from', account], provider)
+    await testLocallyWithNode(
       Lock,
       ['--from', account, '--value', '10000000000000000000000'],
-      web3
+      provider
     )
   })
 
   test('can register validator with 0x prefix', async () => {
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         ValidatorRegister,
         ['--from', account, '--ecdsaKey', ecdsaPublicKey, '--yes'],
-        web3
+        provider
       )
     ).resolves.toBe(undefined)
   })
 
   test('can register validator without 0x prefix', async () => {
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         ValidatorRegister,
         ['--from', account, '--ecdsaKey', ecdsaPublicKey, '--yes'],
-        web3
+        provider
       )
     ).resolves.toBe(undefined)
   })
 
   test('fails if validator already registered', async () => {
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         ValidatorRegister,
         ['--from', account, '--ecdsaKey', ecdsaPublicKey, '--yes'],
-        web3
+        provider
       )
     ).resolves.toBe(undefined)
 
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         ValidatorRegister,
         ['--from', account, '--ecdsaKey', ecdsaPublicKey, '--yes'],
-        web3
+        provider
       )
     ).rejects.toThrow("Some checks didn't pass!")
   })

--- a/packages/cli/src/commands/validator/register.ts
+++ b/packages/cli/src/commands/validator/register.ts
@@ -3,7 +3,7 @@ import { Flags } from '@oclif/core'
 import humanizeDuration from 'humanize-duration'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { binaryPrompt, displaySendTx } from '../../utils/cli'
+import { binaryPrompt, displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class ValidatorRegister extends BaseCommand {
@@ -22,6 +22,7 @@ export default class ValidatorRegister extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(ValidatorRegister)
 
     const validators = await kit.contracts.getValidators()
@@ -50,12 +51,19 @@ export default class ValidatorRegister extends BaseCommand {
       .signerMeetsValidatorBalanceRequirements()
       .runChecks()
 
-    await displaySendTx('registerValidator', validators.registerValidatorNoBls(res.flags.ecdsaKey))
+    await displayViemTx(
+      'registerValidator',
+      validators.registerValidatorNoBls(res.flags.ecdsaKey),
+      publicClient
+    )
 
     // register encryption key on accounts contract
     // TODO: Use a different key data encryption
-    const pubKey = await addressToPublicKey(res.flags.from, kit.web3.eth.sign)
+    const pubKey = await addressToPublicKey(
+      res.flags.from,
+      kit.connection.sign.bind(kit.connection)
+    )
     const setKeyTx = accounts.setAccountDataEncryptionKey(pubKey)
-    await displaySendTx('Set encryption key', setKeyTx)
+    await displayViemTx('Set encryption key', setKeyTx, publicClient)
   }
 }

--- a/packages/cli/src/commands/validator/requirements.test.ts
+++ b/packages/cli/src/commands/validator/requirements.test.ts
@@ -1,11 +1,10 @@
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import Requirements from './requirements'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validator:requirements', (web3: Web3) => {
+testWithAnvilL2('validator:requirements', (provider) => {
   const logMock = jest.spyOn(console, 'log')
 
   afterEach(() => {
@@ -13,7 +12,7 @@ testWithAnvilL2('validator:requirements', (web3: Web3) => {
   })
 
   it('shows all registered validators', async () => {
-    await testLocallyWithWeb3Node(Requirements, [], web3)
+    await testLocallyWithNode(Requirements, [], provider)
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
       [
         [

--- a/packages/cli/src/commands/validator/show.test.ts
+++ b/packages/cli/src/commands/validator/show.test.ts
@@ -1,14 +1,13 @@
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { ux } from '@oclif/core'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import Show from './show'
 
 process.env.NO_SYNCCHECK = 'true'
 
 const KNOWN_DEVCHAIN_VALIDATOR = '0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f'
 
-testWithAnvilL2('validator:show', (web3: Web3) => {
+testWithAnvilL2('validator:show', (provider) => {
   const writeMock = jest.spyOn(ux.write, 'stdout')
   const logMock = jest.spyOn(console, 'log')
 
@@ -17,7 +16,7 @@ testWithAnvilL2('validator:show', (web3: Web3) => {
   })
 
   it('shows the validator', async () => {
-    await testLocallyWithWeb3Node(Show, [KNOWN_DEVCHAIN_VALIDATOR], web3)
+    await testLocallyWithNode(Show, [KNOWN_DEVCHAIN_VALIDATOR], provider)
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
       [
         [

--- a/packages/cli/src/commands/validator/status.test.ts
+++ b/packages/cli/src/commands/validator/status.test.ts
@@ -1,8 +1,7 @@
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { ux } from '@oclif/core'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import Switch from '../epochs/switch'
 import Status from './status'
 
@@ -10,7 +9,7 @@ process.env.NO_SYNCCHECK = 'true'
 
 const KNOWN_DEVCHAIN_VALIDATOR = '0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f'
 
-testWithAnvilL2('validator:status', (web3: Web3) => {
+testWithAnvilL2('validator:status', (provider) => {
   const writeMock = jest.spyOn(ux.write, 'stdout')
   const logMock = jest.spyOn(console, 'log')
 
@@ -19,10 +18,10 @@ testWithAnvilL2('validator:status', (web3: Web3) => {
   })
 
   it('displays status of the validator', async () => {
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       Status,
       ['--validator', KNOWN_DEVCHAIN_VALIDATOR, '--csv', '--start', '349'],
-      web3
+      provider
     )
 
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
@@ -56,7 +55,7 @@ testWithAnvilL2('validator:status', (web3: Web3) => {
   })
 
   it('displays status for all validators', async () => {
-    await testLocallyWithWeb3Node(Status, ['--all', '--csv', '--start', '349'], web3)
+    await testLocallyWithNode(Status, ['--all', '--csv', '--start', '349'], provider)
 
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`[]`)
     expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
@@ -94,16 +93,16 @@ testWithAnvilL2('validator:status', (web3: Web3) => {
   })
 
   it('fails if start and end are in different epochs', async () => {
-    const [account] = await web3.eth.getAccounts()
-    const kit = newKitFromWeb3(web3)
-    const blockNumber = await kit.web3.eth.getBlockNumber()
+    const kit = newKitFromProvider(provider)
+    const [account] = await kit.connection.getAccounts()
+    const blockNumber = Number(await kit.connection.viemClient.getBlockNumber())
     const epoch = await kit.getEpochNumberOfBlock(blockNumber)
     const firstBlockOfCurrentEpoch = await kit.getFirstBlockNumberForEpoch(epoch)
 
-    await testLocallyWithWeb3Node(Switch, ['--from', account], web3)
+    await testLocallyWithNode(Switch, ['--from', account], provider)
 
     await expect(
-      testLocallyWithWeb3Node(
+      testLocallyWithNode(
         Status,
         [
           '--validator',
@@ -111,7 +110,7 @@ testWithAnvilL2('validator:status', (web3: Web3) => {
           '--start',
           (firstBlockOfCurrentEpoch - 2).toString(),
         ],
-        web3
+        provider
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"Start and end blocks must be in the current epoch"`

--- a/packages/cli/src/commands/validator/status.ts
+++ b/packages/cli/src/commands/validator/status.ts
@@ -89,7 +89,7 @@ export default class ValidatorStatus extends BaseCommand {
       )
     }
 
-    const latest = await kit.web3.eth.getBlockNumber()
+    const latest = Number(await kit.connection.viemClient.getBlockNumber())
     const endBlock = res.flags.end === -1 ? latest : res.flags.end
     const startBlock = res.flags.start === -1 ? endBlock - 100 : res.flags.start
 
@@ -208,7 +208,10 @@ export default class ValidatorStatus extends BaseCommand {
       name,
       address: validator,
       signer,
-      elected: await electionCache.elected(signer, await kit.web3.eth.getBlockNumber()),
+      elected: await electionCache.elected(
+        signer,
+        Number(await kit.connection.viemClient.getBlockNumber())
+      ),
       frontRunner: frontRunnerSigners.some(eqAddress.bind(null, signer)),
     }
 

--- a/packages/cli/src/commands/validatorgroup/commission.test.ts
+++ b/packages/cli/src/commands/validatorgroup/commission.test.ts
@@ -1,9 +1,8 @@
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { setCommissionUpdateDelay } from '@celo/dev-utils/chain-setup'
 import { mineBlocks } from '@celo/dev-utils/ganache-test'
-import Web3 from 'web3'
-import { testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { testLocallyWithNode } from '../../test-utils/cliUtils'
 import AccountRegister from '../account/register'
 import Lock from '../lockedcelo/lock'
 import Commission from './commission'
@@ -11,49 +10,51 @@ import ValidatorGroupRegister from './register'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validatorgroup:comission cmd', (web3: Web3) => {
+testWithAnvilL2('validatorgroup:comission cmd', (provider) => {
   const registerValidatorGroup = async () => {
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
 
-    await testLocallyWithWeb3Node(AccountRegister, ['--from', accounts[0]], web3)
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(AccountRegister, ['--from', accounts[0]], provider)
+    await testLocallyWithNode(
       Lock,
       ['--from', accounts[0], '--value', '10000000000000000000000'],
-      web3
+      provider
     )
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       ValidatorGroupRegister,
       ['--from', accounts[0], '--commission', '0.1', '--yes'],
-      web3
+      provider
     )
   }
 
   test('can queue update', async () => {
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
     await registerValidatorGroup()
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       Commission,
       ['--from', accounts[0], '--queue-update', '0.2'],
-      web3
+      provider
     )
   })
   test('can apply update', async () => {
-    const accounts = await web3.eth.getAccounts()
-    const kit = newKitFromWeb3(web3)
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
     const validatorsWrapper = await kit.contracts.getValidators()
 
     // Set commission update delay to 3 blocks for backwards compatibility
-    await setCommissionUpdateDelay(web3, validatorsWrapper.address, 3)
+    await setCommissionUpdateDelay(provider, validatorsWrapper.address, 3)
 
     await registerValidatorGroup()
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       Commission,
       ['--from', accounts[0], '--queue-update', '0.2'],
-      web3
+      provider
     )
 
-    await mineBlocks(3, web3)
+    await mineBlocks(3, provider)
 
-    await testLocallyWithWeb3Node(Commission, ['--from', accounts[0], '--apply'], web3)
+    await testLocallyWithNode(Commission, ['--from', accounts[0], '--apply'], provider)
   })
 })

--- a/packages/cli/src/commands/validatorgroup/commission.ts
+++ b/packages/cli/src/commands/validatorgroup/commission.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 import BigNumber from 'bignumber.js'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class ValidatorGroupCommission extends BaseCommand {
@@ -33,6 +33,7 @@ export default class ValidatorGroupCommission extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(ValidatorGroupCommission)
 
     if (!(res.flags['queue-update'] || res.flags.apply)) {
@@ -51,8 +52,8 @@ export default class ValidatorGroupCommission extends BaseCommand {
         // .signerAccountIsValidatorGroup()
         .runChecks()
 
-      const tx = await validators.setNextCommissionUpdate(commission)
-      await displaySendTx('setNextCommissionUpdate', tx)
+      const tx = validators.setNextCommissionUpdate(commission)
+      await displayViemTx('setNextCommissionUpdate', tx, publicClient)
     } else if (res.flags.apply) {
       await newCheckBuilder(this, res.flags.from)
         .isSignerOrAccount()
@@ -62,8 +63,8 @@ export default class ValidatorGroupCommission extends BaseCommand {
         .hasCommissionUpdateDelayPassed()
         .runChecks()
 
-      const tx = await validators.updateCommission()
-      await displaySendTx('updateCommission', tx)
+      const tx = validators.updateCommission()
+      await displayViemTx('updateCommission', tx, publicClient)
     }
   }
 }

--- a/packages/cli/src/commands/validatorgroup/deregister.test.ts
+++ b/packages/cli/src/commands/validatorgroup/deregister.test.ts
@@ -1,27 +1,26 @@
 import { Address } from '@celo/base'
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { ux } from '@oclif/core'
-import Web3 from 'web3'
 import {
   mockTimeForwardBy,
   setupGroup,
   setupValidatorAndAddToGroup,
 } from '../../test-utils/chain-setup'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import AccountRegister from '../account/register'
 import DeRegisterValidatorGroup from './deregister'
 import ValidatorGroupMembers from './member'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validatorgroup:deregister cmd', (web3: Web3) => {
+testWithAnvilL2('validatorgroup:deregister cmd', (provider) => {
   let groupAddress: Address
   let validatorAddress: Address
   let kit: ContractKit
   beforeEach(async () => {
-    kit = newKitFromWeb3(web3)
-    const addresses = await web3.eth.getAccounts()
+    kit = newKitFromProvider(provider)
+    const addresses = await kit.connection.getAccounts()
     groupAddress = addresses[0]
     validatorAddress = addresses[1]
     await setupGroup(kit, groupAddress)
@@ -34,7 +33,7 @@ testWithAnvilL2('validatorgroup:deregister cmd', (web3: Web3) => {
       const logSpy = jest.spyOn(console, 'log').mockImplementation()
       const writeMock = jest.spyOn(ux.write, 'stdout').mockImplementation()
 
-      await testLocallyWithWeb3Node(DeRegisterValidatorGroup, ['--from', groupAddress], web3)
+      await testLocallyWithNode(DeRegisterValidatorGroup, ['--from', groupAddress], provider)
 
       expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
         [
@@ -71,14 +70,17 @@ testWithAnvilL2('validatorgroup:deregister cmd', (web3: Web3) => {
   describe('when group has had members', () => {
     beforeEach(async () => {
       await setupValidatorAndAddToGroup(kit, validatorAddress, groupAddress)
-      await testLocallyWithWeb3Node(
+      await testLocallyWithNode(
         ValidatorGroupMembers,
         ['--yes', '--from', groupAddress, '--remove', validatorAddress],
-        web3
+        provider
       )
       const validators = await kit.contracts.getValidators()
-      await validators.deaffiliate().sendAndWaitForReceipt({ from: validatorAddress })
-    })
+      const deaffiliateHash = await validators.deaffiliate({ from: validatorAddress })
+      await kit.connection.viemClient.waitForTransactionReceipt({
+        hash: deaffiliateHash as `0x${string}`,
+      })
+    }, 60000)
     describe('when not enough time has passed', () => {
       it('shows error that wait period is not over', async () => {
         // Mock Date.now() to ensure we're before the wait period ends
@@ -93,7 +95,7 @@ testWithAnvilL2('validatorgroup:deregister cmd', (web3: Web3) => {
         const logMock = jest.spyOn(console, 'log').mockImplementation()
         logMock.mockClear()
         await expect(
-          testLocallyWithWeb3Node(DeRegisterValidatorGroup, ['--from', groupAddress], web3)
+          testLocallyWithNode(DeRegisterValidatorGroup, ['--from', groupAddress], provider)
         ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
         expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
           [
@@ -125,10 +127,10 @@ testWithAnvilL2('validatorgroup:deregister cmd', (web3: Web3) => {
         expect(group.members).toHaveLength(0)
         expect(group.affiliates).toHaveLength(0)
         const groupRequirements = await validators.getGroupLockedGoldRequirements()
-        const timeSpy = await mockTimeForwardBy(groupRequirements.duration.toNumber() * 2, web3)
+        const timeSpy = await mockTimeForwardBy(groupRequirements.duration.toNumber() * 2, provider)
         const logMock = jest.spyOn(console, 'log').mockImplementation()
         await expect(
-          testLocallyWithWeb3Node(DeRegisterValidatorGroup, ['--from', groupAddress], web3)
+          testLocallyWithNode(DeRegisterValidatorGroup, ['--from', groupAddress], provider)
         ).resolves.toBeUndefined()
         expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
           [
@@ -190,15 +192,15 @@ testWithAnvilL2('validatorgroup:deregister cmd', (web3: Web3) => {
 
   describe('when is not a validator group', () => {
     beforeEach(async () => {
-      const accounts = await web3.eth.getAccounts()
-      await testLocallyWithWeb3Node(AccountRegister, ['--from', accounts[2]], web3)
+      const accounts = await kit.connection.getAccounts()
+      await testLocallyWithNode(AccountRegister, ['--from', accounts[2]], provider)
     })
     it('shows error message', async () => {
       const logSpy = jest.spyOn(console, 'log').mockImplementation()
-      const accounts = await web3.eth.getAccounts()
+      const accounts = await kit.connection.getAccounts()
       logSpy.mockClear()
       await expect(
-        testLocallyWithWeb3Node(DeRegisterValidatorGroup, ['--from', accounts[2]], web3)
+        testLocallyWithNode(DeRegisterValidatorGroup, ['--from', accounts[2]], provider)
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Some checks didn't pass!"`)
       expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
         [

--- a/packages/cli/src/commands/validatorgroup/deregister.ts
+++ b/packages/cli/src/commands/validatorgroup/deregister.ts
@@ -1,6 +1,6 @@
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class ValidatorGroupDeRegister extends BaseCommand {
@@ -19,6 +19,7 @@ export default class ValidatorGroupDeRegister extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(ValidatorGroupDeRegister)
 
     const validators = await kit.contracts.getValidators()
@@ -32,6 +33,6 @@ export default class ValidatorGroupDeRegister extends BaseCommand {
       .validatorGroupDeregisterDurationPassed()
       .then((checks) => checks.runChecks())
 
-    await displaySendTx('deregister', await validators.deregisterValidatorGroup(account))
+    await displayViemTx('deregister', validators.deregisterValidatorGroup(account), publicClient)
   }
 }

--- a/packages/cli/src/commands/validatorgroup/list.test.ts
+++ b/packages/cli/src/commands/validatorgroup/list.test.ts
@@ -1,14 +1,14 @@
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { ux } from '@oclif/core'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import AccountRegister from '../account/register'
 import Lock from '../lockedcelo/lock'
 import List from './list'
 import ValidatorGroupRegister from './register'
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validatorgroup:list cmd', (web3: Web3) => {
+testWithAnvilL2('validatorgroup:list cmd', (provider) => {
   const writeMock = jest.spyOn(ux.write, 'stdout')
 
   afterAll(() => {
@@ -16,24 +16,25 @@ testWithAnvilL2('validatorgroup:list cmd', (web3: Web3) => {
   })
 
   const registerValidatorGroup = async () => {
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
 
-    await testLocallyWithWeb3Node(AccountRegister, ['--from', accounts[0]], web3)
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(AccountRegister, ['--from', accounts[0]], provider)
+    await testLocallyWithNode(
       Lock,
       ['--from', accounts[0], '--value', '10000000000000000000000'],
-      web3
+      provider
     )
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       ValidatorGroupRegister,
       ['--from', accounts[0], '--commission', '0.1', '--yes'],
-      web3
+      provider
     )
   }
 
   it('outputs the current validator groups', async () => {
     await registerValidatorGroup()
-    await testLocallyWithWeb3Node(List, [], web3)
+    await testLocallyWithNode(List, [], provider)
     expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`
       [
         [

--- a/packages/cli/src/commands/validatorgroup/member.test.ts
+++ b/packages/cli/src/commands/validatorgroup/member.test.ts
@@ -1,19 +1,18 @@
-import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
+import { ContractKit, newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2, withImpersonatedAccount } from '@celo/dev-utils/anvil-test'
 import { ux } from '@oclif/core'
-import Web3 from 'web3'
 import {
   setupGroup,
   setupValidator,
   setupValidatorAndAddToGroup,
 } from '../../test-utils/chain-setup'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import ValidatorAffiliate from '../validator/affiliate'
 import Member from './member'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validatorgroup:member cmd', (web3: Web3) => {
+testWithAnvilL2('validatorgroup:member cmd', (provider) => {
   afterEach(() => {
     jest.clearAllMocks()
   })
@@ -23,8 +22,8 @@ testWithAnvilL2('validatorgroup:member cmd', (web3: Web3) => {
     let kit: ContractKit
     const logSpy = jest.spyOn(console, 'log').mockImplementation()
     beforeEach(async () => {
-      kit = newKitFromWeb3(web3)
-      const addresses = await web3.eth.getAccounts()
+      kit = newKitFromProvider(provider)
+      const addresses = await kit.connection.getAccounts()
       groupAddress = addresses[0]
       validatorAddress = addresses[1]
       await setupGroup(kit, groupAddress)
@@ -32,19 +31,19 @@ testWithAnvilL2('validatorgroup:member cmd', (web3: Web3) => {
     describe('when --accept called from the group signer', () => {
       beforeEach(async () => {
         await setupValidator(kit, validatorAddress)
-        await testLocallyWithWeb3Node(
+        await testLocallyWithNode(
           ValidatorAffiliate,
           [groupAddress, '--from', validatorAddress, '--yes'],
-          web3
+          provider
         )
       })
       it('accepts a new member to the group', async () => {
         const writeMock = jest.spyOn(ux.write, 'stdout').mockImplementation()
         logSpy.mockClear()
-        await testLocallyWithWeb3Node(
+        await testLocallyWithNode(
           Member,
           ['--yes', '--from', groupAddress, '--accept', validatorAddress],
-          web3
+          provider
         )
         expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`[]`)
         expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
@@ -84,10 +83,10 @@ testWithAnvilL2('validatorgroup:member cmd', (web3: Web3) => {
       it('removes a member from the group', async () => {
         const writeMock = jest.spyOn(ux.write, 'stdout').mockImplementation()
         logSpy.mockClear()
-        await testLocallyWithWeb3Node(
+        await testLocallyWithNode(
           Member,
           ['--yes', '--from', groupAddress, '--remove', validatorAddress],
-          web3
+          provider
         )
         expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`[]`)
         expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
@@ -124,7 +123,7 @@ testWithAnvilL2('validatorgroup:member cmd', (web3: Web3) => {
   describe('when --reorder called from the group signer', () => {
     it('orders member to new position in group rank', async () => {
       const logSpy = jest.spyOn(console, 'log').mockImplementation()
-      const kit = newKitFromWeb3(web3)
+      const kit = newKitFromProvider(provider)
 
       const ValidatorsWrapper = await kit.contracts.getValidators()
       const vgroups = await ValidatorsWrapper.getRegisteredValidatorGroups()
@@ -150,11 +149,11 @@ testWithAnvilL2('validatorgroup:member cmd', (web3: Web3) => {
       expect(validatorAddress).toBeDefined()
       const newPosition = '0'
 
-      await withImpersonatedAccount(web3, groupToMessWith.address, async () => {
-        await testLocallyWithWeb3Node(
+      await withImpersonatedAccount(provider, groupToMessWith.address, async () => {
+        await testLocallyWithNode(
           Member,
           [validatorAddress, '--from', groupToMessWith.address, '--reorder', newPosition],
-          web3
+          provider
         )
       })
 

--- a/packages/cli/src/commands/validatorgroup/member.ts
+++ b/packages/cli/src/commands/validatorgroup/member.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 import prompts from 'prompts'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx, humanizeRequirements } from '../../utils/cli'
+import { displayViemTx, humanizeRequirements } from '../../utils/cli'
 import { CustomArgs, CustomFlags } from '../../utils/command'
 
 export default class ValidatorGroupMembers extends BaseCommand {
@@ -38,6 +38,7 @@ export default class ValidatorGroupMembers extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(ValidatorGroupMembers)
     const validatorAddress = res.args.arg1 as string
     if (!(res.flags.accept || res.flags.remove || typeof res.flags.reorder === 'number')) {
@@ -71,14 +72,15 @@ export default class ValidatorGroupMembers extends BaseCommand {
           process.exit(0)
         }
       }
-      const tx = await validators.addMember(validatorGroup, validatorAddress)
-      await displaySendTx('addMember', tx)
+      const tx = validators.addMember(validatorGroup, validatorAddress)
+      await displayViemTx('addMember', tx, publicClient)
     } else if (res.flags.remove) {
-      await displaySendTx('removeMember', validators.removeMember(validatorAddress))
+      await displayViemTx('removeMember', validators.removeMember(validatorAddress), publicClient)
     } else if (res.flags.reorder != null) {
-      await displaySendTx(
+      await displayViemTx(
         'reorderMember',
-        await validators.reorderMember(validatorGroup, validatorAddress, res.flags.reorder)
+        validators.reorderMember(validatorGroup, validatorAddress, res.flags.reorder),
+        publicClient
       )
     }
   }

--- a/packages/cli/src/commands/validatorgroup/register.test.ts
+++ b/packages/cli/src/commands/validatorgroup/register.test.ts
@@ -1,22 +1,23 @@
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { ux } from '@oclif/core'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import AccountRegister from '../account/register'
 import Lock from '../lockedcelo/lock'
 import ValidatorGroupRegister from './register'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validatorgroup:register cmd', (web3: Web3) => {
+testWithAnvilL2('validatorgroup:register cmd', (provider) => {
   beforeEach(async () => {
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
 
-    await testLocallyWithWeb3Node(AccountRegister, ['--from', accounts[0]], web3)
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(AccountRegister, ['--from', accounts[0]], provider)
+    await testLocallyWithNode(
       Lock,
       ['--from', accounts[0], '--value', '10000000000000000000000'],
-      web3
+      provider
     )
   })
   afterAll(() => {
@@ -27,12 +28,13 @@ testWithAnvilL2('validatorgroup:register cmd', (web3: Web3) => {
     const logSpy = jest.spyOn(console, 'log')
     const writeMock = jest.spyOn(ux.write, 'stdout')
 
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
 
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       ValidatorGroupRegister,
       ['--from', accounts[0], '--commission', '0.2', '--yes'],
-      web3
+      provider
     )
     expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
       [

--- a/packages/cli/src/commands/validatorgroup/register.ts
+++ b/packages/cli/src/commands/validatorgroup/register.ts
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js'
 import humanizeDuration from 'humanize-duration'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { binaryPrompt, displaySendTx } from '../../utils/cli'
+import { binaryPrompt, displayViemTx } from '../../utils/cli'
 import { CustomFlags } from '../../utils/command'
 
 export default class ValidatorGroupRegister extends BaseCommand {
@@ -25,6 +25,7 @@ export default class ValidatorGroupRegister extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const res = await this.parse(ValidatorGroupRegister)
 
     const validators = await kit.contracts.getValidators()
@@ -54,7 +55,7 @@ export default class ValidatorGroupRegister extends BaseCommand {
       .signerMeetsValidatorGroupBalanceRequirements()
       .runChecks()
 
-    const tx = await validators.registerValidatorGroup(commission)
-    await displaySendTx('registerValidatorGroup', tx)
+    const tx = validators.registerValidatorGroup(commission)
+    await displayViemTx('registerValidatorGroup', tx, publicClient)
   }
 }

--- a/packages/cli/src/commands/validatorgroup/reset-slashing-multiplier.test.ts
+++ b/packages/cli/src/commands/validatorgroup/reset-slashing-multiplier.test.ts
@@ -1,7 +1,7 @@
+import { newKitFromProvider } from '@celo/contractkit'
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { ux } from '@oclif/core'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import AccountRegister from '../account/register'
 import Lock from '../lockedcelo/lock'
 import ValidatorGroupRegister from './register'
@@ -9,20 +9,21 @@ import ResetSlashingMultiplier from './reset-slashing-multiplier'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validatorgroup:reset-slashing-multiplier cmd', (web3: Web3) => {
+testWithAnvilL2('validatorgroup:reset-slashing-multiplier cmd', (provider) => {
   beforeEach(async () => {
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
 
-    await testLocallyWithWeb3Node(AccountRegister, ['--from', accounts[0]], web3)
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(AccountRegister, ['--from', accounts[0]], provider)
+    await testLocallyWithNode(
       Lock,
       ['--from', accounts[0], '--value', '10000000000000000000000'],
-      web3
+      provider
     )
-    await testLocallyWithWeb3Node(
+    await testLocallyWithNode(
       ValidatorGroupRegister,
       ['--from', accounts[0], '--commission', '0.2', '--yes'],
-      web3
+      provider
     )
   })
   afterAll(() => {
@@ -33,9 +34,10 @@ testWithAnvilL2('validatorgroup:reset-slashing-multiplier cmd', (web3: Web3) => 
     const logSpy = jest.spyOn(console, 'log')
     const writeMock = jest.spyOn(ux.write, 'stdout')
 
-    const accounts = await web3.eth.getAccounts()
+    const kit = newKitFromProvider(provider)
+    const accounts = await kit.connection.getAccounts()
 
-    await testLocallyWithWeb3Node(ResetSlashingMultiplier, [accounts[0]], web3)
+    await testLocallyWithNode(ResetSlashingMultiplier, [accounts[0]], provider)
 
     expect(stripAnsiCodesFromNestedArray(logSpy.mock.calls)).toMatchInlineSnapshot(`
       [

--- a/packages/cli/src/commands/validatorgroup/reset-slashing-multiplier.ts
+++ b/packages/cli/src/commands/validatorgroup/reset-slashing-multiplier.ts
@@ -1,7 +1,7 @@
 import { StrongAddress } from '@celo/base'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
-import { displaySendTx } from '../../utils/cli'
+import { displayViemTx } from '../../utils/cli'
 import { CustomArgs } from '../../utils/command'
 
 export default class ResetSlashingMultiplier extends BaseCommand {
@@ -19,6 +19,7 @@ export default class ResetSlashingMultiplier extends BaseCommand {
 
   async run() {
     const kit = await this.getKit()
+    const publicClient = await this.getPublicClient()
     const { args } = await this.parse(ResetSlashingMultiplier)
     const address = args.arg1 as StrongAddress
 
@@ -32,6 +33,10 @@ export default class ResetSlashingMultiplier extends BaseCommand {
       .resetSlashingmultiplierPeriodPassed()
       .runChecks()
 
-    await displaySendTx('reset-slashing-multiplier', validators.resetSlashingMultiplier())
+    await displayViemTx(
+      'reset-slashing-multiplier',
+      validators.resetSlashingMultiplier(),
+      publicClient
+    )
   }
 }

--- a/packages/cli/src/commands/validatorgroup/rpc-urls.test.ts
+++ b/packages/cli/src/commands/validatorgroup/rpc-urls.test.ts
@@ -1,4 +1,4 @@
-import { newKitFromWeb3 } from '@celo/contractkit'
+import { newKitFromProvider } from '@celo/contractkit'
 import { AccountsWrapper } from '@celo/contractkit/lib/wrappers/Accounts'
 import { setBalance, testWithAnvilL2, withImpersonatedAccount } from '@celo/dev-utils/anvil-test'
 import { ClaimTypes, IdentityMetadataWrapper } from '@celo/metadata-claims'
@@ -9,12 +9,12 @@ import {
   setupGroupAndAffiliateValidator,
   setupValidator,
 } from '../../test-utils/chain-setup'
-import { stripAnsiCodesAndTxHashes, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesAndTxHashes, testLocallyWithNode } from '../../test-utils/cliUtils'
 import RpcUrls from './rpc-urls'
 
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validatorgroup:rpc-urls cmd', async (web3) => {
+testWithAnvilL2('validatorgroup:rpc-urls cmd', async (provider) => {
   jest.spyOn(IdentityMetadataWrapper, 'fetchFromURL').mockImplementation(async (_, url) => {
     const validatorAddress = url.split('/').pop()
 
@@ -38,19 +38,23 @@ testWithAnvilL2('validatorgroup:rpc-urls cmd', async (web3) => {
     } as any) // that data is enough
   })
 
+  let kit: ReturnType<typeof newKitFromProvider>
+
   const setMetadataUrlForValidator = async (
     accountsWrapper: AccountsWrapper,
     validator: string
   ) => {
     await withImpersonatedAccount(
-      web3,
+      provider,
       validator,
       async () => {
-        await accountsWrapper
-          .setMetadataURL(`https://example.com/metadata/${validator}`)
-          .sendAndWaitForReceipt({
+        const hash = await accountsWrapper.setMetadataURL(
+          `https://example.com/metadata/${validator}`,
+          {
             from: validator,
-          })
+          }
+        )
+        await kit.connection.viemClient.waitForTransactionReceipt({ hash: hash as `0x${string}` })
       },
       parseEther('10000000')
     )
@@ -65,40 +69,47 @@ testWithAnvilL2('validatorgroup:rpc-urls cmd', async (web3) => {
   ]
 
   beforeEach(async () => {
-    const kit = newKitFromWeb3(web3)
+    kit = newKitFromProvider(provider)
     const accountsWrapper = await kit.contracts.getAccounts()
 
     const [nonElectedGroupAddress, validatorAddress, nonAffilatedValidatorAddress] =
-      await web3.eth.getAccounts()
+      await kit.connection.getAccounts()
 
-    await setBalance(web3, nonAffilatedValidatorAddress as Address, MIN_PRACTICAL_LOCKED_CELO_VALUE)
+    await setBalance(
+      provider,
+      nonAffilatedValidatorAddress as Address,
+      MIN_PRACTICAL_LOCKED_CELO_VALUE
+    )
     await setupValidator(kit, nonAffilatedValidatorAddress)
-    await setBalance(web3, nonElectedGroupAddress as Address, MIN_PRACTICAL_LOCKED_CELO_VALUE)
-    await setBalance(web3, validatorAddress as Address, MIN_PRACTICAL_LOCKED_CELO_VALUE)
+    await setBalance(provider, nonElectedGroupAddress as Address, MIN_PRACTICAL_LOCKED_CELO_VALUE)
+    await setBalance(provider, validatorAddress as Address, MIN_PRACTICAL_LOCKED_CELO_VALUE)
     await setupGroupAndAffiliateValidator(kit, nonElectedGroupAddress, validatorAddress)
 
-    await accountsWrapper
-      .setName('Test group')
-      .sendAndWaitForReceipt({ from: nonElectedGroupAddress })
+    const setNameHash = await accountsWrapper.setName('Test group', {
+      from: nonElectedGroupAddress,
+    })
+    await kit.connection.viemClient.waitForTransactionReceipt({
+      hash: setNameHash as `0x${string}`,
+    })
     for (const validator of [
       ...EXISTING_VALIDATORS,
       validatorAddress,
       nonAffilatedValidatorAddress,
     ]) {
-      await setBalance(web3, validator as Address, MIN_PRACTICAL_LOCKED_CELO_VALUE)
+      await setBalance(provider, validator as Address, MIN_PRACTICAL_LOCKED_CELO_VALUE)
       try {
         await setMetadataUrlForValidator(accountsWrapper, validator)
       } catch (error) {
         process.stderr.write(`Failed to set metadata URL for ${validator}: ${error}\n`)
       }
     }
-  })
+  }, 60000)
 
   it('shows the RPC URLs of the elected validator groups', async () => {
     const logMock = jest.spyOn(console, 'log')
     const writeMock = jest.spyOn(ux.write, 'stdout')
 
-    await testLocallyWithWeb3Node(RpcUrls, ['--csv'], web3)
+    await testLocallyWithNode(RpcUrls, ['--csv'], provider)
 
     expect(
       writeMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes))
@@ -127,7 +138,7 @@ testWithAnvilL2('validatorgroup:rpc-urls cmd', async (web3) => {
     const logMock = jest.spyOn(console, 'log')
     const writeMock = jest.spyOn(ux.write, 'stdout')
 
-    await testLocallyWithWeb3Node(RpcUrls, ['--all', '--csv'], web3)
+    await testLocallyWithNode(RpcUrls, ['--all', '--csv'], provider)
 
     expect(
       writeMock.mock.calls.map((args) => args.map(stripAnsiCodesAndTxHashes))

--- a/packages/cli/src/commands/validatorgroup/show.test.ts
+++ b/packages/cli/src/commands/validatorgroup/show.test.ts
@@ -1,11 +1,10 @@
 import { testWithAnvilL2 } from '@celo/dev-utils/anvil-test'
 import { ux } from '@oclif/core'
-import Web3 from 'web3'
-import { stripAnsiCodesFromNestedArray, testLocallyWithWeb3Node } from '../../test-utils/cliUtils'
+import { stripAnsiCodesFromNestedArray, testLocallyWithNode } from '../../test-utils/cliUtils'
 import Show from './show'
 process.env.NO_SYNCCHECK = 'true'
 
-testWithAnvilL2('validatorgroup:show cmd', (web3: Web3) => {
+testWithAnvilL2('validatorgroup:show cmd', (provider) => {
   const writeMock = jest.spyOn(ux.write, 'stdout')
   const logMock = jest.spyOn(console, 'log')
 
@@ -15,7 +14,7 @@ testWithAnvilL2('validatorgroup:show cmd', (web3: Web3) => {
 
   it('outputs the current validator groups', async () => {
     const validatorGroupfromDevChainSetup = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
-    await testLocallyWithWeb3Node(Show, [validatorGroupfromDevChainSetup], web3)
+    await testLocallyWithNode(Show, [validatorGroupfromDevChainSetup], provider)
     expect(stripAnsiCodesFromNestedArray(writeMock.mock.calls)).toMatchInlineSnapshot(`[]`)
     expect(stripAnsiCodesFromNestedArray(logMock.mock.calls)).toMatchInlineSnapshot(`
       [

--- a/packages/dev-utils/src/test-utils.ts
+++ b/packages/dev-utils/src/test-utils.ts
@@ -14,12 +14,15 @@ class SimpleHttpProvider implements Provider {
   }
 
   request: EIP1193RequestFn = async ({ method, params }) => {
-    const body = JSON.stringify({
-      id: ++nextId,
-      jsonrpc: '2.0',
-      method,
-      params: Array.isArray(params) ? params : params != null ? [params] : [],
-    })
+    const body = JSON.stringify(
+      {
+        id: ++nextId,
+        jsonrpc: '2.0',
+        method,
+        params: Array.isArray(params) ? params : params != null ? [params] : [],
+      },
+      (_, val) => (typeof val === 'bigint' ? `0x${val.toString(16)}` : val)
+    )
     const parsedUrl = new URL(this.url)
 
     return new Promise<any>((resolve, reject) => {

--- a/packages/sdk/contractkit/src/wrappers/Validators.test.ts
+++ b/packages/sdk/contractkit/src/wrappers/Validators.test.ts
@@ -125,11 +125,11 @@ testWithAnvilL2('Validators Wrapper', (provider) => {
   })
 
   describe('reorders member', () => {
-    jest.setTimeout(30 * 1000)
+    jest.setTimeout(60 * 1000)
     let groupAccount: string, validator1: string, validator2: string
 
     beforeEach(async () => {
-      jest.setTimeout(30 * 1000)
+      jest.setTimeout(60 * 1000)
 
       groupAccount = accounts[0]
       await setupGroup(groupAccount, 2)
@@ -210,13 +210,13 @@ testWithAnvilL2('Validators Wrapper', (provider) => {
       await startAndFinishEpochProcess(kit)
       const lastBlockNumberForEpochPromise = validators.getLastBlockNumberForEpoch(lastEpoch)
       expect(typeof (await lastBlockNumberForEpochPromise)).toBe('number')
-    })
+    }, 60000)
     it("can fetch block's epoch information", async () => {
       await startAndFinishEpochProcess(kit)
       const epochNumberOfBlockPromise = validators.getEpochNumberOfBlock(
         Number(await kit.connection.viemClient.getBlockNumber())
       )
       expect(typeof (await epochNumberOfBlockPromise)).toBe('number')
-    })
+    }, 60000)
   })
 })


### PR DESCRIPTION
## Stack
> [A](#766) → [B](#767) → [C](#768) → [D1](#769) → [D2](#770) → [D3](#771) → [D4](#772) → **D5** ← CI must be green

## Changes
Replace web3-based transaction patterns with viem equivalents across `releasecelo/`, `validator/`, and `validatorgroup/` CLI commands and their tests.

This is the final PR in the stack — CI must pass here before merging any of the chain.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the codebase to replace instances of `displaySendTx` with `displayViemTx`, updating the transaction handling mechanism to use a new client. It also modifies test cases to use a provider instead of Web3, enhancing compatibility with a new connection method.

### Detailed summary
- Replaced `displaySendTx` with `displayViemTx` in various command files.
- Updated transaction handling to use `publicClient`.
- Modified test cases to use `provider` instead of `web3`.
- Changed `newKitFromWeb3` to `newKitFromProvider` in tests.
- Adjusted transaction hash handling for better compatibility.

> The following files were skipped due to too many changes: `packages/cli/src/commands/releasecelo/set-account.test.ts`, `packages/cli/src/commands/validator/affilliate.test.ts`, `packages/cli/src/commands/releasecelo/refund-and-finalize.test.ts`, `packages/cli/src/commands/validatorgroup/member.test.ts`, `packages/cli/src/commands/releasecelo/admin-revoke.ts`, `packages/cli/src/commands/validatorgroup/rpc-urls.test.ts`, `packages/cli/src/commands/releasecelo/set-beneficiary.test.ts`, `packages/cli/src/commands/validatorgroup/deregister.test.ts`, `packages/cli/src/commands/releasecelo/authorize.test.ts`, `packages/cli/src/commands/releasecelo/transfer-dollars.test.ts`, `packages/cli/src/commands/releasecelo/withdraw.test.ts`, `packages/cli/src/commands/releasecelo/admin-revoke.test.ts`, `packages/cli/src/commands/validator/deregister.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->