### PR TITLE
Add --simulate flag to governance:propose

### DIFF
--- a/.changeset/celocli-governance-propose-simulate.md
+++ b/.changeset/celocli-governance-propose-simulate.md
@@ -1,0 +1,9 @@
+---
+'@celo/celocli': minor
+---
+
+Add `--simulate` flag to `governance:propose` command to simulate proposal execution against a forked node (e.g. anvil) before submitting on-chain.
+
+Unlike the default `eth_call`-based simulation, `--simulate` actually sends each proposal transaction sequentially from the Governance contract address (which the node must have unlocked, e.g. `anvil --auto-impersonate`). This means transactions execute against cumulative state changes — useful for proposals where the success of one transaction depends on a previous one succeeding. If any transaction fails, the proposal is not submitted and the decoded revert reason is printed.
+
+Example: `celocli governance:propose --jsonTransactions ./transactions.json --deposit 100e18 --from 0x... --descriptionURL https://... --simulate http://127.0.0.1:8545`

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -18,9 +18,7 @@ import { ArgOutput, FlagOutput, Input, ParserOutput } from '@oclif/core/lib/inte
 import chalk from 'chalk'
 import net from 'net'
 import {
-  createPublicClient,
   createWalletClient,
-  extractChain,
   http,
   isAddressEqual,
   MethodNotFoundRpcError,
@@ -31,6 +29,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 import { celo, celoSepolia } from 'viem/chains'
 import { ipc } from 'viem/node'
 import Web3 from 'web3'
+import createCeloPublicClient from './packages-to-be/public-client'
 import createRpcWalletClient from './packages-to-be/rpc-client'
 import { failWith } from './utils/cli'
 import { CustomFlags } from './utils/command'
@@ -227,39 +226,7 @@ export abstract class BaseCommand extends Command {
       const nodeUrl = await this.getNodeUrl()
       ux.action.start(`Connecting to Node ${nodeUrl}`)
       const transport = await this.getTransport()
-
-      // Create an intermediate client to get the chain id
-      const intermediateClient = createPublicClient({
-        transport,
-      })
-      const chainId = await intermediateClient.getChainId()
-      const extractedChain = extractChain({
-        chains: [celo, celoSepolia],
-        id: chainId as typeof celo.id | typeof celoSepolia.id,
-      })
-
-      if (extractedChain) {
-        this.publicClient = createPublicClient({
-          transport,
-          batch: { multicall: true },
-          chain: extractedChain,
-        })
-      } else {
-        // we might be connecting to a dev chain or anvil fork or another testnet
-        this.publicClient = createPublicClient({
-          transport,
-          chain: {
-            name: 'Custom Celo Chain',
-            id: chainId,
-            nativeCurrency: celo.nativeCurrency,
-            formatters: celo.formatters,
-            serializers: celo.serializers,
-            rpcUrls: {
-              default: { http: [nodeUrl] },
-            },
-          } as unknown as PublicCeloClient['chain'],
-        })
-      }
+      this.publicClient = await createCeloPublicClient({ transport, nodeUrl })
       ux.action.stop()
     }
 

--- a/packages/cli/src/commands/governance/build-proposal.ts
+++ b/packages/cli/src/commands/governance/build-proposal.ts
@@ -55,6 +55,7 @@ export default class BuildProposal extends BaseCommand {
     output.forEach((tx) => builder.addJsonTx(tx))
     const proposal = await builder.build()
 
-    await checkProposal(proposal, kit)
+    const governance = await kit.contracts.getGovernance()
+    await checkProposal(proposal, kit, governance.address)
   }
 }

--- a/packages/cli/src/commands/governance/hashhotfix.ts
+++ b/packages/cli/src/commands/governance/hashhotfix.ts
@@ -34,15 +34,16 @@ export default class HashHotfix extends BaseCommand {
     jsonTransactions.forEach((tx) => builder.addJsonTx(tx))
     const hotfix = await builder.build()
 
+    const governance = await kit.contracts.getGovernance()
+
     if (!res.flags.force) {
-      const ok = await checkProposal(hotfix, kit)
+      const ok = await checkProposal(hotfix, kit, governance.address)
       if (!ok) {
         return
       }
     }
 
     // Combine with the salt and hash the proposal.
-    const governance = await kit.contracts.getGovernance()
     const saltBuff = Buffer.from(trimLeading0x(res.flags.salt), 'hex')
     console.log(`salt: ${res.flags.salt}, buf: ${saltBuff.toString('hex')}`)
     const hash = await governance.getHotfixHash(hotfix, saltBuff)

--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -2,6 +2,7 @@ import { ProposalBuilder, proposalToJSON, ProposalTransactionJSON } from '@celo/
 import { Flags } from '@oclif/core'
 import { BigNumber } from 'bignumber.js'
 import { readFileSync } from 'fs'
+import { type Hex } from 'viem'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { displaySendTx, printValueMapRecursive } from '../../utils/cli'
@@ -11,6 +12,7 @@ import {
   addExistingProposalIDToBuilder,
   addExistingProposalJSONFileToBuilder,
   checkProposal,
+  simulateProposalOnRpc,
 } from '../../utils/governance'
 import {
   createSafeFromWeb3,
@@ -33,7 +35,17 @@ export default class Propose extends BaseCommand {
       description: 'Amount of Celo to attach to proposal',
     }),
     from: CustomFlags.address({ required: true, description: "Proposer's address" }),
-    force: Flags.boolean({ description: 'Skip execution check', default: false }),
+    force: Flags.boolean({
+      description: 'Skip execution check',
+      default: false,
+      exclusive: ['simulate'],
+    }),
+    simulate: Flags.string({
+      required: false,
+      description:
+        'RPC URL of a forked node (e.g. anvil) to simulate the proposal against. Each proposal transaction is actually sent (not eth_call) from the Governance contract address, which the node must have unlocked (e.g. anvil --auto-impersonate). Replaces the default eth_call simulation.',
+      exclusive: ['force'],
+    }),
     noInfo: Flags.boolean({ description: 'Skip printing the proposal info', default: false }),
     descriptionURL: CustomFlags.proposalDescriptionURL({
       required: true,
@@ -114,7 +126,9 @@ export default class Propose extends BaseCommand {
     }
 
     if (!res.flags.force) {
-      const ok = await checkProposal(proposal, kit)
+      const ok = res.flags.simulate
+        ? await simulateProposalOnRpc(proposal, res.flags.simulate, governance.address as Hex)
+        : await checkProposal(proposal, kit)
       if (!ok) {
         return
       }

--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -127,7 +127,7 @@ export default class Propose extends BaseCommand {
     if (!res.flags.force) {
       const ok = res.flags.simulate
         ? await simulateProposalOnRpc(proposal, res.flags.simulate, governance.address)
-        : await checkProposal(proposal, kit)
+        : await checkProposal(proposal, kit, governance.address)
       if (!ok) {
         return
       }

--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -2,7 +2,6 @@ import { ProposalBuilder, proposalToJSON, ProposalTransactionJSON } from '@celo/
 import { Flags } from '@oclif/core'
 import { BigNumber } from 'bignumber.js'
 import { readFileSync } from 'fs'
-import { type Hex } from 'viem'
 import { BaseCommand } from '../../base'
 import { newCheckBuilder } from '../../utils/checks'
 import { displaySendTx, printValueMapRecursive } from '../../utils/cli'
@@ -127,7 +126,7 @@ export default class Propose extends BaseCommand {
 
     if (!res.flags.force) {
       const ok = res.flags.simulate
-        ? await simulateProposalOnRpc(proposal, res.flags.simulate, governance.address as Hex)
+        ? await simulateProposalOnRpc(proposal, res.flags.simulate, governance.address)
         : await checkProposal(proposal, kit)
       if (!ok) {
         return

--- a/packages/cli/src/commands/governance/propose.ts
+++ b/packages/cli/src/commands/governance/propose.ts
@@ -43,7 +43,7 @@ export default class Propose extends BaseCommand {
     simulate: Flags.string({
       required: false,
       description:
-        'RPC URL of a forked node (e.g. anvil) to simulate the proposal against. Each proposal transaction is actually sent (not eth_call) from the Governance contract address, which the node must have unlocked (e.g. anvil --auto-impersonate). Replaces the default eth_call simulation.',
+        'RPC URL of a forked node (e.g. anvil) to simulate the proposal against. Each proposal transaction is actually sent (not eth_call) from the Governance contract address, which the node must have unlocked (e.g. anvil --auto-impersonate). Replaces the default eth_call simulation. Useful for proposals where the success of one tx depends on a previous one succeeding.',
       exclusive: ['force'],
     }),
     noInfo: Flags.boolean({ description: 'Skip printing the proposal info', default: false }),

--- a/packages/cli/src/packages-to-be/public-client.ts
+++ b/packages/cli/src/packages-to-be/public-client.ts
@@ -1,0 +1,40 @@
+import { type PublicCeloClient } from '@celo/actions'
+import { createPublicClient, extractChain, type Transport } from 'viem'
+import { celo, celoSepolia } from 'viem/chains'
+
+export default async function createCeloPublicClient({
+  transport,
+  nodeUrl,
+}: {
+  transport: Transport
+  nodeUrl: string
+}): Promise<PublicCeloClient> {
+  const intermediateClient = createPublicClient({ transport })
+  const chainId = await intermediateClient.getChainId()
+  const extractedChain = extractChain({
+    chains: [celo, celoSepolia],
+    id: chainId as typeof celo.id | typeof celoSepolia.id,
+  })
+
+  if (extractedChain) {
+    return createPublicClient({
+      transport,
+      batch: { multicall: true },
+      chain: extractedChain,
+    })
+  }
+
+  return createPublicClient({
+    transport,
+    chain: {
+      name: 'Custom Celo Chain',
+      id: chainId,
+      nativeCurrency: celo.nativeCurrency,
+      formatters: celo.formatters,
+      serializers: celo.serializers,
+      rpcUrls: {
+        default: { http: [nodeUrl] },
+      },
+    } as unknown as PublicCeloClient['chain'],
+  })
+}

--- a/packages/cli/src/packages-to-be/public-client.ts
+++ b/packages/cli/src/packages-to-be/public-client.ts
@@ -9,6 +9,7 @@ export default async function createCeloPublicClient({
   transport: Transport
   nodeUrl: string
 }): Promise<PublicCeloClient> {
+  // Create an intermediate client to get the chain id
   const intermediateClient = createPublicClient({ transport })
   const chainId = await intermediateClient.getChainId()
   const extractedChain = extractChain({
@@ -24,6 +25,7 @@ export default async function createCeloPublicClient({
     })
   }
 
+  // we might be connecting to a dev chain or anvil fork or another testnet
   return createPublicClient({
     transport,
     chain: {

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -4,10 +4,74 @@ import { ProposalTransaction } from '@celo/contractkit/lib/wrappers/Governance'
 import { ProposalBuilder, proposalToJSON, ProposalTransactionJSON } from '@celo/governance'
 import chalk from 'chalk'
 import { readJsonSync } from 'fs-extra'
+import { createWalletClient, http, type Hex } from 'viem'
+import createCeloPublicClient from '../packages-to-be/public-client'
 
 export async function checkProposal(proposal: ProposalTransaction[], kit: ContractKit) {
   const governance = await kit.contracts.getGovernance()
   return tryProposal(proposal, kit, governance.address, true)
+}
+
+export async function simulateProposalOnRpc(
+  proposal: ProposalTransaction[],
+  rpcUrl: string,
+  governanceAddress: Hex
+) {
+  const transport = http(rpcUrl)
+  const publicClient = await createCeloPublicClient({ transport, nodeUrl: rpcUrl })
+
+  const walletClient = createWalletClient({
+    transport,
+    chain: publicClient.chain,
+    account: governanceAddress,
+  })
+
+  console.log(
+    `Simulating proposal execution against ${rpcUrl} as Governance ${governanceAddress}`
+  )
+
+  let ok = true
+  for (const [i, tx] of proposal.entries()) {
+    if (!tx.to) {
+      continue
+    }
+    try {
+      const hash = await walletClient.sendTransaction({
+        to: tx.to as Hex,
+        value: BigInt(tx.value ?? 0),
+        data: (tx.input ?? '0x') as Hex,
+      })
+      const receipt = await publicClient.waitForTransactionReceipt({ hash })
+      if (receipt.status !== 'success') {
+        let reason = ''
+        try {
+          await publicClient.call({
+            to: tx.to as Hex,
+            data: (tx.input ?? '0x') as Hex,
+            value: BigInt(tx.value ?? 0),
+            account: governanceAddress,
+            blockNumber: receipt.blockNumber,
+          })
+        } catch (callErr: any) {
+          reason = callErr.shortMessage || callErr.message || String(callErr)
+        }
+        console.log(
+          chalk.red(
+            `   ${chalk.bold('✘')}  Transaction ${i} reverted on-chain (${hash})${
+              reason ? `: ${reason}` : ''
+            }`
+          )
+        )
+        ok = false
+      } else {
+        console.log(chalk.green(`   ${chalk.bold('✔')}  Transaction ${i} success! (${hash})`))
+      }
+    } catch (err: any) {
+      console.log(chalk.red(`   ${chalk.bold('✘')}  Transaction ${i} failure: ${err.toString()}`))
+      ok = false
+    }
+  }
+  return ok
 }
 
 export async function executeProposal(

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -8,9 +8,12 @@ import { readJsonSync } from 'fs-extra'
 import { createWalletClient, http, type Hex } from 'viem'
 import createCeloPublicClient from '../packages-to-be/public-client'
 
-export async function checkProposal(proposal: ProposalTransaction[], kit: ContractKit) {
-  const governance = await kit.contracts.getGovernance()
-  return tryProposal(proposal, kit, governance.address, true)
+export async function checkProposal(
+  proposal: ProposalTransaction[],
+  kit: ContractKit,
+  governanceAddress: StrongAddress
+) {
+  return tryProposal(proposal, kit, governanceAddress, true)
 }
 
 export async function simulateProposalOnRpc(

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -1,3 +1,4 @@
+import { type StrongAddress } from '@celo/base'
 import { toTxResult } from '@celo/connect'
 import { ContractKit } from '@celo/contractkit'
 import { ProposalTransaction } from '@celo/contractkit/lib/wrappers/Governance'
@@ -15,7 +16,7 @@ export async function checkProposal(proposal: ProposalTransaction[], kit: Contra
 export async function simulateProposalOnRpc(
   proposal: ProposalTransaction[],
   rpcUrl: string,
-  governanceAddress: Hex
+  governanceAddress: StrongAddress
 ) {
   const transport = http(rpcUrl)
   const publicClient = await createCeloPublicClient({ transport, nodeUrl: rpcUrl })
@@ -26,9 +27,7 @@ export async function simulateProposalOnRpc(
     account: governanceAddress,
   })
 
-  console.log(
-    `Simulating proposal execution against ${rpcUrl} as Governance ${governanceAddress}`
-  )
+  console.log(`Simulating proposal execution against ${rpcUrl} as Governance ${governanceAddress}`)
 
   let ok = true
   for (const [i, tx] of proposal.entries()) {
@@ -37,7 +36,7 @@ export async function simulateProposalOnRpc(
     }
     try {
       const hash = await walletClient.sendTransaction({
-        to: tx.to as Hex,
+        to: tx.to as StrongAddress,
         value: BigInt(tx.value ?? 0),
         data: (tx.input ?? '0x') as Hex,
       })
@@ -46,7 +45,7 @@ export async function simulateProposalOnRpc(
         let reason = ''
         try {
           await publicClient.call({
-            to: tx.to as Hex,
+            to: tx.to as StrongAddress,
             data: (tx.input ?? '0x') as Hex,
             value: BigInt(tx.value ?? 0),
             account: governanceAddress,

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -35,6 +35,10 @@ export async function simulateProposalOnRpc(
   let ok = true
   for (const [i, tx] of proposal.entries()) {
     if (!tx.to) {
+      console.log(
+        chalk.red(`   ${chalk.bold('✘')}  Transaction ${i} has no 'to' address; skipping`)
+      )
+      ok = false
       continue
     }
     try {
@@ -94,6 +98,10 @@ async function tryProposal(
   let ok = true
   for (const [i, tx] of proposal.entries()) {
     if (!tx.to) {
+      console.log(
+        chalk.red(`   ${chalk.bold('✘')}  Transaction ${i} has no 'to' address; skipping`)
+      )
+      ok = false
       continue
     }
 


### PR DESCRIPTION
Adds a `--simulate <RPC_URL>` flag to `celocli governance:propose`. When set, each proposal transaction is sent (not `eth_call`) against the given RPC, with `from = Governance contract address`. The node must have that address unlocked (e.g. anvil run with `--auto-impersonate`). Failures are reported with the decoded revert reason. The proposal isn't submitted on-chain if any tx fails.

Replaces the default `eth_call`-based simulation only when `--simulate` is set; mutually exclusive with `--force`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `--simulate` flag for the `governance:propose` command, allowing for proposal execution simulation against a forked node. It enhances proposal checks and adds functionality to simulate transaction execution, improving the governance process.

### Detailed summary
- Added `--simulate` flag to `governance:propose` command.
- Updated `checkProposal` function to accept `governanceAddress`.
- Introduced `simulateProposalOnRpc` function for simulating proposals.
- Modified proposal validation logic to use simulation when `--simulate` is specified.
- Refactored public client creation to a new utility function `createCeloPublicClient`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->